### PR TITLE
feat(auth): add register and login endpoints

### DIFF
--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -1,0 +1,86 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { userRepository } from '@/core/repositories/user.repository';
+
+// ─────────────────────────────────────────────────────────────
+// Auth Routes
+// POST /auth/register
+// POST /auth/login
+// ─────────────────────────────────────────────────────────────
+
+const registerSchema = z.object({
+  username: z
+    .string()
+    .min(3, 'Username deve ter no mínimo 3 caracteres')
+    .max(30, 'Username deve ter no máximo 30 caracteres')
+    .regex(/^[a-zA-Z0-9_]+$/, 'Username aceita apenas letras, números e _'),
+  email: z
+    .string()
+    .email('Email inválido'),
+  password: z
+    .string()
+    .min(6, 'Senha deve ter no mínimo 6 caracteres'),
+});
+
+const loginSchema = z.object({
+  email:    z.string().email('Email inválido'),
+  password: z.string().min(1, 'Senha obrigatória'),
+});
+
+export async function authRoutes(app: FastifyInstance): Promise<void> {
+
+  // ── POST /auth/register ──────────────────────────────────
+  app.post('/register', async (request, reply) => {
+    const result = registerSchema.safeParse(request.body);
+
+    if (!result.success) {
+      return reply.status(400).send({
+        message: result.error.errors[0]?.message ?? 'Dados inválidos.',
+      });
+    }
+
+    const { username, email, password } = result.data;
+
+    const alreadyExists = await userRepository.existsByEmailOrUsername(email, username);
+    if (alreadyExists) {
+      return reply.status(409).send({
+        message: 'Email ou username já está em uso.',
+      });
+    }
+
+    const user = await userRepository.create({ username, email, password });
+
+    return reply.status(201).send({
+      id:       user.id,
+      username: user.username,
+    });
+  });
+
+  // ── POST /auth/login ─────────────────────────────────────
+  app.post('/login', async (request, reply) => {
+    const result = loginSchema.safeParse(request.body);
+
+    if (!result.success) {
+      return reply.status(400).send({
+        message: result.error.errors[0]?.message ?? 'Dados inválidos.',
+      });
+    }
+
+    const { email, password } = result.data;
+
+    const user = await userRepository.findByEmail(email);
+
+    if (!user || user.password_hash !== password) {
+      return reply.status(401).send({
+        message: 'Credenciais inválidas.',
+      });
+    }
+
+    return reply.status(200).send({
+      id:       user.id,
+      username: user.username,
+      message:  'Acesso autorizado.',
+    });
+  });
+
+}

--- a/backend/src/core/repositories/user.repository.ts
+++ b/backend/src/core/repositories/user.repository.ts
@@ -1,0 +1,64 @@
+import { User } from '@prisma/client';
+import { prisma } from '@/infra/database/client';
+
+// ─────────────────────────────────────────────────────────────
+// User Repository
+// Toda comunicação com a tabela users passa por aqui
+// Rotas e services nunca chamam o Prisma diretamente
+// ─────────────────────────────────────────────────────────────
+
+export interface CreateUserInput {
+  username: string;
+  email:    string;
+  password: string;
+}
+
+export const userRepository = {
+
+  async findById(id: string): Promise<User | null> {
+    return prisma.user.findUnique({ where: { id } });
+  },
+
+  async findByEmail(email: string): Promise<User | null> {
+    return prisma.user.findUnique({ where: { email } });
+  },
+
+  async findByUsername(username: string): Promise<User | null> {
+    return prisma.user.findUnique({ where: { username } });
+  },
+
+  async existsByEmailOrUsername(email: string, username: string): Promise<boolean> {
+    const user = await prisma.user.findFirst({
+      where: { OR: [{ email }, { username }] },
+      select: { id: true },
+    });
+    return user !== null;
+  },
+
+  async create(input: CreateUserInput): Promise<User> {
+    return prisma.user.create({
+      data: {
+        username:      input.username,
+        email:         input.email,
+        password_hash: input.password,
+        profile: {
+          create: {
+            displayName: input.username,
+          },
+        },
+        stats: {
+          create: {
+            level: 1,
+            xp:    0,
+          },
+        },
+        presence: {
+          create: {
+            status: 'OFFLINE',
+          },
+        },
+      },
+    });
+  },
+
+};

--- a/backend/src/infra/database/client.ts
+++ b/backend/src/infra/database/client.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from '@prisma/client';
+
+// ─────────────────────────────────────────────────────────────
+// Singleton do Prisma Client
+// Evita múltiplas instâncias em desenvolvimento com hot reload
+// ─────────────────────────────────────────────────────────────
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,4 +1,5 @@
 import Fastify from 'fastify';
+import { authRoutes } from '@/api/routes/auth.routes';
 
 // ─────────────────────────────────────────────────────────────
 // CLUTCH ⚡ — Entry point
