### PR TITLE
feat(integrations): add Steam, IGDB and Epic Games integrations

### DIFF
--- a/backend/src/api/routes/integrations.routes.ts
+++ b/backend/src/api/routes/integrations.routes.ts
@@ -1,0 +1,197 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { steamService }  from '@/infra/integrations/steam/steam.service';
+import { igdbService }   from '@/infra/integrations/igdb/igdb.service';
+import { epicService }   from '@/infra/integrations/epic/epic.service';
+import { prisma }        from '@/infra/database/client';
+
+// ─────────────────────────────────────────────────────────────
+// Integrations Routes
+// POST /integrations/steam/connect
+// POST /integrations/steam/sync
+// GET  /integrations/igdb/search
+// POST /integrations/epic/connect
+// ─────────────────────────────────────────────────────────────
+
+const steamConnectSchema = z.object({
+  steamId: z.string().min(1, 'SteamID é obrigatório'),
+});
+
+const epicConnectSchema = z.object({
+  authToken: z.string().min(1, 'Token Epic é obrigatório'),
+});
+
+export async function integrationRoutes(app: FastifyInstance): Promise<void> {
+
+  // ── POST /integrations/steam/connect ────────────────────
+  app.post(
+    '/steam/connect',
+    async (request, reply) => {
+      const userId = request.headers['x-user-id'] as string | undefined;
+      if (!userId) return reply.status(401).send({ message: 'Não autorizado.' });
+
+      const result = steamConnectSchema.safeParse(request.body);
+      if (!result.success) {
+        return reply.status(400).send({ message: result.error.errors[0]?.message });
+      }
+
+      const { steamId } = result.data;
+
+      const isValid = await steamService.validateSteamId(steamId);
+      if (!isValid) {
+        return reply.status(400).send({ message: 'SteamID inválido ou perfil privado.' });
+      }
+
+      await prisma.platformIntegration.upsert({
+        where:  { userId_platform: { userId, platform: 'STEAM' } },
+        create: { userId, platform: 'STEAM', externalId: steamId },
+        update: { externalId: steamId, isActive: true },
+      });
+
+      const games = await steamService.getOwnedGames(steamId);
+
+      let imported = 0;
+      for (const game of games) {
+        const igdbData = await igdbService.searchGame(game.name).catch(() => null);
+
+        await prisma.userGameLibrary.upsert({
+          where: {
+            userId_gameId_platform: {
+              userId,
+              gameId:   String(game.appid),
+              platform: 'STEAM',
+            },
+          },
+          create: {
+            userId,
+            gameId:      String(game.appid),
+            gameName:    game.name,
+            coverUrl:    igdbData?.coverUrl ?? null,
+            platform:    'STEAM',
+            hoursPlayed: game.playtime_forever / 60,
+          },
+          update: {
+            hoursPlayed: game.playtime_forever / 60,
+            coverUrl:    igdbData?.coverUrl ?? null,
+          },
+        });
+        imported++;
+      }
+
+      return reply.status(200).send({
+        message:  `Steam conectado. ${imported} jogos importados.`,
+        imported,
+      });
+    },
+  );
+
+  // ── POST /integrations/steam/sync ───────────────────────
+  app.post(
+    '/steam/sync',
+    async (request, reply) => {
+      const userId = request.headers['x-user-id'] as string | undefined;
+      if (!userId) return reply.status(401).send({ message: 'Não autorizado.' });
+
+      const integration = await prisma.platformIntegration.findUnique({
+        where: { userId_platform: { userId, platform: 'STEAM' } },
+      });
+
+      if (!integration) {
+        return reply.status(404).send({ message: 'Steam não conectado.' });
+      }
+
+      const games   = await steamService.getOwnedGames(integration.externalId);
+      let synced    = 0;
+
+      for (const game of games) {
+        await prisma.userGameLibrary.upsert({
+          where: {
+            userId_gameId_platform: {
+              userId,
+              gameId:   String(game.appid),
+              platform: 'STEAM',
+            },
+          },
+          create: {
+            userId,
+            gameId:      String(game.appid),
+            gameName:    game.name,
+            platform:    'STEAM',
+            hoursPlayed: game.playtime_forever / 60,
+          },
+          update: {
+            hoursPlayed: game.playtime_forever / 60,
+          },
+        });
+        synced++;
+      }
+
+      return reply.status(200).send({ message: `${synced} jogos sincronizados.`, synced });
+    },
+  );
+
+  // ── GET /integrations/igdb/search ───────────────────────
+  app.get<{ Querystring: { q: string } }>(
+    '/igdb/search',
+    async (request, reply) => {
+      const { q } = request.query;
+      if (!q || q.trim().length < 2) {
+        return reply.status(400).send({ message: 'Query deve ter pelo menos 2 caracteres.' });
+      }
+
+      const game = await igdbService.searchGame(q.trim());
+      if (!game) {
+        return reply.status(404).send({ message: 'Jogo não encontrado.' });
+      }
+
+      return reply.status(200).send(game);
+    },
+  );
+
+  // ── POST /integrations/epic/connect ─────────────────────
+  app.post(
+    '/epic/connect',
+    async (request, reply) => {
+      const userId = request.headers['x-user-id'] as string | undefined;
+      if (!userId) return reply.status(401).send({ message: 'Não autorizado.' });
+
+      const result = epicConnectSchema.safeParse(request.body);
+      if (!result.success) {
+        return reply.status(400).send({ message: result.error.errors[0]?.message });
+      }
+
+      const { authToken } = result.data;
+
+      const isValid = await epicService.validateToken(authToken);
+      if (!isValid) {
+        return reply.status(400).send({ message: 'Token Epic inválido ou expirado.' });
+      }
+
+      const games = await epicService.getLibrary(authToken).catch(() => {
+        throw { statusCode: 503, message: 'Serviço Epic indisponível. Tente novamente.' };
+      });
+
+      await prisma.platformIntegration.upsert({
+        where:  { userId_platform: { userId, platform: 'EPIC' } },
+        create: { userId, platform: 'EPIC', externalId: 'epic', accessToken: authToken },
+        update: { accessToken: authToken, isActive: true },
+      });
+
+      let imported = 0;
+      for (const game of games) {
+        await prisma.userGameLibrary.upsert({
+          where:  { userId_gameId_platform: { userId, gameId: game.id, platform: 'EPIC' } },
+          create: { userId, gameId: game.id, gameName: game.title, coverUrl: game.coverUrl, platform: 'EPIC' },
+          update: { gameName: game.title, coverUrl: game.coverUrl },
+        });
+        imported++;
+      }
+
+      return reply.status(200).send({
+        message:  `Epic conectado. ${imported} jogos importados.`,
+        imported,
+      });
+    },
+  );
+
+}

