### PR TITLE
feat(posts): add feed, posts, interactions and comments

### DIFF
--- a/backend/src/api/routes/posts.routes.ts
+++ b/backend/src/api/routes/posts.routes.ts
@@ -1,0 +1,188 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { postRepository }     from '@/core/repositories/post.repository';
+import { presenceRepository } from '@/core/repositories/presence.repository';
+import { userRepository }     from '@/core/repositories/user.repository';
+
+// ─────────────────────────────────────────────────────────────
+// Posts Routes
+// POST   /posts
+// GET    /posts/feed/:userId
+// POST   /posts/:id/interactions
+// POST   /comments
+// GET    /comments/:postId
+// DELETE /posts/:id
+// ─────────────────────────────────────────────────────────────
+
+const createPostSchema = z.object({
+  contentText: z.string().max(500).optional(),
+  mediaUrl:    z.string().url().optional(),
+  type:        z.enum(['TEXT', 'IMAGE', 'ACHIEVEMENT', 'GAME_SESSION']).default('TEXT'),
+});
+
+const interactionSchema = z.object({
+  type: z.enum(['LIKE', 'GG', 'F', 'CLAP', 'HYPE']),
+});
+
+const createCommentSchema = z.object({
+  postId:   z.string().min(1),
+  content:  z.string().min(1).max(300),
+  parentId: z.string().optional(),
+});
+
+export async function postRoutes(app: FastifyInstance): Promise<void> {
+
+  // ── POST /posts ──────────────────────────────────────────
+  app.post(
+    '/',
+    async (request, reply) => {
+      const userId = request.headers['x-user-id'] as string | undefined;
+      if (!userId) return reply.status(401).send({ message: 'Não autorizado.' });
+
+      const result = createPostSchema.safeParse(request.body);
+      if (!result.success) {
+        return reply.status(400).send({ message: result.error.errors[0]?.message });
+      }
+
+      const { contentText, mediaUrl, type } = result.data;
+
+      if (!contentText && !mediaUrl) {
+        return reply.status(400).send({ message: 'Post precisa ter texto ou mídia.' });
+      }
+
+      // Captura o jogo sendo jogado no momento
+      const presence    = await presenceRepository.get(userId);
+      const gameContext = presence.status === 'IN_GAME'
+        ? {
+            gameName:    presence.currentGame,
+            platform:    presence.platform,
+            capturedAt:  new Date().toISOString(),
+          }
+        : null;
+
+      const post = await postRepository.create({
+        userId,
+        contentText: contentText ?? null,
+        mediaUrl:    mediaUrl    ?? null,
+        type,
+        gameContext,
+      });
+
+      return reply.status(201).send(post);
+    },
+  );
+
+  // ── GET /posts/feed/:userId ──────────────────────────────
+  app.get<{
+    Params:      { userId: string };
+    Querystring: { cursor?: string; limit?: string };
+  }>(
+    '/feed/:userId',
+    async (request, reply) => {
+      const { userId }        = request.params;
+      const { cursor, limit } = request.query;
+
+      const user = await userRepository.findById(userId);
+      if (!user) return reply.status(404).send({ message: 'Usuário não encontrado.' });
+
+      const feed = await postRepository.findFeedByUserId(
+        userId,
+        cursor,
+        limit ? Math.min(parseInt(limit), 50) : 20,
+      );
+
+      return reply.status(200).send(feed);
+    },
+  );
+
+  // ── POST /posts/:id/interactions ─────────────────────────
+  app.post<{ Params: { id: string } }>(
+    '/:id/interactions',
+    async (request, reply) => {
+      const userId = request.headers['x-user-id'] as string | undefined;
+      if (!userId) return reply.status(401).send({ message: 'Não autorizado.' });
+
+      const result = interactionSchema.safeParse(request.body);
+      if (!result.success) {
+        return reply.status(400).send({ message: result.error.errors[0]?.message });
+      }
+
+      const post = await postRepository.findById(request.params.id);
+      if (!post) return reply.status(404).send({ message: 'Post não encontrado.' });
+
+      if (post.userId === userId) {
+        return reply.status(400).send({ message: 'Você não pode reagir ao próprio post.' });
+      }
+
+      const { added } = await postRepository.toggleInteraction(
+        request.params.id,
+        userId,
+        result.data.type,
+      );
+
+      return reply.status(200).send({ added });
+    },
+  );
+
+  // ── POST /comments ───────────────────────────────────────
+  app.post(
+    '/comments',
+    async (request, reply) => {
+      const userId = request.headers['x-user-id'] as string | undefined;
+      if (!userId) return reply.status(401).send({ message: 'Não autorizado.' });
+
+      const result = createCommentSchema.safeParse(request.body);
+      if (!result.success) {
+        return reply.status(400).send({ message: result.error.errors[0]?.message });
+      }
+
+      const { postId, content, parentId } = result.data;
+
+      const post = await postRepository.findById(postId);
+      if (!post) return reply.status(404).send({ message: 'Post não encontrado.' });
+
+      const comment = await postRepository.createComment(
+        postId,
+        userId,
+        content,
+        parentId,
+      );
+
+      return reply.status(201).send(comment);
+    },
+  );
+
+  // ── GET /posts/comments/:postId ──────────────────────────
+  app.get<{ Params: { postId: string } }>(
+    '/comments/:postId',
+    async (request, reply) => {
+      const post = await postRepository.findById(request.params.postId);
+      if (!post) return reply.status(404).send({ message: 'Post não encontrado.' });
+
+      const comments = await postRepository.findCommentsByPostId(request.params.postId);
+
+      return reply.status(200).send(comments);
+    },
+  );
+
+  // ── DELETE /posts/:id ────────────────────────────────────
+  app.delete<{ Params: { id: string } }>(
+    '/:id',
+    async (request, reply) => {
+      const userId = request.headers['x-user-id'] as string | undefined;
+      if (!userId) return reply.status(401).send({ message: 'Não autorizado.' });
+
+      const post = await postRepository.findById(request.params.id);
+      if (!post) return reply.status(404).send({ message: 'Post não encontrado.' });
+
+      if (post.userId !== userId) {
+        return reply.status(403).send({ message: 'Você não pode deletar este post.' });
+      }
+
+      await postRepository.deleteById(request.params.id);
+
+      return reply.status(200).send({ message: 'Post removido.' });
+    },
+  );
+
+}

