### PR TITLE
docs: add README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contribuindo com o CLUTCH ⚡
+
+---
+
+## 🌿 Fluxo de branches
+
+```
+main          ← produção, protegida
+  └── develop ← branch principal de desenvolvimento
+        └── feature/nome-da-feature
+        └── fix/nome-do-bug
+        └── chore/nome-da-tarefa
+        └── ci/nome-da-pipeline
+        └── docs/nome-do-doc
+        └── test/nome-do-teste
+```
+
+**Regras:**
+- Nunca commitar direto em `main` ou `develop`
+- Todo trabalho entra via Pull Request
+- PR sempre aponta para `develop`
+- `main` só recebe merge de `develop` via release
+
+---
+
+## 📝 Padrão de commits
+
+Seguimos [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+<tipo>(escopo): <descrição curta>
+
+<corpo opcional — explica o porquê, não o como>
+```
+
+**Tipos permitidos:**
+
+| Tipo | Quando usar |
+|---|---|
+| `feat` | Nova funcionalidade |
+| `fix` | Correção de bug |
+| `chore` | Infra, deps, config |
+| `refactor` | Refatoração sem mudança de comportamento |
+| `test` | Adição ou correção de testes |
+| `docs` | Documentação |
+| `ci` | Mudanças no pipeline CI/CD |
+
+**Exemplos:**
+```bash
+feat(auth): add user registration endpoint
+fix(presence): handle websocket disconnection correctly
+chore(backend): upgrade fastify to v5.8.2
+test(auth): add unit tests for userRepository
+docs: update README with local setup instructions
+```
+
+---
+
+## 🔀 Como abrir um PR
+
+```bash
+# 1. Atualizar develop
+git checkout develop
+git pull origin develop
+
+# 2. Criar branch
+git checkout -b feature/nome-da-feature
+
+# 3. Fazer commits
+git commit -m "feat(escopo): descrição"
+
+# 4. Push
+git push origin feature/nome-da-feature
+```
+
+No GitHub:
+- Base: `develop`
+- Preencher o template de PR completamente
+- Adicionar labels, assignee e projeto
+- Linkar a issue com `Closes #N`
+
+---
+
+## ✅ Checklist antes de abrir o PR
+
+- [ ] `npx tsc --noEmit` — zero erros
+- [ ] `npx eslint src --ext .ts` — zero erros
+- [ ] `npm test` — todos os testes passando
+- [ ] Nenhum `any` explícito no código
+- [ ] Branch atualizada com `develop`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,144 @@
+# CLUTCH ⚡
+
+> **The ultimate gaming & geek social ecosystem.**
+
+[![CI](https://github.com/alessandrolsdev/clutch/actions/workflows/ci.yml/badge.svg)](https://github.com/alessandrolsdev/clutch/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![Node.js](https://img.shields.io/badge/Node.js-20-green)
+![TypeScript](https://img.shields.io/badge/TypeScript-5.6-blue)
+![Prisma](https://img.shields.io/badge/Prisma-5-black)
+
+CLUTCH é uma rede social para gamers, otakus e geeks. Perfil unificado, Rich Presence em tempo real, biblioteca de jogos integrada com Steam e Epic, sistema de amizades e feed social — tudo em um único lugar.
+
+---
+
+## 🛠️ Stack
+
+| Camada | Tecnologia | Função |
+|---|---|---|
+| **API** | Node.js 20 + Fastify + TypeScript | Backend principal |
+| **Presença** | Go + goroutines | WebSockets de alta escala |
+| **Integração** | Python + FastAPI | Auth Epic Games |
+| **Banco** | PostgreSQL 15 | Dados relacionais |
+| **Cache** | Redis 7 | Sessões, presença, pub/sub |
+| **ORM** | Prisma 5 | Queries type-safe |
+| **Frontend** | Next.js 15 + Tailwind | Interface |
+
+---
+
+## 📋 Pré-requisitos
+
+- [Node.js 20+](https://nodejs.org)
+- [Docker + Docker Compose](https://www.docker.com)
+- [Go 1.22+](https://golang.org) *(para o presence-service)*
+- [Git](https://git-scm.com)
+
+---
+
+## 🚀 Como rodar localmente
+
+### 1. Clonar o repositório
+```bash
+git clone https://github.com/alessandrolsdev/clutch.git
+cd clutch
+```
+
+### 2. Subir Postgres e Redis
+```bash
+docker-compose up -d
+```
+
+### 3. Configurar variáveis de ambiente
+```bash
+cd backend
+cp .env.example .env
+# Edite o .env com seus valores
+```
+
+### 4. Instalar dependências
+```bash
+npm install
+```
+
+### 5. Rodar as migrations
+```bash
+npx prisma migrate dev
+```
+
+### 6. Iniciar o servidor
+```bash
+npm run dev
+```
+
+O backend estará disponível em `http://localhost:3333`.
+
+**Health check:**
+```bash
+curl http://localhost:3333/health
+# { "status": "ok", "service": "clutch-backend" }
+```
+
+---
+
+## 🧪 Testes
+
+```bash
+# Rodar todos os testes
+npm test
+
+# Modo watch
+npm run test:watch
+
+# Com relatório de cobertura
+npm run test:coverage
+```
+
+**Threshold mínimo:** 80% de cobertura em linhas, funções e statements.
+
+---
+
+## 📁 Estrutura de pastas
+
+```
+clutch/
+├── .github/
+│   ├── workflows/ci.yml          ← GitHub Actions CI
+│   └── ISSUE_TEMPLATE/           ← Templates de issues
+├── backend/
+│   ├── presence-service/         ← Go (Rich Presence WebSocket)
+│   ├── python-service/           ← Python (Epic Games auth)
+│   ├── prisma/schema.prisma      ← Schema do banco de dados
+│   └── src/
+│       ├── api/routes/           ← Rotas HTTP
+│       ├── api/middlewares/      ← Middlewares
+│       ├── core/domain/          ← Types e interfaces
+│       ├── core/repositories/    ← Acesso a dados
+│       ├── core/services/        ← Regras de negócio
+│       └── infra/                ← Database, Redis, integrações
+├── frontend/                     ← Next.js 15
+└── docker-compose.yml            ← Postgres + Redis
+```
+
+---
+
+## 🤝 Contribuindo
+
+Leia o [CONTRIBUTING.md](CONTRIBUTING.md) para entender o fluxo de branches, padrão de commits e como abrir PRs.
+
+---
+
+## 🗺️ Roadmap
+
+| Versão | Nome | Status |
+|---|---|---|
+| v1.0 | Identidade | 🚧 Em desenvolvimento |
+| v1.5 | Comunidade | 📋 Planejado |
+| v2.0 | Universo Otaku | 📋 Planejado |
+| v2.5 | Criação | 📋 Planejado |
+| v3.0 | Ecossistema | 📋 Planejado |
+
+---
+
+## 📄 Licença
+
+MIT © [Alessandro](https://github.com/alessandrolsdev)


### PR DESCRIPTION
## 📋 Descrição
Adiciona README profissional com instruções de setup, stack e roadmap.
Adiciona CONTRIBUTING.md com padrão de commits, fluxo de branches e guia de PR.

---

## 🏷️ Tipo de mudança
- [x] 📝 Documentação (`docs`)

---

## 🔗 Issue relacionada
Closes #8

---

## 🧪 Como testar
1. Ler o README e seguir os passos — deve funcionar do zero
2. Verificar que o badge de CI aparece corretamente

---

## ✅ Checklist
- [ ] Código segue TypeScript strict — zero `any`
- [ ] Testes adicionados ou atualizados
- [ ] `npm test` passa localmente
- [ ] `npm run lint` passa sem erros
- [x] Branch está atualizada com `develop`
- [ ] Funções complexas documentadas com JSDoc