### PR TITLE
fix(presence): authenticate websocket handshake and restrict origins

### DIFF
--- a/backend/presence-service/go.mod
+++ b/backend/presence-service/go.mod
@@ -3,6 +3,7 @@ module github.com/alessandrolsdev/clutch/presence-service
 go 1.24
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/redis/go-redis/v9 v9.7.0
 )

--- a/backend/presence-service/go.sum
+++ b/backend/presence-service/go.sum
@@ -6,6 +6,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=

--- a/backend/presence-service/main.go
+++ b/backend/presence-service/main.go
@@ -3,34 +3,48 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 	"github.com/redis/go-redis/v9"
 )
 
-// ─────────────────────────────────────────────────────────────
-// CLUTCH ⚡ — Go Presence Service
-// WebSocket hub para Rich Presence em tempo real
-// Port: 8080
-// ─────────────────────────────────────────────────────────────
-
 const (
-	writeWait      = 10 * time.Second
-	pongWait       = 60 * time.Second
-	pingPeriod     = (pongWait * 9) / 10
-	maxMessageSize = 512
+	writeWait        = 10 * time.Second
+	pongWait         = 60 * time.Second
+	pingPeriod       = (pongWait * 9) / 10
+	maxMessageSize   = 512
+	defaultJWTSecret = "clutch-dev-secret-change-in-production"
+	authQueryParam   = "token"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		return true // TODO: restringir origins em produção
-	},
+var (
+	errDisallowedOrigin  = errors.New("origin not allowed")
+	errMissingCredential = errors.New("missing websocket credential")
+	errInvalidCredential = errors.New("invalid websocket credential")
+	defaultAllowedOrigin = []string{
+		"http://localhost:3000",
+		"http://127.0.0.1:3000",
+		"http://localhost:3001",
+		"http://127.0.0.1:3001",
+	}
+)
+
+type presenceConfig struct {
+	jwtSecret      string
+	allowedOrigins map[string]struct{}
+}
+
+type presenceClaims struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	jwt.RegisteredClaims
 }
 
 type Client struct {
@@ -40,7 +54,142 @@ type Client struct {
 	userId string
 }
 
-// readPump — lê mensagens do cliente
+func loadPresenceConfig() presenceConfig {
+	secret := strings.TrimSpace(os.Getenv("JWT_SECRET"))
+	if secret == "" {
+		secret = defaultJWTSecret
+	}
+
+	return presenceConfig{
+		jwtSecret:      secret,
+		allowedOrigins: buildAllowedOrigins(os.Getenv("PRESENCE_ALLOWED_ORIGINS")),
+	}
+}
+
+func buildAllowedOrigins(raw string) map[string]struct{} {
+	allowedOrigins := make(map[string]struct{})
+
+	for _, origin := range strings.Split(raw, ",") {
+		trimmed := strings.TrimSpace(origin)
+		if trimmed == "" {
+			continue
+		}
+		allowedOrigins[trimmed] = struct{}{}
+	}
+
+	if len(allowedOrigins) > 0 {
+		return allowedOrigins
+	}
+
+	for _, origin := range defaultAllowedOrigin {
+		allowedOrigins[origin] = struct{}{}
+	}
+
+	return allowedOrigins
+}
+
+func isOriginAllowed(origin string, allowedOrigins map[string]struct{}) bool {
+	if strings.TrimSpace(origin) == "" {
+		return false
+	}
+
+	_, ok := allowedOrigins[origin]
+	return ok
+}
+
+func extractCredential(r *http.Request) (string, error) {
+	authorization := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authorization != "" {
+		scheme, token, found := strings.Cut(authorization, " ")
+		if !found || !strings.EqualFold(strings.TrimSpace(scheme), "Bearer") || strings.TrimSpace(token) == "" {
+			return "", errInvalidCredential
+		}
+		return strings.TrimSpace(token), nil
+	}
+
+	token := strings.TrimSpace(r.URL.Query().Get(authQueryParam))
+	if token != "" {
+		return token, nil
+	}
+
+	return "", errMissingCredential
+}
+
+func authenticateRequest(r *http.Request, cfg presenceConfig) (string, error) {
+	tokenString, err := extractCredential(r)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := jwt.ParseWithClaims(
+		tokenString,
+		&presenceClaims{},
+		func(parsed *jwt.Token) (interface{}, error) {
+			if parsed.Method != jwt.SigningMethodHS256 {
+				return nil, errInvalidCredential
+			}
+
+			return []byte(cfg.jwtSecret), nil
+		},
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}),
+	)
+	if err != nil {
+		return "", errInvalidCredential
+	}
+
+	claims, ok := token.Claims.(*presenceClaims)
+	if !ok || !token.Valid || strings.TrimSpace(claims.ID) == "" {
+		return "", errInvalidCredential
+	}
+
+	return claims.ID, nil
+}
+
+func newUpgrader(cfg presenceConfig) websocket.Upgrader {
+	return websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			return isOriginAllowed(r.Header.Get("Origin"), cfg.allowedOrigins)
+		},
+	}
+}
+
+func newPresenceHandler(hub *Hub, cfg presenceConfig) http.HandlerFunc {
+	wsUpgrader := newUpgrader(cfg)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isOriginAllowed(r.Header.Get("Origin"), cfg.allowedOrigins) {
+			http.Error(w, errDisallowedOrigin.Error(), http.StatusForbidden)
+			return
+		}
+
+		userID, err := authenticateRequest(r, cfg)
+		if err != nil {
+			http.Error(w, "unauthorized websocket connection", http.StatusUnauthorized)
+			return
+		}
+
+		conn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			log.Printf("websocket upgrade error: %v", err)
+			return
+		}
+
+		client := &Client{
+			hub:    hub,
+			conn:   conn,
+			send:   make(chan []byte, 256),
+			userId: userID,
+		}
+
+		hub.register <- client
+
+		go client.writePump()
+		go client.readPump()
+	}
+}
+
 func (c *Client) readPump() {
 	defer func() {
 		c.hub.unregister <- c
@@ -67,22 +216,18 @@ func (c *Client) readPump() {
 			break
 		}
 
-		// Responde PING com PONG
 		var msg map[string]interface{}
-		if err := json.Unmarshal(message, &msg); err == nil {
-			if msg["event"] == "PING" {
-				pong, _ := json.Marshal(WsMessage{
-					Event:   EventPong,
-					Payload: nil,
-					Ts:      time.Now().UnixMilli(),
-				})
-				c.send <- pong
-			}
+		if err := json.Unmarshal(message, &msg); err == nil && msg["event"] == "PING" {
+			pong, _ := json.Marshal(WsMessage{
+				Event:   EventPong,
+				Payload: nil,
+				Ts:      time.Now().UnixMilli(),
+			})
+			c.send <- pong
 		}
 	}
 }
 
-// writePump — escreve mensagens para o cliente
 func (c *Client) writePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
@@ -124,8 +269,8 @@ func (c *Client) writePump() {
 
 func main() {
 	ctx := context.Background()
+	cfg := loadPresenceConfig()
 
-	// ── Redis ──────────────────────────────────────────────
 	redisURL := os.Getenv("REDIS_URL")
 	if redisURL == "" {
 		redisURL = "redis://localhost:6379"
@@ -140,42 +285,13 @@ func main() {
 	if err := redisClient.Ping(ctx).Err(); err != nil {
 		log.Fatalf("failed to connect to Redis: %v", err)
 	}
-	log.Println("✅ Connected to Redis")
+	log.Println("connected to Redis")
 
-	// ── Hub ────────────────────────────────────────────────
 	hub := NewHub(redisClient)
 	go hub.Run(ctx)
 
-	// ── HTTP handlers ──────────────────────────────────────
+	http.HandleFunc("/ws/presence", newPresenceHandler(hub, cfg))
 
-	// WebSocket endpoint
-	http.HandleFunc("/ws/presence", func(w http.ResponseWriter, r *http.Request) {
-		userId := r.URL.Query().Get("userId")
-		if userId == "" {
-			http.Error(w, "userId is required", http.StatusBadRequest)
-			return
-		}
-
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			log.Printf("websocket upgrade error: %v", err)
-			return
-		}
-
-		client := &Client{
-			hub:    hub,
-			conn:   conn,
-			send:   make(chan []byte, 256),
-			userId: userId,
-		}
-
-		hub.register <- client
-
-		go client.writePump()
-		go client.readPump()
-	})
-
-	// Stats endpoint
 	http.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]interface{}{
@@ -187,7 +303,6 @@ func main() {
 		}
 	})
 
-	// Health check
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]string{
@@ -203,7 +318,7 @@ func main() {
 		port = "8080"
 	}
 
-	log.Printf("⚡ CLUTCH Presence Service → ws://localhost:%s/ws/presence", port)
+	log.Printf("CLUTCH Presence Service listening on ws://localhost:%s/ws/presence", port)
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatalf("server error: %v", err)
 	}

--- a/backend/presence-service/main_test.go
+++ b/backend/presence-service/main_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+)
+
+func TestAuthenticateRequestRejectsMissingCredential(t *testing.T) {
+	t.Parallel()
+
+	request := httptest.NewRequest(http.MethodGet, "/ws/presence?userId=attacker-id", nil)
+	request.Header.Set("Origin", "http://localhost:3000")
+
+	_, err := authenticateRequest(request, testPresenceConfig())
+	if err != errMissingCredential {
+		t.Fatalf("expected missing credential error, got %v", err)
+	}
+}
+
+func TestAuthenticateRequestRejectsInvalidCredential(t *testing.T) {
+	t.Parallel()
+
+	request := httptest.NewRequest(http.MethodGet, "/ws/presence?token=invalid-token", nil)
+	request.Header.Set("Origin", "http://localhost:3000")
+
+	_, err := authenticateRequest(request, testPresenceConfig())
+	if err != errInvalidCredential {
+		t.Fatalf("expected invalid credential error, got %v", err)
+	}
+}
+
+func TestPresenceHandlerRejectsDisallowedOrigin(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	server := httptest.NewServer(newPresenceHandler(hub, testPresenceConfig()))
+	defer server.Close()
+
+	_, response, err := dialPresence(
+		server.URL,
+		"http://malicious.example",
+		tokenQuery(signTestToken(t, "user-123")),
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected websocket dial to fail for disallowed origin")
+	}
+	if response == nil || response.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 response, got %v", response)
+	}
+
+	assertNoRegistration(t, hub)
+}
+
+func TestPresenceHandlerRejectsMissingCredentialEvenWithUserIDQuery(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	server := httptest.NewServer(newPresenceHandler(hub, testPresenceConfig()))
+	defer server.Close()
+
+	_, response, err := dialPresence(server.URL, "http://localhost:3000", "userId=attacker-id", nil)
+	if err == nil {
+		t.Fatal("expected websocket dial to fail without credential")
+	}
+	if response == nil || response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 response, got %v", response)
+	}
+
+	assertNoRegistration(t, hub)
+}
+
+func TestPresenceHandlerRejectsInvalidCredential(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	server := httptest.NewServer(newPresenceHandler(hub, testPresenceConfig()))
+	defer server.Close()
+
+	_, response, err := dialPresence(server.URL, "http://localhost:3000", tokenQuery("invalid-token"), nil)
+	if err == nil {
+		t.Fatal("expected websocket dial to fail with invalid credential")
+	}
+	if response == nil || response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 response, got %v", response)
+	}
+
+	assertNoRegistration(t, hub)
+}
+
+func TestPresenceHandlerAuthenticatesConnectionAndUsesTokenIdentity(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	server := httptest.NewServer(newPresenceHandler(hub, testPresenceConfig()))
+	defer server.Close()
+
+	validToken := signTestToken(t, "user-123")
+	connection, response, err := dialPresence(
+		server.URL,
+		"http://localhost:3000",
+		tokenQuery(validToken)+"&userId=attacker-id",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected websocket dial to succeed, got status %v and error %v", response, err)
+	}
+	defer connection.Close()
+
+	select {
+	case registeredClient := <-hub.register:
+		if registeredClient.userId != "user-123" {
+			t.Fatalf("expected registered user id to come from token, got %q", registeredClient.userId)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected authenticated client to be registered")
+	}
+}
+
+func TestPresenceHandlerAuthenticatesBearerHeader(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	server := httptest.NewServer(newPresenceHandler(hub, testPresenceConfig()))
+	defer server.Close()
+
+	headers := make(http.Header)
+	headers.Set("Authorization", "Bearer "+signTestToken(t, "user-456"))
+
+	connection, response, err := dialPresence(server.URL, "http://localhost:3000", "userId=ignored", headers)
+	if err != nil {
+		t.Fatalf("expected websocket dial to succeed, got status %v and error %v", response, err)
+	}
+	defer connection.Close()
+
+	select {
+	case registeredClient := <-hub.register:
+		if registeredClient.userId != "user-456" {
+			t.Fatalf("expected bearer-authenticated user id, got %q", registeredClient.userId)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected authenticated client to be registered")
+	}
+}
+
+func testPresenceConfig() presenceConfig {
+	return presenceConfig{
+		jwtSecret: "test-secret",
+		allowedOrigins: map[string]struct{}{
+			"http://localhost:3000": {},
+		},
+	}
+}
+
+func newTestHub() *Hub {
+	return &Hub{
+		clients:    make(map[string]*Client),
+		register:   make(chan *Client, 2),
+		unregister: make(chan *Client, 2),
+	}
+}
+
+func signTestToken(t *testing.T, userID string) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, presenceClaims{
+		ID:       userID,
+		Username: "tester",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+
+	signedToken, err := token.SignedString([]byte("test-secret"))
+	if err != nil {
+		t.Fatalf("failed to sign test token: %v", err)
+	}
+
+	return signedToken
+}
+
+func dialPresence(serverURL string, origin string, query string, headers http.Header) (*websocket.Conn, *http.Response, error) {
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + "/ws/presence"
+	if query != "" {
+		wsURL += "?" + query
+	}
+
+	requestHeaders := make(http.Header)
+	for key, values := range headers {
+		for _, value := range values {
+			requestHeaders.Add(key, value)
+		}
+	}
+	requestHeaders.Set("Origin", origin)
+
+	return websocket.DefaultDialer.Dial(wsURL, requestHeaders)
+}
+
+func tokenQuery(token string) string {
+	return fmt.Sprintf("token=%s", token)
+}
+
+func assertNoRegistration(t *testing.T, hub *Hub) {
+	t.Helper()
+
+	select {
+	case registeredClient := <-hub.register:
+		t.Fatalf("expected no registered client, got %q", registeredClient.userId)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
- require explicit JWT credentials during the presence WebSocket handshake
- derive the connected user from the validated token instead of trusting query-string userId
- restrict WebSocket origins through an allowlist and add Go coverage for success/failure cases

## Testing
- go test ./...

Closes #106