--- a/backend/src/core/repositories/post.repository.ts
+++ b/backend/src/core/repositories/post.repository.ts
@@ -1,0 +1,258 @@
+import { Post, Interaction, Comment } from '@prisma/client';
+import { prisma } from '@/infra/database/client';
+
+// ─────────────────────────────────────────────────────────────
+// Post Repository
+// ─────────────────────────────────────────────────────────────
+
+export interface CreatePostInput {
+  userId:      string;
+  contentText?: string | null;
+  mediaUrl?:    string | null;
+  type:         'TEXT' | 'IMAGE' | 'ACHIEVEMENT' | 'GAME_SESSION';
+  gameContext?: Record<string, unknown> | null;
+}
+
+export interface FeedPage {
+  posts:      PostWithAuthor[];
+  nextCursor: string | null;
+}
+
+export interface PostWithAuthor {
+  id:          string;
+  contentText: string | null;
+  mediaUrl:    string | null;
+  type:        string;
+  gameContext: Record<string, unknown> | null;
+  createdAt:   Date;
+  author: {
+    id:       string;
+    username: string;
+    profile: {
+      displayName: string | null;
+      avatarUrl:   string | null;
+      accentColor: string | null;
+    } | null;
+  };
+  _count: {
+    interactions: number;
+    comments:     number;
+  };
+}
+
+export interface CommentWithAuthor {
+  id:        string;
+  content:   string;
+  parentId:  string | null;
+  createdAt: Date;
+  author: {
+    id:       string;
+    username: string;
+    profile: { displayName: string | null; avatarUrl: string | null } | null;
+  };
+  replies: CommentWithAuthor[];
+}
+
+export const postRepository = {
+
+  // ── Posts ──────────────────────────────────────────────────
+
+  async create(input: CreatePostInput): Promise<Post> {
+    const post = await prisma.post.create({
+      data: {
+        userId:      input.userId,
+        contentText: input.contentText ?? null,
+        mediaUrl:    input.mediaUrl    ?? null,
+        type:        input.type,
+        gameContext: input.gameContext
+          ? JSON.parse(JSON.stringify(input.gameContext))
+          : undefined,
+      },
+    });
+
+    await prisma.userStats.updateMany({
+      where: { userId: input.userId },
+      data:  { postCount: { increment: 1 } },
+    });
+
+    return post;
+  },
+
+  async findById(id: string): Promise<Post | null> {
+    return prisma.post.findUnique({ where: { id } });
+  },
+
+  async deleteById(id: string): Promise<void> {
+    await prisma.post.delete({ where: { id } });
+
+    await prisma.userStats.updateMany({
+      where: { userId: (await prisma.post.findUnique({ where: { id } }))?.userId ?? '' },
+      data:  { postCount: { decrement: 1 } },
+    });
+  },
+
+  async findFeedByUserId(
+    userId:  string,
+    cursor?: string,
+    limit    = 20,
+  ): Promise<FeedPage> {
+    const friendships = await prisma.friendship.findMany({
+      where:  { userId },
+      select: { friendId: true },
+    });
+
+    const friendIds = friendships.map((f) => f.friendId);
+    const authorIds = [userId, ...friendIds];
+
+    const posts = await prisma.post.findMany({
+      where:   { userId: { in: authorIds } },
+      orderBy: { createdAt: 'desc' },
+      take:    limit + 1,
+      cursor:  cursor ? { id: cursor } : undefined,
+      skip:    cursor ? 1 : 0,
+      select: {
+        id:          true,
+        contentText: true,
+        mediaUrl:    true,
+        type:        true,
+        gameContext: true,
+        createdAt:   true,
+        user: {
+          select: {
+            id:       true,
+            username: true,
+            profile: {
+              select: {
+                displayName: true,
+                avatarUrl:   true,
+                accentColor: true,
+              },
+            },
+          },
+        },
+        _count: {
+          select: { interactions: true, comments: true },
+        },
+      },
+    });
+
+    const hasMore   = posts.length > limit;
+    const sliced    = hasMore ? posts.slice(0, limit) : posts;
+    const nextCursor = hasMore ? (sliced[sliced.length - 1]?.id ?? null) : null;
+
+    return {
+      posts: sliced.map((p) => ({
+        id:          p.id,
+        contentText: p.contentText,
+        mediaUrl:    p.mediaUrl,
+        type:        p.type,
+        gameContext: p.gameContext as Record<string, unknown> | null,
+        createdAt:   p.createdAt,
+        author:      p.user,
+        _count:      p._count,
+      })),
+      nextCursor,
+    };
+  },
+
+  // ── Interactions ───────────────────────────────────────────
+
+  async toggleInteraction(
+    postId: string,
+    userId: string,
+    type:   'LIKE' | 'GG' | 'F' | 'CLAP' | 'HYPE',
+  ): Promise<{ added: boolean }> {
+    const existing = await prisma.interaction.findUnique({
+      where: { postId_userId_type: { postId, userId, type } },
+    });
+
+    if (existing) {
+      await prisma.interaction.delete({
+        where: { postId_userId_type: { postId, userId, type } },
+      });
+      return { added: false };
+    }
+
+    await prisma.interaction.create({
+      data: { postId, userId, type },
+    });
+    return { added: true };
+  },
+
+  async findInteraction(
+    postId: string,
+    userId: string,
+    type:   string,
+  ): Promise<Interaction | null> {
+    return prisma.interaction.findUnique({
+      where: { postId_userId_type: { postId, userId, type: type as 'LIKE' | 'GG' | 'F' | 'CLAP' | 'HYPE' } },
+    });
+  },
+
+  // ── Comments ───────────────────────────────────────────────
+
+  async createComment(
+    postId:   string,
+    userId:   string,
+    content:  string,
+    parentId?: string | null,
+  ): Promise<Comment> {
+    return prisma.comment.create({
+      data: { postId, userId, content, parentId: parentId ?? null },
+    });
+  },
+
+  async findCommentsByPostId(postId: string): Promise<CommentWithAuthor[]> {
+    const comments = await prisma.comment.findMany({
+      where:   { postId, parentId: null },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id:        true,
+        content:   true,
+        parentId:  true,
+        createdAt: true,
+        user: {
+          select: {
+            id:       true,
+            username: true,
+            profile: { select: { displayName: true, avatarUrl: true } },
+          },
+        },
+        replies: {
+          orderBy: { createdAt: 'asc' },
+          select: {
+            id:        true,
+            content:   true,
+            parentId:  true,
+            createdAt: true,
+            user: {
+              select: {
+                id:       true,
+                username: true,
+                profile: { select: { displayName: true, avatarUrl: true } },
+              },
+            },
+            replies: false,
+          },
+        },
+      },
+    });
+
+    return comments.map((c) => ({
+      id:        c.id,
+      content:   c.content,
+      parentId:  c.parentId,
+      createdAt: c.createdAt,
+      author:    c.user,
+      replies:   c.replies.map((r) => ({
+        id:        r.id,
+        content:   r.content,
+        parentId:  r.parentId,
+        createdAt: r.createdAt,
+        author:    r.user,
+        replies:   [],
+      })),
+    }));
+  },
+
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,10 @@
 import Fastify from 'fastify';