@@ -6,12 +7,17 @@ import Fastify from 'fastify';
 
 const app = Fastify({ logger: true });
 
+// ── Health check ─────────────────────────────────────────────
 app.get('/health', async () => ({
-  status: 'ok',
-  service: 'clutch-backend',
+  status:    'ok',
+  service:   'clutch-backend',
   timestamp: new Date().toISOString(),
 }));
 
+// ── Routes ───────────────────────────────────────────────────
+await app.register(authRoutes, { prefix: '/auth' });
+
+// ── Start ────────────────────────────────────────────────────
 const start = async (): Promise<void> => {
   try {
     await app.listen({ port: 3333, host: '0.0.0.0' });

--- a/backend/tests/unit/repositories/user.repository.test.ts
+++ b/backend/tests/unit/repositories/user.repository.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { userRepository } from '@/core/repositories/user.repository';
+
+// ─────────────────────────────────────────────────────────────
+// Mock do Prisma — zero chamadas reais ao banco
+// ─────────────────────────────────────────────────────────────
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      findFirst:  vi.fn(),
+      create:     vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/infra/database/client';
+
+const mockUser = {
+  id:            'user-id-1',
+  username:      'clutchplayer',
+  email:         'player@clutch.gg',
+  password_hash: 'password123',
+  isActive:      true,
+  createdAt:     new Date(),
+  updatedAt:     new Date(),
+};
+
+describe('userRepository', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── findById ───────────────────────────────────────────────
+  describe('findById', () => {
+    it('retorna o usuário quando ID existe', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
+
+      const result = await userRepository.findById('user-id-1');
+
+      expect(result).toEqual(mockUser);
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-id-1' },
+      });
+    });
+
+    it('retorna null quando ID não existe', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+      const result = await userRepository.findById('id-inexistente');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── findByEmail ────────────────────────────────────────────
+  describe('findByEmail', () => {
+    it('retorna o usuário quando email existe', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser);
+
+      const result = await userRepository.findByEmail('player@clutch.gg');
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it('retorna null quando email não existe', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+      const result = await userRepository.findByEmail('naoexiste@clutch.gg');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── existsByEmailOrUsername ────────────────────────────────
+  describe('existsByEmailOrUsername', () => {
+    it('retorna true quando email já está cadastrado', async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(mockUser);
+
+      const result = await userRepository.existsByEmailOrUsername(
+        'player@clutch.gg',
+        'outrousername',
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('retorna true quando username já está cadastrado', async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(mockUser);
+
+      const result = await userRepository.existsByEmailOrUsername(
+        'outro@clutch.gg',
+        'clutchplayer',
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('retorna false quando email e username são únicos', async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+
+      const result = await userRepository.existsByEmailOrUsername(
+        'novo@clutch.gg',
+        'novoplayer',
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ── create ─────────────────────────────────────────────────
+  describe('create', () => {
+    it('cria usuário com profile, stats e presence aninhados', async () => {
+      vi.mocked(prisma.user.create).mockResolvedValue(mockUser);
+
+      const result = await userRepository.create({
+        username: 'clutchplayer',
+        email:    'player@clutch.gg',
+        password: 'password123',
+      });
+
+      expect(result).toEqual(mockUser);
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          username:      'clutchplayer',
+          email:         'player@clutch.gg',
+          password_hash: 'password123',
+          profile:  { create: { displayName: 'clutchplayer' } },
+          stats:    { create: { level: 1, xp: 0 } },
+          presence: { create: { status: 'OFFLINE' } },
+        }),
+      });
+    });
+  });
+
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
     "outDir": "./dist",
-    "rootDirs": ["./src", "./tests"], 
+    "rootDirs": ["./src", "./tests"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## 📋 Descrição
Implementa os endpoints de registro e login de usuários.
Adiciona o Prisma singleton, userRepository e rotas de auth com validação Zod.
Cobre o repository com 8 testes unitários com Prisma mockado.

---

## 🏷️ Tipo de mudança
- [x] ✨ Nova feature (`feat`)

---

## 🔗 Issue relacionada
Closes #10
Closes #11
Closes #12

---

## 🧪 Como testar
1. `docker-compose up -d` na raiz
2. `cd backend && npm run dev`
3. `POST http://localhost:3333/auth/register` com `{ username, email, password }`
4. `POST http://localhost:3333/auth/login` com `{ email, password }`
5. `npm test` → 15 testes passando

---

## ✅ Checklist
- [x] Código segue TypeScript strict — zero `any`
- [x] Testes adicionados ou atualizados
- [x] `npm test` passa localmente
- [x] `npm run lint` passa sem erros
- [x] Branch está atualizada com `develop`
- [ ] Funções complexas documentadas com JSDoc