### PR TITLE
feat(profile): add profile routes and repository

### DIFF
--- a/backend/src/api/routes/profile.routes.ts
+++ b/backend/src/api/routes/profile.routes.ts
@@ -1,0 +1,86 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { profileRepository } from '@/core/repositories/profile.repository';
+import { userRepository } from '@/core/repositories/user.repository';
+
+// ─────────────────────────────────────────────────────────────
+// Profile Routes
+// GET  /profiles/:username
+// PATCH /profiles/:username
+// ─────────────────────────────────────────────────────────────
+
+const updateProfileSchema = z.object({
+  displayName: z.string().min(1).max(50).optional(),
+  bio:         z.string().max(300).optional(),
+  avatarUrl:   z.string().url('URL de avatar inválida').optional(),
+  bannerUrl:   z.string().url('URL de banner inválida').optional(),
+  accentColor: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/, 'Cor deve ser um hex válido ex: #FF5500')
+    .optional(),
+});
+
+export async function profileRoutes(app: FastifyInstance): Promise<void> {
+
+  // ── GET /profiles/:username ──────────────────────────────
+  app.get<{ Params: { username: string } }>(
+    '/:username',
+    async (request, reply) => {
+      const { username } = request.params;
+
+      const profile = await profileRepository.findFullProfileByUsername(username);
+
+      if (!profile) {
+        return reply.status(404).send({
+          message: 'Perfil não encontrado.',
+        });
+      }
+
+      return reply.status(200).send(profile);
+    },
+  );
+
+  // ── PATCH /profiles/:username ────────────────────────────
+  app.patch<{ Params: { username: string } }>(
+    '/:username',
+    async (request, reply) => {
+      const { username } = request.params;
+
+      // Temporário até JWT: userId via header x-user-id
+      const requesterId = request.headers['x-user-id'] as string | undefined;
+
+      if (!requesterId) {
+        return reply.status(401).send({
+          message: 'Não autorizado.',
+        });
+      }
+
+      const user = await userRepository.findByUsername(username);
+
+      if (!user) {
+        return reply.status(404).send({
+          message: 'Usuário não encontrado.',
+        });
+      }
+
+      if (user.id !== requesterId) {
+        return reply.status(403).send({
+          message: 'Você não tem permissão para editar este perfil.',
+        });
+      }
+
+      const result = updateProfileSchema.safeParse(request.body);
+
+      if (!result.success) {
+        return reply.status(400).send({
+          message: result.error.errors[0]?.message ?? 'Dados inválidos.',
+        });
+      }
+
+      const updated = await profileRepository.updateByUserId(user.id, result.data);
+
+      return reply.status(200).send(updated);
+    },
+  );
+
+}