-import { authRoutes }         from '@/api/routes/auth.routes';
-import { profileRoutes }      from '@/api/routes/profile.routes';
-import { friendRoutes }       from '@/api/routes/friends.routes';
-import { presenceRoutes }     from '@/api/routes/presence.routes';
-import { integrationRoutes }  from '@/api/routes/integrations.routes';
+import { authRoutes }        from '@/api/routes/auth.routes';
+import { profileRoutes }     from '@/api/routes/profile.routes';
+import { friendRoutes }      from '@/api/routes/friends.routes';
+import { presenceRoutes }    from '@/api/routes/presence.routes';
+import { integrationRoutes } from '@/api/routes/integrations.routes';
+import { postRoutes }        from '@/api/routes/posts.routes';
 
 // ─────────────────────────────────────────────────────────────
 // CLUTCH ⚡ — Entry point
@@ -22,6 +23,7 @@ await app.register(profileRoutes,     { prefix: '/profiles' });
 await app.register(friendRoutes,      { prefix: '/friends' });
 await app.register(presenceRoutes,    { prefix: '/presence' });
 await app.register(integrationRoutes, { prefix: '/integrations' });
+await app.register(postRoutes,        { prefix: '/posts' });
 
 const start = async (): Promise<void> => {
   try {

--- a/backend/tests/helpers/build-app.ts
+++ b/backend/tests/helpers/build-app.ts
@@ -4,6 +4,7 @@ import { profileRoutes }     from '@/api/routes/profile.routes';
 import { friendRoutes }      from '@/api/routes/friends.routes';
 import { presenceRoutes }    from '@/api/routes/presence.routes';
 import { integrationRoutes } from '@/api/routes/integrations.routes';
+import { postRoutes }        from '@/api/routes/posts.routes';
 
 export const buildApp = async (): Promise<FastifyInstance> => {
   const app = Fastify({ logger: false });
@@ -13,6 +14,7 @@ export const buildApp = async (): Promise<FastifyInstance> => {
   await app.register(friendRoutes,      { prefix: '/friends' });
   await app.register(presenceRoutes,    { prefix: '/presence' });
   await app.register(integrationRoutes, { prefix: '/integrations' });
+  await app.register(postRoutes,        { prefix: '/posts' });
 
   await app.ready();
   return app;

--- a/backend/tests/integration/routes/posts.routes.test.ts
+++ b/backend/tests/integration/routes/posts.routes.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildApp } from '../../helpers/build-app';
+
+vi.mock('@/core/repositories/post.repository', () => ({
+  postRepository: {
+    create:              vi.fn(),
+    findById:            vi.fn(),
+    deleteById:          vi.fn(),
+    findFeedByUserId:    vi.fn(),
+    toggleInteraction:   vi.fn(),
+    createComment:       vi.fn(),
+    findCommentsByPostId: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/presence.repository', () => ({
+  presenceRepository: {
+    set:        vi.fn(),
+    get:        vi.fn(),
+    setOffline: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/user.repository', () => ({
+  userRepository: {
+    findById:                vi.fn(),
+    findByEmail:             vi.fn(),
+    findByUsername:          vi.fn(),
+    existsByEmailOrUsername: vi.fn(),
+    create:                  vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/profile.repository', () => ({
+  profileRepository: {
+    findFullProfileByUsername: vi.fn(),
+    updateByUserId:            vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/friend.repository', () => ({
+  friendRepository: {
+    createRequest:       vi.fn(),
+    findRequestById:     vi.fn(),
+    existsRequest:       vi.fn(),
+    existsFriendship:    vi.fn(),
+    acceptRequest:       vi.fn(),
+    removeFriendship:    vi.fn(),
+    findFriendsByUserId: vi.fn(),
+    findPendingRequests: vi.fn(),
+  },
+}));
+
+vi.mock('@/infra/integrations/steam/steam.service',  () => ({ steamService:  {} }));
+vi.mock('@/infra/integrations/igdb/igdb.service',    () => ({ igdbService:   {} }));
+vi.mock('@/infra/integrations/epic/epic.service',    () => ({ epicService:   {} }));
+
+import { postRepository }     from '@/core/repositories/post.repository';
+import { presenceRepository } from '@/core/repositories/presence.repository';
+import { userRepository }     from '@/core/repositories/user.repository';
+
+const mockUser = {
+  id: 'user-id-1', username: 'clutchplayer', email: 'player@clutch.gg',
+  password_hash: 'hash', isActive: true, createdAt: new Date(), updatedAt: new Date(),
+};
+
+const mockPost = {
+  id: 'post-id-1', userId: 'user-id-1', contentText: 'Hello CLUTCH!',
+  mediaUrl: null, type: 'TEXT' as const, gameContext: null,
+  createdAt: new Date(), updatedAt: new Date(),
+};
+
+const mockPresenceOffline = {
+  userId: 'user-id-1', status: 'OFFLINE' as const,
+  currentGame: null, gameDetails: null, platform: null,
+  updatedAt: new Date().toISOString(),
+};
+
+const mockPresenceInGame = {
+  ...mockPresenceOffline,
+  status:      'IN_GAME' as const,
+  currentGame: 'Valorant',
+  platform:    'PC',
+};
+
+describe('Posts Routes', () => {
+
+  beforeEach(() => vi.clearAllMocks());
+
+  // ── POST /posts ──────────────────────────────────────────
+  describe('POST /posts', () => {
+
+    it('retorna 201 com post criado', async () => {
+      vi.mocked(presenceRepository.get).mockResolvedValue(mockPresenceOffline);
+      vi.mocked(postRepository.create).mockResolvedValue(mockPost);
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts',
+        headers: { 'x-user-id': 'user-id-1' },
+        payload: { contentText: 'Hello CLUTCH!' },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(response.json()).toMatchObject({ contentText: 'Hello CLUTCH!' });
+      await app.close();
+    });
+
+    it('captura gameContext quando IN_GAME', async () => {
+      vi.mocked(presenceRepository.get).mockResolvedValue(mockPresenceInGame);
+      vi.mocked(postRepository.create).mockResolvedValue({
+        ...mockPost,
+        gameContext: { gameName: 'Valorant' },
+      } as never);
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts',
+        headers: { 'x-user-id': 'user-id-1' },
+        payload: { contentText: 'Jogando Valorant!' },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(postRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gameContext: expect.objectContaining({ gameName: 'Valorant' }),
+        }),
+      );
+      await app.close();
+    });
+
+    it('retorna 400 sem conteúdo', async () => {
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts',
+        headers: { 'x-user-id': 'user-id-1' },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it('retorna 401 sem header', async () => {
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts',
+        payload: { contentText: 'test' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await app.close();
+    });
+
+  });
+
+  // ── GET /posts/feed/:userId ──────────────────────────────
+  describe('GET /posts/feed/:userId', () => {
+
+    it('retorna 200 com feed paginado', async () => {
+      vi.mocked(userRepository.findById).mockResolvedValue(mockUser);
+      vi.mocked(postRepository.findFeedByUserId).mockResolvedValue({
+        posts: [], nextCursor: null,
+      });
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method: 'GET',
+        url:    '/posts/feed/user-id-1',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ posts: [], nextCursor: null });
+      await app.close();
+    });
+
+    it('retorna 404 quando usuário não existe', async () => {
+      vi.mocked(userRepository.findById).mockResolvedValue(null);
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method: 'GET',
+        url:    '/posts/feed/inexistente',
+      });
+
+      expect(response.statusCode).toBe(404);
+      await app.close();
+    });
+
+  });
+
+  // ── POST /posts/:id/interactions ─────────────────────────
+  describe('POST /posts/:id/interactions', () => {
+
+    it('retorna 200 adicionando reaction', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
+      vi.mocked(postRepository.toggleInteraction).mockResolvedValue({ added: true });
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts/post-id-1/interactions',
+        headers: { 'x-user-id': 'user-id-2' },
+        payload: { type: 'GG' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({ added: true });
+      await app.close();
+    });
+
+    it('retorna 400 ao reagir ao próprio post', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts/post-id-1/interactions',
+        headers: { 'x-user-id': 'user-id-1' },
+        payload: { type: 'GG' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      await app.close();
+    });
+
+    it('retorna 404 para post inexistente', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(null);
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts/inexistente/interactions',
+        headers: { 'x-user-id': 'user-id-2' },
+        payload: { type: 'GG' },
+      });
+
+      expect(response.statusCode).toBe(404);
+      await app.close();
+    });
+
+  });
+
+  // ── POST /posts/comments ─────────────────────────────────
+  describe('POST /posts/comments', () => {
+
+    it('retorna 201 com comentário criado', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
+      vi.mocked(postRepository.createComment).mockResolvedValue({
+        id: 'c1', postId: 'post-id-1', userId: 'user-id-2',
+        parentId: null, content: 'Ótimo post!', createdAt: new Date(),
+      });
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts/comments',
+        headers: { 'x-user-id': 'user-id-2' },
+        payload: { postId: 'post-id-1', content: 'Ótimo post!' },
+      });
+
+      expect(response.statusCode).toBe(201);
+      await app.close();
+    });
+
+  });
+
+  // ── DELETE /posts/:id ────────────────────────────────────
+  describe('DELETE /posts/:id', () => {
+
+    it('retorna 200 deletando post do próprio usuário', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
+      vi.mocked(postRepository.deleteById).mockResolvedValue(undefined);
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'DELETE',
+        url:     '/posts/post-id-1',
+        headers: { 'x-user-id': 'user-id-1' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it('retorna 403 deletando post de outro usuário', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
+
+      const app = await buildApp();
+      const response = await app.inject({
+        method:  'DELETE',
+        url:     '/posts/post-id-1',
+        headers: { 'x-user-id': 'user-id-2' },
+      });
+
+      expect(response.statusCode).toBe(403);
+      await app.close();
+    });
+
+  });
+
+});