--- a/backend/src/infra/integrations/epic/epic.service.ts
+++ b/backend/src/infra/integrations/epic/epic.service.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+
+// ─────────────────────────────────────────────────────────────
+// Epic Games Service — proxy para o Python service
+// ─────────────────────────────────────────────────────────────
+
+const EPIC_SERVICE_URL = process.env['EPIC_SERVICE_URL'] ?? 'http://localhost:8000';
+const EPIC_TIMEOUT     = 30_000;
+
+export interface EpicGame {
+  id:        string;
+  title:     string;
+  namespace: string;
+  coverUrl:  string | null;
+}
+
+export const epicService = {
+
+  async getLibrary(authToken: string): Promise<EpicGame[]> {
+    const response = await axios.get<{ games: EpicGame[] }>(
+      `${EPIC_SERVICE_URL}/library`,
+      {
+        headers: { Authorization: `Bearer ${authToken}` },
+        timeout: EPIC_TIMEOUT,
+      },
+    );
+
+    return response.data.games ?? [];
+  },
+
+  async validateToken(authToken: string): Promise<boolean> {
+    try {
+      await axios.get(`${EPIC_SERVICE_URL}/validate`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+        timeout: 5_000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+};

--- a/backend/src/infra/integrations/igdb/igdb.service.ts
+++ b/backend/src/infra/integrations/igdb/igdb.service.ts
@@ -1,0 +1,116 @@
+    import axios from 'axios';
+import { redis } from '@/infra/cache/redis';
+
+// ─────────────────────────────────────────────────────────────
+// IGDB Service — Twitch OAuth + game metadata
+// ─────────────────────────────────────────────────────────────
+
+const IGDB_BASE_URL  = 'https://api.igdb.com/v4';
+const TWITCH_TOKEN_URL = 'https://id.twitch.tv/oauth2/token';
+const TOKEN_REDIS_KEY  = 'igdb:token';
+
+interface TwitchTokenResponse {
+  access_token: string;
+  expires_in:   number;
+  token_type:   string;
+}
+
+export interface IgdbGame {
+  id:       number;
+  name:     string;
+  coverUrl: string | null;
+  platforms: string[];
+  summary:  string | null;
+}
+
+async function getAccessToken(): Promise<string> {
+  const cached = await redis.get(TOKEN_REDIS_KEY);
+  if (cached) return cached;
+
+  const response = await axios.post<TwitchTokenResponse>(TWITCH_TOKEN_URL, null, {
+    params: {
+      client_id:     process.env['IGDB_CLIENT_ID'],
+      client_secret: process.env['IGDB_CLIENT_SECRET'],
+      grant_type:    'client_credentials',
+    },
+  });
+
+  const { access_token, expires_in } = response.data;
+  await redis.setex(TOKEN_REDIS_KEY, expires_in - 60, access_token);
+
+  return access_token;
+}
+
+export const igdbService = {
+
+  async searchGame(name: string): Promise<IgdbGame | null> {
+    const token = await getAccessToken();
+
+    const response = await axios.post<Array<{
+      id: number;
+      name: string;
+      cover?: { id: number; url: string };
+      platforms?: Array<{ name: string }>;
+      summary?: string;
+    }>>(
+      `${IGDB_BASE_URL}/games`,
+      `search "${name}"; fields name,cover.url,platforms.name,summary; limit 1;`,
+      {
+        headers: {
+          'Client-ID':     process.env['IGDB_CLIENT_ID'] ?? '',
+          'Authorization': `Bearer ${token}`,
+          'Content-Type':  'text/plain',
+        },
+      },
+    );
+
+    const game = response.data[0];
+    if (!game) return null;
+
+    return {
+      id:        game.id,
+      name:      game.name,
+      coverUrl:  game.cover?.url
+        ? `https:${game.cover.url.replace('t_thumb', 't_cover_big')}`
+        : null,
+      platforms: game.platforms?.map((p) => p.name) ?? [],
+      summary:   game.summary ?? null,
+    };
+  },
+
+  async getGameById(igdbId: number): Promise<IgdbGame | null> {
+    const token = await getAccessToken();
+
+    const response = await axios.post<Array<{
+      id: number;
+      name: string;
+      cover?: { id: number; url: string };
+      platforms?: Array<{ name: string }>;
+      summary?: string;
+    }>>(
+      `${IGDB_BASE_URL}/games`,
+      `where id = ${igdbId}; fields name,cover.url,platforms.name,summary; limit 1;`,
+      {
+        headers: {
+          'Client-ID':     process.env['IGDB_CLIENT_ID'] ?? '',
+          'Authorization': `Bearer ${token}`,
+          'Content-Type':  'text/plain',
+        },
+      },
+    );
+
+    const game = response.data[0];
+    if (!game) return null;
+
+    return {
+      id:        game.id,
+      name:      game.name,
+      coverUrl:  game.cover?.url
+        ? `https:${game.cover.url.replace('t_thumb', 't_cover_big')}`
+        : null,
+      platforms: game.platforms?.map((p) => p.name) ?? [],
+      summary:   game.summary ?? null,
+    };
+  },
+
+};

--- a/backend/src/infra/integrations/steam/steam.service.ts
+++ b/backend/src/infra/integrations/steam/steam.service.ts
@@ -1,0 +1,72 @@
+import axios from 'axios';
+
+// ─────────────────────────────────────────────────────────────
+// Steam Service — biblioteca e horas jogadas
+// ─────────────────────────────────────────────────────────────
+
+const STEAM_BASE_URL = 'https://api.steampowered.com';
+
+export interface SteamGame {
+  appid:            number;
+  name:             string;
+  playtime_forever: number;
+  img_icon_url:     string;
+}
+
+export interface SteamPlayerSummary {
+  steamid:      string;
+  personaname:  string;
+  profileurl:   string;
+  avatarfull:   string;
+  personastate: number;
+  gameid?:      string;
+  gameextrainfo?: string;
+}
+
+export const steamService = {
+
+  async getOwnedGames(steamId: string): Promise<SteamGame[]> {
+    const response = await axios.get<{
+      response: {
+        game_count: number;
+        games:      SteamGame[];
+      };
+    }>(
+      `${STEAM_BASE_URL}/IPlayerService/GetOwnedGames/v1/`,
+      {
+        params: {
+          key:                  process.env['STEAM_API_KEY'],
+          steamid:              steamId,
+          include_appinfo:      true,
+          include_played_free_games: true,
+        },
+        timeout: 10_000,
+      },
+    );
+
+    return response.data.response.games ?? [];
+  },
+
+  async getPlayerSummary(steamId: string): Promise<SteamPlayerSummary | null> {
+    const response = await axios.get<{
+      response: { players: SteamPlayerSummary[] };
+    }>(
+      `${STEAM_BASE_URL}/ISteamUser/GetPlayerSummaries/v2/`,
+      {
+        params: {
+          key:      process.env['STEAM_API_KEY'],
+          steamids: steamId,
+        },
+        timeout: 10_000,
+      },
+    );
+
+    return response.data.response.players[0] ?? null;
+  },
+
+  async validateSteamId(steamId: string): Promise<boolean> {
+    const player = await steamService.getPlayerSummary(steamId);
+    return player !== null;
+  },
+
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,8 +1,9 @@
 import Fastify from 'fastify';
-import { authRoutes }     from '@/api/routes/auth.routes';
-import { profileRoutes }  from '@/api/routes/profile.routes';
-import { friendRoutes }   from '@/api/routes/friends.routes';
-import { presenceRoutes } from '@/api/routes/presence.routes';
+import { authRoutes }         from '@/api/routes/auth.routes';
+import { profileRoutes }      from '@/api/routes/profile.routes';
+import { friendRoutes }       from '@/api/routes/friends.routes';
+import { presenceRoutes }     from '@/api/routes/presence.routes';
+import { integrationRoutes }  from '@/api/routes/integrations.routes';
 
 // ─────────────────────────────────────────────────────────────
 // CLUTCH ⚡ — Entry point
@@ -10,20 +11,18 @@ import { presenceRoutes } from '@/api/routes/presence.routes';
 
 const app = Fastify({ logger: true });
 
-// ── Health check ─────────────────────────────────────────────
 app.get('/health', async () => ({
   status:    'ok',
   service:   'clutch-backend',
   timestamp: new Date().toISOString(),
 }));
 
-// ── Routes ───────────────────────────────────────────────────
-await app.register(authRoutes,     { prefix: '/auth' });
-await app.register(profileRoutes,  { prefix: '/profiles' });
-await app.register(friendRoutes,   { prefix: '/friends' });
-await app.register(presenceRoutes, { prefix: '/presence' });
+await app.register(authRoutes,        { prefix: '/auth' });
+await app.register(profileRoutes,     { prefix: '/profiles' });
+await app.register(friendRoutes,      { prefix: '/friends' });
+await app.register(presenceRoutes,    { prefix: '/presence' });
+await app.register(integrationRoutes, { prefix: '/integrations' });
 
-// ── Start ────────────────────────────────────────────────────
 const start = async (): Promise<void> => {
   try {
     await app.listen({ port: 3333, host: '0.0.0.0' });

--- a/backend/tests/helpers/build-app.ts
+++ b/backend/tests/helpers/build-app.ts
@@ -1,22 +1,19 @@
 import Fastify, { FastifyInstance } from 'fastify';
-import { authRoutes }     from '@/api/routes/auth.routes';
-import { profileRoutes }  from '@/api/routes/profile.routes';
-import { friendRoutes }   from '@/api/routes/friends.routes';
-import { presenceRoutes } from '@/api/routes/presence.routes';
-
-// ─────────────────────────────────────────────────────────────
-// Builds a Fastify instance with all routes registered
-// Used exclusively in integration tests
-// ─────────────────────────────────────────────────────────────
+import { authRoutes }        from '@/api/routes/auth.routes';
+import { profileRoutes }     from '@/api/routes/profile.routes';
+import { friendRoutes }      from '@/api/routes/friends.routes';
+import { presenceRoutes }    from '@/api/routes/presence.routes';
+import { integrationRoutes } from '@/api/routes/integrations.routes';
 
 export const buildApp = async (): Promise<FastifyInstance> => {
   const app = Fastify({ logger: false });
 
-  await app.register(authRoutes,     { prefix: '/auth' });
-  await app.register(profileRoutes,  { prefix: '/profiles' });
-  await app.register(friendRoutes,   { prefix: '/friends' });
-  await app.register(presenceRoutes, { prefix: '/presence' });
+  await app.register(authRoutes,        { prefix: '/auth' });
+  await app.register(profileRoutes,     { prefix: '/profiles' });
+  await app.register(friendRoutes,      { prefix: '/friends' });
+  await app.register(presenceRoutes,    { prefix: '/presence' });
+  await app.register(integrationRoutes, { prefix: '/integrations' });
 
   await app.ready();
   return app;
-};  
+};

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─────────────────────────────────────────────────────────────
+// Mock axios e Redis antes de importar os services
+// ─────────────────────────────────────────────────────────────
+
+vi.mock('axios');
+vi.mock('@/infra/cache/redis', () => ({
+  redis: {
+    get:    vi.fn(),
+    setex:  vi.fn(),
+  },
+}));
+
+import axios         from 'axios';
+import { redis }     from '@/infra/cache/redis';
+import { igdbService }  from '@/infra/integrations/igdb/igdb.service';
+import { steamService } from '@/infra/integrations/steam/steam.service';
+import { epicService }  from '@/infra/integrations/epic/epic.service';
+
+// ─────────────────────────────────────────────────────────────
+// IGDB Service
+// ─────────────────────────────────────────────────────────────
+
+describe('igdbService', () => {
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('searchGame', () => {
+    it('renova token quando Redis miss e retorna jogo', async () => {
+      vi.mocked(redis.get).mockResolvedValue(null);
+      vi.mocked(redis.setex).mockResolvedValue('OK');
+
+      vi.mocked(axios.post)
+        .mockResolvedValueOnce({
+          data: { access_token: 'test-token', expires_in: 3600, token_type: 'bearer' },
+        })
+        .mockResolvedValueOnce({
+          data: [{
+            id:   1234,
+            name: 'Valorant',
+            cover: { id: 1, url: '//images.igdb.com/igdb/image/upload/t_thumb/test.jpg' },
+            platforms: [{ name: 'PC (Microsoft Windows)' }],
+            summary: 'Tactical shooter',
+          }],
+        });
+
+      const result = await igdbService.searchGame('Valorant');
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Valorant');
+      expect(result?.coverUrl).toContain('t_cover_big');
+    });
+
+    it('usa token do cache Redis quando disponível', async () => {
+      vi.mocked(redis.get).mockResolvedValue('cached-token');
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: [{ id: 1, name: 'CS2', platforms: [], summary: null }],
+      });
+
+      await igdbService.searchGame('CS2');
+
+      expect(axios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('retorna null quando jogo não encontrado', async () => {
+      vi.mocked(redis.get).mockResolvedValue('cached-token');
+      vi.mocked(axios.post).mockResolvedValueOnce({ data: [] });
+
+      const result = await igdbService.searchGame('jogo-inexistente-xyz');
+
+      expect(result).toBeNull();
+    });
+  });
+
+});
+
+// ─────────────────────────────────────────────────────────────
+// Steam Service
+// ─────────────────────────────────────────────────────────────
+
+describe('steamService', () => {
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('getOwnedGames', () => {
+    it('retorna biblioteca quando SteamID é válido', async () => {
+      vi.mocked(axios.get).mockResolvedValue({
+        data: {
+          response: {
+            game_count: 2,
+            games: [
+              { appid: 730,  name: 'Counter-Strike 2',    playtime_forever: 6000, img_icon_url: '' },
+              { appid: 570,  name: 'Dota 2',              playtime_forever: 1200, img_icon_url: '' },
+            ],
+          },
+        },
+      });
+
+      const games = await steamService.getOwnedGames('76561198000000000');
+
+      expect(games).toHaveLength(2);
+      expect(games[0]?.name).toBe('Counter-Strike 2');
+    });
+
+    it('retorna array vazio quando perfil não tem jogos', async () => {
+      vi.mocked(axios.get).mockResolvedValue({
+        data: { response: { game_count: 0 } },
+      });
+
+      const games = await steamService.getOwnedGames('76561198000000000');
+
+      expect(games).toEqual([]);
+    });
+  });
+
+  describe('validateSteamId', () => {
+    it('retorna true quando SteamID é válido', async () => {
+      vi.mocked(axios.get).mockResolvedValue({
+        data: {
+          response: {
+            players: [{ steamid: '76561198000000000', personaname: 'player' }],
+          },
+        },
+      });
+
+      const result = await steamService.validateSteamId('76561198000000000');
+
+      expect(result).toBe(true);
+    });
+
+    it('retorna false quando SteamID é inválido', async () => {
+      vi.mocked(axios.get).mockResolvedValue({
+        data: { response: { players: [] } },
+      });
+
+      const result = await steamService.validateSteamId('steamid-invalido');
+
+      expect(result).toBe(false);
+    });
+  });
+
+});
+
+// ─────────────────────────────────────────────────────────────
+// Epic Service
+// ─────────────────────────────────────────────────────────────
+
+describe('epicService', () => {
+
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('getLibrary', () => {
+    it('retorna biblioteca quando Python service responde', async () => {
+      vi.mocked(axios.get).mockResolvedValue({
+        data: {
+          games: [
+            { id: 'fortnite', title: 'Fortnite', namespace: 'fn', coverUrl: null },
+            { id: 'rocket',   title: 'Rocket League', namespace: 'rl', coverUrl: null },
+          ],
+        },
+      });
+
+      const games = await epicService.getLibrary('valid-token');
+
+      expect(games).toHaveLength(2);
+      expect(games[0]?.title).toBe('Fortnite');
+    });
+  });
+
+  describe('validateToken', () => {
+    it('retorna true quando token é válido', async () => {
+      vi.mocked(axios.get).mockResolvedValue({ data: { valid: true } });
+
+      const result = await epicService.validateToken('valid-token');
+
+      expect(result).toBe(true);
+    });
+
+    it('retorna false quando token é inválido', async () => {
+      vi.mocked(axios.get).mockRejectedValue(new Error('Unauthorized'));
+
+      const result = await epicService.validateToken('invalid-token');
+
+      expect(result).toBe(false);
+    });
+  });
+
+});


### PR DESCRIPTION
## 📋 Descrição
Implementa integrações com Steam, IGDB e Epic Games.
Steam importa biblioteca completa com capas via IGDB.
Epic Games via proxy ao Python service.
Token IGDB/Twitch com cache automático no Redis.

---

## 🏷️ Tipo de mudança
- [x] ✨ Nova feature (`feat`)

---

## 🔗 Issue relacionada
Closes #51
Closes #52
Closes #54
Closes #55

---

## 🧪 Como testar
1. `docker-compose up -d`
2. `cd backend && npm run dev`
3. `POST /integrations/steam/connect` com `{ "steamId": "seu-steam-id" }`
4. `GET /integrations/igdb/search?q=Valorant`
5. `npm test` → 83 testes passando

---

## ✅ Checklist
- [x] Código segue TypeScript strict — zero `any`
- [x] Testes adicionados ou atualizados
- [x] `npm test` passa localmente
- [x] `npm run lint` passa sem erros
- [x] Branch está atualizada com `develop`
- [ ] Funções complexas documentadas com JSDoc