--- a/backend/src/core/repositories/profile.repository.ts
+++ b/backend/src/core/repositories/profile.repository.ts
@@ -1,0 +1,98 @@
+import { Profile } from '@prisma/client';
+import { prisma } from '@/infra/database/client';
+
+// ─────────────────────────────────────────────────────────────
+// Profile Repository
+// ─────────────────────────────────────────────────────────────
+
+export interface UpdateProfileInput {
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+  accentColor?: string;
+}
+
+export const profileRepository = {
+  async findByUsername(username: string): Promise<Profile | null> {
+    const user = await prisma.user.findUnique({
+      where: { username },
+      include: {
+        profile: true,
+        stats: true,
+        presence: true,
+        platformIntegrations: {
+          where: { isActive: true },
+          select: { platform: true, externalId: true, metadata: true },
+        },
+        gameLibrary: {
+          orderBy: { lastPlayedAt: 'desc' },
+          take: 10,
+        },
+      },
+    });
+
+    return user?.profile ?? null;
+  },
+
+  async findFullProfileByUsername(username: string): Promise<object | null> {
+    return prisma.user.findUnique({
+      where: { username },
+      select: {
+        id: true,
+        username: true,
+        createdAt: true,
+        profile: {
+          select: {
+            displayName: true,
+            bio: true,
+            avatarUrl: true,
+            bannerUrl: true,
+            accentColor: true,
+            badges: true,
+          },
+        },
+        stats: {
+          select: {
+            level: true,
+            xp: true,
+            reputation: true,
+            friendCount: true,
+            postCount: true,
+          },
+        },
+        presence: {
+          select: {
+            status: true,
+            currentGame: true,
+            gameDetails: true,
+            platform: true,
+            updatedAt: true,
+          },
+        },
+        platformIntegrations: {
+          where: { isActive: true },
+          select: { platform: true, metadata: true },
+        },
+        gameLibrary: {
+          orderBy: { lastPlayedAt: 'desc' },
+          take: 10,
+          select: {
+            gameName: true,
+            coverUrl: true,
+            platform: true,
+            hoursPlayed: true,
+            lastPlayedAt: true,
+          },
+        },
+      },
+    });
+  },
+
+  async updateByUserId(userId: string, input: UpdateProfileInput): Promise<Profile> {
+    return prisma.profile.update({
+      where: { userId },
+      data: input,
+    });
+  },
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify';
 import { authRoutes } from '@/api/routes/auth.routes';
+import { profileRoutes } from '@/api/routes/profile.routes';
 
 // ─────────────────────────────────────────────────────────────
 // CLUTCH ⚡ — Entry point
@@ -15,7 +16,8 @@ app.get('/health', async () => ({
 }));
 
 // ── Routes ───────────────────────────────────────────────────
-await app.register(authRoutes, { prefix: '/auth' });
+await app.register(authRoutes,    { prefix: '/auth' });
+await app.register(profileRoutes, { prefix: '/profiles' });
 
 // ── Start ────────────────────────────────────────────────────
 const start = async (): Promise<void> => {

--- a/backend/tests/unit/repositories/profile.repository.test.ts
+++ b/backend/tests/unit/repositories/profile.repository.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { profileRepository } from '@/core/repositories/profile.repository';
+
+// ─────────────────────────────────────────────────────────────
+// Mock do Prisma
+// ─────────────────────────────────────────────────────────────
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    profile: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/infra/database/client';
+
+const mockFullProfile = {
+  id:        'user-id-1',
+  username:  'clutchplayer',
+  createdAt: new Date(),
+  profile: {
+    displayName: 'Clutch Player',
+    bio:         'Gamer profissional',
+    avatarUrl:   null,
+    bannerUrl:   null,
+    accentColor: '#FF5500',
+    badges:      [],
+  },
+  stats: {
+    level:       5,
+    xp:          1200,
+    reputation:  80,
+    friendCount: 12,
+    postCount:   34,
+  },
+  presence: {
+    status:      'ONLINE',
+    currentGame: null,
+    gameDetails: null,
+    platform:    null,
+    updatedAt:   new Date(),
+  },
+  platformIntegrations: [],
+  gameLibrary:          [],
+};
+
+const mockProfile = {
+  id:          'profile-id-1',
+  userId:      'user-id-1',
+  displayName: 'Clutch Player',
+  bio:         'Bio atualizada',
+  avatarUrl:   null,
+  bannerUrl:   null,
+  accentColor: null,
+  badges:      [],
+  createdAt:   new Date(),
+  updatedAt:   new Date(),
+};
+
+describe('profileRepository', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── findFullProfileByUsername ──────────────────────────────
+  describe('findFullProfileByUsername', () => {
+    it('retorna perfil completo quando username existe', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockFullProfile as never);
+
+      const result = await profileRepository.findFullProfileByUsername('clutchplayer');
+
+      expect(result).toEqual(mockFullProfile);
+      expect(prisma.user.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { username: 'clutchplayer' } }),
+      );
+    });
+
+    it('retorna null quando username não existe', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+      const result = await profileRepository.findFullProfileByUsername('naoexiste');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── updateByUserId ─────────────────────────────────────────
+  describe('updateByUserId', () => {
+    it('atualiza e retorna o perfil com novos dados', async () => {
+      vi.mocked(prisma.profile.update).mockResolvedValue(mockProfile);
+
+      const result = await profileRepository.updateByUserId('user-id-1', {
+        bio: 'Bio atualizada',
+      });
+
+      expect(result.bio).toBe('Bio atualizada');
+      expect(prisma.profile.update).toHaveBeenCalledWith({
+        where: { userId: 'user-id-1' },
+        data:  { bio: 'Bio atualizada' },
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
## 📋 Descrição
Implementa os endpoints de perfil de usuário.
GET /profiles/:username retorna perfil completo com stats, presença e biblioteca.
PATCH /profiles/:username permite edição pelo dono do perfil via header x-user-id.

---

## 🏷️ Tipo de mudança
- [x] ✨ Nova feature (`feat`)

---

## 🔗 Issue relacionada
Closes #15
Closes #16
Closes #18

---

## 🧪 Como testar
1. `docker-compose up -d` na raiz
2. `cd backend && npm run dev`
3. `POST /auth/register` para criar usuário
4. `GET /profiles/:username` para ver o perfil
5. `PATCH /profiles/:username` com header `x-user-id: <id>` para editar
6. `npm test` → 18 testes passando

---

## ✅ Checklist
- [x] Código segue TypeScript strict — zero `any`
- [x] Testes adicionados ou atualizados
- [x] `npm test` passa localmente
- [x] `npm run lint` passa sem erros
- [x] Branch está atualizada com `develop`
- [ ] Funções complexas documentadas com JSDoc