--- a/backend/tests/unit/repositories/post.repository.test.ts
+++ b/backend/tests/unit/repositories/post.repository.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { postRepository } from '@/core/repositories/post.repository';
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    post: {
+      create:     vi.fn(),
+      findUnique: vi.fn(),
+      findMany:   vi.fn(),
+      delete:     vi.fn(),
+    },
+    interaction: {
+      findUnique: vi.fn(),
+      create:     vi.fn(),
+      delete:     vi.fn(),
+    },
+    comment: {
+      create:   vi.fn(),
+      findMany: vi.fn(),
+    },
+    friendship: {
+      findMany: vi.fn(),
+    },
+    userStats: {
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/infra/database/client';
+
+const mockPost = {
+  id:          'post-id-1',
+  userId:      'user-id-1',
+  contentText: 'Post de teste',
+  mediaUrl:    null,
+  type:        'TEXT' as const,
+  gameContext: null,
+  createdAt:   new Date(),
+  updatedAt:   new Date(),
+};
+
+const mockComment = {
+  id:        'comment-id-1',
+  postId:    'post-id-1',
+  userId:    'user-id-1',
+  parentId:  null,
+  content:   'Comentário de teste',
+  createdAt: new Date(),
+};
+
+const mockInteraction = {
+  id:        'interaction-id-1',
+  postId:    'post-id-1',
+  userId:    'user-id-1',
+  type:      'GG' as const,
+  createdAt: new Date(),
+};
+
+describe('postRepository', () => {
+
+  beforeEach(() => vi.clearAllMocks());
+
+  // ── create ─────────────────────────────────────────────────
+  describe('create', () => {
+    it('cria post e incrementa postCount', async () => {
+      vi.mocked(prisma.post.create).mockResolvedValue(mockPost);
+      vi.mocked(prisma.userStats.updateMany).mockResolvedValue({ count: 1 });
+
+      const result = await postRepository.create({
+        userId:      'user-id-1',
+        contentText: 'Post de teste',
+        type:        'TEXT',
+      });
+
+      expect(result.contentText).toBe('Post de teste');
+      expect(prisma.userStats.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-id-1' },
+        data:  { postCount: { increment: 1 } },
+      });
+    });
+
+    it('cria post com gameContext quando IN_GAME', async () => {
+      const postWithContext = {
+        ...mockPost,
+        gameContext: { gameName: 'Valorant', platform: 'PC' },
+      };
+      vi.mocked(prisma.post.create).mockResolvedValue(postWithContext);
+      vi.mocked(prisma.userStats.updateMany).mockResolvedValue({ count: 1 });
+
+      const result = await postRepository.create({
+        userId:      'user-id-1',
+        contentText: 'Jogando Valorant!',
+        type:        'GAME_SESSION',
+        gameContext: { gameName: 'Valorant', platform: 'PC' },
+      });
+
+      expect(result.gameContext).toMatchObject({ gameName: 'Valorant' });
+    });
+  });
+
+  // ── findById ───────────────────────────────────────────────
+  describe('findById', () => {
+    it('retorna post quando ID existe', async () => {
+      vi.mocked(prisma.post.findUnique).mockResolvedValue(mockPost);
+
+      const result = await postRepository.findById('post-id-1');
+
+      expect(result).toEqual(mockPost);
+    });
+
+    it('retorna null quando ID não existe', async () => {
+      vi.mocked(prisma.post.findUnique).mockResolvedValue(null);
+
+      const result = await postRepository.findById('inexistente');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── findFeedByUserId ───────────────────────────────────────
+  describe('findFeedByUserId', () => {
+    it('retorna feed com posts do usuário e amigos', async () => {
+      vi.mocked(prisma.friendship.findMany).mockResolvedValue([
+        { id: 'f1', userId: 'user-id-1', friendId: 'user-id-2', createdAt: new Date() },
+      ]);
+
+      vi.mocked(prisma.post.findMany).mockResolvedValue([
+        {
+          ...mockPost,
+          user: {
+            id: 'user-id-1', username: 'clutchplayer',
+            profile: { displayName: 'Clutch', avatarUrl: null, accentColor: null },
+          },
+          _count: { interactions: 2, comments: 1 },
+        } as never,
+      ]);
+
+      const result = await postRepository.findFeedByUserId('user-id-1');
+
+      expect(result.posts).toHaveLength(1);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('retorna nextCursor quando há mais posts', async () => {
+      vi.mocked(prisma.friendship.findMany).mockResolvedValue([]);
+
+      const manyPosts = Array.from({ length: 21 }, (_, i) => ({
+        ...mockPost,
+        id: `post-id-${i}`,
+        user: { id: 'user-id-1', username: 'player', profile: null },
+        _count: { interactions: 0, comments: 0 },
+      }));
+
+      vi.mocked(prisma.post.findMany).mockResolvedValue(manyPosts as never);
+
+      const result = await postRepository.findFeedByUserId('user-id-1', undefined, 20);
+
+      expect(result.posts).toHaveLength(20);
+      expect(result.nextCursor).not.toBeNull();
+    });
+  });
+
+  // ── toggleInteraction ──────────────────────────────────────
+  describe('toggleInteraction', () => {
+    it('cria interaction quando não existe (added: true)', async () => {
+      vi.mocked(prisma.interaction.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.interaction.create).mockResolvedValue(mockInteraction);
+
+      const result = await postRepository.toggleInteraction('post-id-1', 'user-id-1', 'GG');
+
+      expect(result.added).toBe(true);
+      expect(prisma.interaction.create).toHaveBeenCalled();
+    });
+
+    it('remove interaction quando já existe (added: false)', async () => {
+      vi.mocked(prisma.interaction.findUnique).mockResolvedValue(mockInteraction);
+      vi.mocked(prisma.interaction.delete).mockResolvedValue(mockInteraction);
+
+      const result = await postRepository.toggleInteraction('post-id-1', 'user-id-1', 'GG');
+
+      expect(result.added).toBe(false);
+      expect(prisma.interaction.delete).toHaveBeenCalled();
+    });
+  });
+
+  // ── createComment ──────────────────────────────────────────
+  describe('createComment', () => {
+    it('cria comentário corretamente', async () => {
+      vi.mocked(prisma.comment.create).mockResolvedValue(mockComment);
+
+      const result = await postRepository.createComment(
+        'post-id-1',
+        'user-id-1',
+        'Comentário de teste',
+      );
+
+      expect(result.content).toBe('Comentário de teste');
+      expect(prisma.comment.create).toHaveBeenCalledWith({
+        data: {
+          postId:   'post-id-1',
+          userId:   'user-id-1',
+          content:  'Comentário de teste',
+          parentId: null,
+        },
+      });
+    });
+  });
+
+  // ── findCommentsByPostId ───────────────────────────────────
+  describe('findCommentsByPostId', () => {
+    it('retorna comentários com replies aninhados', async () => {
+      vi.mocked(prisma.comment.findMany).mockResolvedValue([
+        {
+          ...mockComment,
+          user:    { id: 'user-id-1', username: 'clutch', profile: null },
+          replies: [],
+        } as never,
+      ]);
+
+      const result = await postRepository.findCommentsByPostId('post-id-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.replies).toEqual([]);
+    });
+  });
+
+});


### PR DESCRIPTION
## 📋 Descrição
Implementa o feed social completo do CLUTCH.
Posts capturam automaticamente o jogo sendo jogado via Rich Presence.
Feed paginado com cursor-based pagination. Reactions com toggle (GG, F, CLAP, HYPE).
Comentários com replies aninhados.

---

## 🏷️ Tipo de mudança
- [x] ✨ Nova feature (`feat`)

---

## 🔗 Issue relacionada
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Closes #62

---

## 🧪 Como testar
1. `docker-compose up -d`
2. `cd backend && npm run dev`
3. `POST /posts` com header `x-user-id` e `{ "contentText": "Hello CLUTCH!" }`
4. `GET /posts/feed/:userId` para ver o feed
5. `POST /posts/:id/interactions` com `{ "type": "GG" }` para reagir
6. `npm test` → 105 testes passando

---

## ✅ Checklist
- [x] Código segue TypeScript strict — zero `any`
- [x] Testes adicionados ou atualizados
- [x] `npm test` passa localmente
- [x] `npm run lint` passa sem erros
- [x] Branch está atualizada com `develop`
- [ ] Funções complexas documentadas com JSDoc