### PR TITLE
fix(realtime): scope presence and notification delivery

### DIFF
--- a/backend/presence-service/hub.go
+++ b/backend/presence-service/hub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,6 +36,20 @@ type PresenceUpdate struct {
 	Platform    *string `json:"platform"`
 }
 
+type NotificationPayload struct {
+	ID        string                 `json:"id"`
+	Type      string                 `json:"type"`
+	Payload   map[string]interface{} `json:"payload"`
+	ActorID   *string                `json:"actorId"`
+	IsRead    bool                   `json:"isRead"`
+	CreatedAt string                 `json:"createdAt"`
+}
+
+const (
+	presenceChannelPrefix      = "realtime:presence:"
+	notificationsChannelPrefix = "notifications:"
+)
+
 type Hub struct {
 	mu          sync.RWMutex
 	clients     map[string]*Client // userId → Client
@@ -53,8 +68,7 @@ func NewHub(redisClient *redis.Client) *Hub {
 }
 
 func (h *Hub) Run(ctx context.Context) {
-	// Subscreve no canal de presença do Redis
-	pubsub := h.redisClient.Subscribe(ctx, "presence:updates")
+	pubsub := h.redisClient.PSubscribe(ctx, presenceChannelPrefix+"*", notificationsChannelPrefix+"*")
 	defer func() {
 		if err := pubsub.Close(); err != nil {
 			log.Printf("error closing pubsub: %v", err)
@@ -84,45 +98,107 @@ func (h *Hub) Run(ctx context.Context) {
 			log.Printf("client unregistered: %s (total: %d)", client.userId, h.Count())
 
 		case msg := <-redisCh:
-			h.broadcastPresenceUpdate(msg.Payload)
+			h.routeRealtimeMessage(msg.Channel, msg.Payload)
 		}
 	}
 }
 
-func (h *Hub) broadcastPresenceUpdate(payload string) {
-	var update PresenceUpdate
-	if err := json.Unmarshal([]byte(payload), &update); err != nil {
+func (h *Hub) routeRealtimeMessage(channel string, payload string) {
+	switch {
+	case strings.HasPrefix(channel, presenceChannelPrefix):
+		h.deliverPresenceUpdate(channel, payload)
+	case strings.HasPrefix(channel, notificationsChannelPrefix):
+		h.deliverNotification(channel, payload)
+	default:
+		log.Printf("unsupported realtime channel: %s", channel)
+	}
+}
+
+func (h *Hub) deliverPresenceUpdate(channel string, payload string) {
+	recipientID, ok := channelRecipientID(channel, presenceChannelPrefix)
+	if !ok {
+		log.Printf("invalid presence channel: %s", channel)
+		return
+	}
+
+	var message WsMessage
+	if err := json.Unmarshal([]byte(payload), &message); err != nil {
 		log.Printf("error parsing presence update: %v", err)
 		return
 	}
 
-	msg := WsMessage{
-		Event:   EventFriendPresence,
-		Payload: update,
-		Ts:      time.Now().UnixMilli(),
-	}
-
-	data, err := json.Marshal(msg)
-	if err != nil {
-		log.Printf("error marshaling message: %v", err)
+	if message.Event != EventFriendPresence {
+		log.Printf("unexpected presence event: %s", message.Event)
 		return
 	}
 
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	data, err := json.Marshal(message)
+	if err != nil {
+		log.Printf("error marshaling presence message: %v", err)
+		return
+	}
 
-	// Entrega para todos os clientes conectados exceto o próprio usuário
-	for userId, client := range h.clients {
-		if userId == update.UserId {
-			continue
-		}
-		select {
-		case client.send <- data:
-		default:
-			// Canal cheio — cliente lento, será desconectado
+	h.sendToUser(recipientID, data)
+}
+
+func (h *Hub) deliverNotification(channel string, payload string) {
+	recipientID, ok := channelRecipientID(channel, notificationsChannelPrefix)
+	if !ok {
+		log.Printf("invalid notification channel: %s", channel)
+		return
+	}
+
+	var notification NotificationPayload
+	if err := json.Unmarshal([]byte(payload), &notification); err != nil {
+		log.Printf("error parsing notification payload: %v", err)
+		return
+	}
+
+	message := WsMessage{
+		Event:   EventNotification,
+		Payload: notification,
+		Ts:      time.Now().UnixMilli(),
+	}
+
+	data, err := json.Marshal(message)
+	if err != nil {
+		log.Printf("error marshaling notification message: %v", err)
+		return
+	}
+
+	h.sendToUser(recipientID, data)
+}
+
+func channelRecipientID(channel string, prefix string) (string, bool) {
+	if !strings.HasPrefix(channel, prefix) {
+		return "", false
+	}
+
+	recipientID := strings.TrimPrefix(channel, prefix)
+	if recipientID == "" {
+		return "", false
+	}
+
+	return recipientID, true
+}
+
+func (h *Hub) sendToUser(userID string, data []byte) {
+	h.mu.RLock()
+	client, ok := h.clients[userID]
+	h.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	select {
+	case client.send <- data:
+	default:
+		h.mu.Lock()
+		if currentClient, exists := h.clients[userID]; exists && currentClient == client {
 			close(client.send)
-			delete(h.clients, userId)
+			delete(h.clients, userID)
 		}
+		h.mu.Unlock()
 	}
 }
 

--- a/backend/presence-service/hub_test.go
+++ b/backend/presence-service/hub_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDeliverPresenceUpdateSendsOnlyToRecipient(t *testing.T) {
+	t.Parallel()
+
+	hub := &Hub{
+		clients: map[string]*Client{
+			"friend-id-1": {userId: "friend-id-1", send: make(chan []byte, 1)},
+			"friend-id-2": {userId: "friend-id-2", send: make(chan []byte, 1)},
+		},
+	}
+
+	message, err := json.Marshal(WsMessage{
+		Event: EventFriendPresence,
+		Payload: PresenceUpdate{
+			UserId: "user-id-1",
+			Status: "ONLINE",
+		},
+		Ts: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal presence message: %v", err)
+	}
+
+	hub.deliverPresenceUpdate("realtime:presence:friend-id-1", string(message))
+
+	assertMessageDelivered(t, hub.clients["friend-id-1"].send)
+	assertNoMessageDelivered(t, hub.clients["friend-id-2"].send)
+}
+
+func TestDeliverNotificationSendsOnlyToRecipient(t *testing.T) {
+	t.Parallel()
+
+	hub := &Hub{
+		clients: map[string]*Client{
+			"user-id-1": {userId: "user-id-1", send: make(chan []byte, 1)},
+			"user-id-2": {userId: "user-id-2", send: make(chan []byte, 1)},
+		},
+	}
+
+	payload, err := json.Marshal(NotificationPayload{
+		ID:      "notif-id-1",
+		Type:    "FRIEND_REQUEST",
+		Payload: map[string]interface{}{"requestId": "request-id-1"},
+		IsRead:  false,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal notification payload: %v", err)
+	}
+
+	hub.deliverNotification("notifications:user-id-1", string(payload))
+
+	assertMessageDelivered(t, hub.clients["user-id-1"].send)
+	assertNoMessageDelivered(t, hub.clients["user-id-2"].send)
+}
+
+func TestChannelRecipientIDRejectsInvalidChannel(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := channelRecipientID("presence:updates", presenceChannelPrefix); ok {
+		t.Fatal("expected invalid channel to be rejected")
+	}
+}
+
+func assertMessageDelivered(t *testing.T, messages <-chan []byte) {
+	t.Helper()
+
+	select {
+	case <-messages:
+	case <-time.After(time.Second):
+		t.Fatal("expected message to be delivered")
+	}
+}
+
+func assertNoMessageDelivered(t *testing.T, messages <-chan []byte) {
+	t.Helper()
+
+	select {
+	case message := <-messages:
+		t.Fatalf("expected no message, received %s", string(message))
+	default:
+	}
+}

--- a/backend/src/api/routes/friends.routes.ts
+++ b/backend/src/api/routes/friends.routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { friendRepository } from '@/core/repositories/friend.repository';
+import { notificationService } from '@/core/services/notification.service';
 import { userRepository }   from '@/core/repositories/user.repository';
 
 // ─────────────────────────────────────────────────────────────
@@ -36,6 +37,16 @@ export async function friendRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const friendRequest = await friendRepository.createRequest(request.userId, targetId);
+      await notificationService.create({
+        userId:  targetId,
+        actorId: request.userId,
+        type:    'FRIEND_REQUEST',
+        payload: {
+          requestId: friendRequest.id,
+          senderId:  request.userId,
+        },
+      });
+
       return reply.status(201).send({ id: friendRequest.id, status: friendRequest.status });
     },
   );
@@ -61,6 +72,15 @@ export async function friendRoutes(app: FastifyInstance): Promise<void> {
         friendRequest.senderId,
         friendRequest.receiverId,
       );
+      await notificationService.create({
+        userId:  friendRequest.senderId,
+        actorId: request.userId,
+        type:    'FRIEND_ACCEPTED',
+        payload: {
+          requestId: request.params.requestId,
+          friendId:  request.userId,
+        },
+      });
 
       return reply.status(200).send({ message: 'Amizade confirmada.' });
     },

--- a/backend/src/api/routes/posts.routes.ts
+++ b/backend/src/api/routes/posts.routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { notificationService } from '@/core/services/notification.service';
 import { postRepository }     from '@/core/repositories/post.repository';
 import { presenceRepository } from '@/core/repositories/presence.repository';
 import { userRepository }     from '@/core/repositories/user.repository';
@@ -85,6 +86,18 @@ export async function postRoutes(app: FastifyInstance): Promise<void> {
       }
 
       const { added } = await postRepository.toggleInteraction(request.params.id, request.userId, result.data.type);
+      if (added) {
+        await notificationService.create({
+          userId:  post.userId,
+          actorId: request.userId,
+          type:    'POST_LIKE',
+          payload: {
+            postId:          post.id,
+            interactionType: result.data.type,
+          },
+        });
+      }
+
       return reply.status(200).send({ added });
     },
   );
@@ -105,6 +118,20 @@ export async function postRoutes(app: FastifyInstance): Promise<void> {
       const comment = await postRepository.createComment(
         result.data.postId, request.userId, result.data.content, result.data.parentId,
       );
+
+      if (post.userId !== request.userId) {
+        await notificationService.create({
+          userId:  post.userId,
+          actorId: request.userId,
+          type:    'POST_COMMENT',
+          payload: {
+            postId:    post.id,
+            commentId: comment.id,
+            parentId:  comment.parentId ?? null,
+          },
+        });
+      }
+
       return reply.status(201).send(comment);
     },
   );

--- a/backend/src/api/routes/presence.routes.ts
+++ b/backend/src/api/routes/presence.routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { friendRepository } from '@/core/repositories/friend.repository';
 import { presenceRepository } from '@/core/repositories/presence.repository';
 import { userRepository }     from '@/core/repositories/user.repository';
 
@@ -22,12 +23,15 @@ export async function presenceRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(400).send({ message: result.error.errors[0]?.message ?? 'Dados inválidos.' });
       }
 
-      await presenceRepository.set(request.userId, {
+      const presence = await presenceRepository.set(request.userId, {
         status:      result.data.status,
         currentGame: result.data.currentGame,
         gameDetails: result.data.gameDetails as Record<string, unknown> | null | undefined,
         platform:    result.data.platform,
       });
+
+      const friendIds = await friendRepository.findFriendIdsByUserId(request.userId);
+      await presenceRepository.publishScopedUpdate(presence, friendIds);
 
       return reply.status(200).send({ message: 'Presença atualizada.' });
     },

--- a/backend/src/core/repositories/friend.repository.ts
+++ b/backend/src/core/repositories/friend.repository.ts
@@ -137,6 +137,15 @@ export const friendRepository = {
     return friendships.map((f) => f.friend);
   },
 
+  async findFriendIdsByUserId(userId: string): Promise<string[]> {
+    const friendships = await prisma.friendship.findMany({
+      where:  { userId },
+      select: { friendId: true },
+    });
+
+    return friendships.map((friendship) => friendship.friendId);
+  },
+
   async findPendingRequests(receiverId: string): Promise<PendingRequest[]> {
     return prisma.friendRequest.findMany({
       where:   { receiverId, status: 'PENDING' },

--- a/backend/src/core/repositories/presence.repository.ts
+++ b/backend/src/core/repositories/presence.repository.ts
@@ -24,9 +24,15 @@ export interface SetPresenceInput {
   platform?:    string | null;
 }
 
+export interface PresenceRealtimeMessage {
+  event:   'FRIEND_PRESENCE';
+  payload: PresenceData;
+  ts:      number;
+}
+
 export const presenceRepository = {
 
-  async set(userId: string, input: SetPresenceInput): Promise<void> {
+  async set(userId: string, input: SetPresenceInput): Promise<PresenceData> {
     const data: PresenceData = {
       userId,
       status:      input.status,
@@ -65,11 +71,7 @@ export const presenceRepository = {
       },
     });
 
-    // ── Pub/Sub → Go service ───────────────────────────────
-    await redis.publish(
-      REDIS_KEYS.presenceUpdate,
-      JSON.stringify(data),
-    );
+    return data;
   },
 
   async get(userId: string): Promise<PresenceData> {
@@ -105,7 +107,7 @@ export const presenceRepository = {
     };
   },
 
-  async setOffline(userId: string): Promise<void> {
+  async setOffline(userId: string): Promise<PresenceData> {
     // ── Remove do Redis ────────────────────────────────────
     await redis.del(REDIS_KEYS.presence(userId));
 
@@ -116,18 +118,14 @@ export const presenceRepository = {
       update: { status: 'OFFLINE', currentGame: null, platform: null },
     });
 
-    // ── Publica OFFLINE no Pub/Sub ─────────────────────────
-    await redis.publish(
-      REDIS_KEYS.presenceUpdate,
-      JSON.stringify({
-        userId,
-        status:      'OFFLINE',
-        currentGame: null,
-        gameDetails: null,
-        platform:    null,
-        updatedAt:   new Date().toISOString(),
-      }),
-    );
+    return {
+      userId,
+      status:      'OFFLINE',
+      currentGame: null,
+      gameDetails: null,
+      platform:    null,
+      updatedAt:   new Date().toISOString(),
+    };
   },
 
   async getFriendsPresence(userIds: string[]): Promise<PresenceData[]> {
@@ -162,6 +160,29 @@ export const presenceRepository = {
     });
 
     return presences;
+  },
+
+  async publishScopedUpdate(presence: PresenceData, recipientIds: string[]): Promise<void> {
+    const uniqueRecipients = Array.from(new Set(
+      recipientIds.filter((recipientId) => recipientId !== presence.userId),
+    ));
+
+    if (uniqueRecipients.length === 0) {
+      return;
+    }
+
+    const message: PresenceRealtimeMessage = {
+      event:   'FRIEND_PRESENCE',
+      payload: presence,
+      ts:      Date.now(),
+    };
+
+    await Promise.all(uniqueRecipients.map((recipientId) => (
+      redis.publish(
+        REDIS_KEYS.presenceFeed(recipientId),
+        JSON.stringify(message),
+      )
+    )));
   },
 
 };

--- a/backend/src/core/services/notification.service.ts
+++ b/backend/src/core/services/notification.service.ts
@@ -1,5 +1,5 @@
 import { notificationRepository } from '@/core/repositories/notification.repository';
-import { redis } from '@/infra/cache/redis';
+import { redis, REDIS_KEYS } from '@/infra/cache/redis';
 
 // ─────────────────────────────────────────────────────────────
 // Notification Service
@@ -35,7 +35,7 @@ export const notificationService = {
 
     // ── Publica no Redis → Go service entrega via WebSocket ─
     await redis.publish(
-      `notifications:${input.userId}`,
+      REDIS_KEYS.notifications(input.userId),
       JSON.stringify({
         id:        notification.id,
         type:      notification.type,

--- a/backend/src/infra/cache/redis.ts
+++ b/backend/src/infra/cache/redis.ts
@@ -24,6 +24,8 @@ if (process.env.NODE_ENV !== 'production') {
 // Chaves Redis
 export const REDIS_KEYS = {
   presence:       (userId: string) => `presence:${userId}`,
+  presenceFeed:   (userId: string) => `realtime:presence:${userId}`,
+  notifications:  (userId: string) => `notifications:${userId}`,
   friendsList:    (userId: string) => `friends:${userId}`,
   presenceUpdate: 'presence:updates',
 } as const;

--- a/backend/tests/integration/routes/friends.routes.test.ts
+++ b/backend/tests/integration/routes/friends.routes.test.ts
@@ -5,7 +5,13 @@ vi.mock('@/core/repositories/friend.repository', () => ({
   friendRepository: {
     createRequest: vi.fn(), findRequestById: vi.fn(), existsRequest: vi.fn(),
     existsFriendship: vi.fn(), acceptRequest: vi.fn(), removeFriendship: vi.fn(),
-    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(),
+    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(), findFriendIdsByUserId: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/services/notification.service', () => ({
+  notificationService: {
+    create: vi.fn(),
   },
 }));
 
@@ -25,6 +31,7 @@ vi.mock('@/infra/integrations/igdb/igdb.service',    () => ({ igdbService:   {} 
 vi.mock('@/infra/integrations/epic/epic.service',    () => ({ epicService:   {} }));
 
 import { friendRepository } from '@/core/repositories/friend.repository';
+import { notificationService } from '@/core/services/notification.service';
 import { userRepository }   from '@/core/repositories/user.repository';
 
 const mockUser = {
@@ -58,6 +65,15 @@ describe('Friends Routes', () => {
       });
 
       expect(response.statusCode).toBe(201);
+      expect(notificationService.create).toHaveBeenCalledWith({
+        userId:  'user-id-2',
+        actorId: 'user-id-1',
+        type:    'FRIEND_REQUEST',
+        payload: {
+          requestId: 'request-id-1',
+          senderId:  'user-id-1',
+        },
+      });
       await app.close();
     });
 
@@ -133,6 +149,15 @@ describe('Friends Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
+      expect(notificationService.create).toHaveBeenCalledWith({
+        userId:  'user-id-1',
+        actorId: 'user-id-2',
+        type:    'FRIEND_ACCEPTED',
+        payload: {
+          requestId: 'request-id-1',
+          friendId:  'user-id-2',
+        },
+      });
       await app.close();
     });
 

--- a/backend/tests/integration/routes/notifications.routes.test.ts
+++ b/backend/tests/integration/routes/notifications.routes.test.ts
@@ -23,12 +23,12 @@ vi.mock('@/core/repositories/friend.repository', () => ({
   friendRepository: {
     createRequest: vi.fn(), findRequestById: vi.fn(), existsRequest: vi.fn(),
     existsFriendship: vi.fn(), acceptRequest: vi.fn(), removeFriendship: vi.fn(),
-    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(),
+    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(), findFriendIdsByUserId: vi.fn(),
   },
 }));
 
 vi.mock('@/core/repositories/presence.repository', () => ({
-  presenceRepository: { set: vi.fn(), get: vi.fn(), setOffline: vi.fn() },
+  presenceRepository: { set: vi.fn(), get: vi.fn(), setOffline: vi.fn(), publishScopedUpdate: vi.fn() },
 }));
 
 vi.mock('@/core/repositories/post.repository', () => ({

--- a/backend/tests/integration/routes/posts.routes.test.ts
+++ b/backend/tests/integration/routes/posts.routes.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/core/repositories/post.repository', () => ({
 }));
 
 vi.mock('@/core/repositories/presence.repository', () => ({
-  presenceRepository: { set: vi.fn(), get: vi.fn(), setOffline: vi.fn() },
+  presenceRepository: { set: vi.fn(), get: vi.fn(), setOffline: vi.fn(), publishScopedUpdate: vi.fn() },
 }));
 
 vi.mock('@/core/repositories/user.repository', () => ({
@@ -28,7 +28,13 @@ vi.mock('@/core/repositories/friend.repository', () => ({
   friendRepository: {
     createRequest: vi.fn(), findRequestById: vi.fn(), existsRequest: vi.fn(),
     existsFriendship: vi.fn(), acceptRequest: vi.fn(), removeFriendship: vi.fn(),
-    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(),
+    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(), findFriendIdsByUserId: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/services/notification.service', () => ({
+  notificationService: {
+    create: vi.fn(),
   },
 }));
 
@@ -37,6 +43,7 @@ vi.mock('@/infra/integrations/igdb/igdb.service',    () => ({ igdbService:   {} 
 vi.mock('@/infra/integrations/epic/epic.service',    () => ({ epicService:   {} }));
 
 import { postRepository }     from '@/core/repositories/post.repository';
+import { notificationService } from '@/core/services/notification.service';
 import { presenceRepository } from '@/core/repositories/presence.repository';
 import { userRepository }     from '@/core/repositories/user.repository';
 
@@ -168,6 +175,15 @@ describe('Posts Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
+      expect(notificationService.create).toHaveBeenCalledWith({
+        userId:  'user-id-1',
+        actorId: 'user-id-2',
+        type:    'POST_LIKE',
+        payload: {
+          postId:          'post-id-1',
+          interactionType: 'GG',
+        },
+      });
       await app.close();
     });
 
@@ -185,6 +201,7 @@ describe('Posts Routes', () => {
       });
 
       expect(response.statusCode).toBe(400);
+      expect(notificationService.create).not.toHaveBeenCalled();
       await app.close();
     });
 
@@ -225,6 +242,16 @@ describe('Posts Routes', () => {
       });
 
       expect(response.statusCode).toBe(201);
+      expect(notificationService.create).toHaveBeenCalledWith({
+        userId:  'user-id-1',
+        actorId: 'user-id-2',
+        type:    'POST_COMMENT',
+        payload: {
+          postId:    'post-id-1',
+          commentId: 'c1',
+          parentId:  null,
+        },
+      });
       await app.close();
     });
   });

--- a/backend/tests/integration/routes/presence.routes.test.ts
+++ b/backend/tests/integration/routes/presence.routes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildApp, generateTestToken } from '../../helpers/build-app';
 
 vi.mock('@/core/repositories/presence.repository', () => ({
-  presenceRepository: { set: vi.fn(), get: vi.fn(), setOffline: vi.fn() },
+  presenceRepository: { set: vi.fn(), get: vi.fn(), setOffline: vi.fn(), publishScopedUpdate: vi.fn() },
 }));
 
 vi.mock('@/core/repositories/user.repository', () => ({
@@ -20,7 +20,7 @@ vi.mock('@/core/repositories/friend.repository', () => ({
   friendRepository: {
     createRequest: vi.fn(), findRequestById: vi.fn(), existsRequest: vi.fn(),
     existsFriendship: vi.fn(), acceptRequest: vi.fn(), removeFriendship: vi.fn(),
-    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(),
+    findFriendsByUserId: vi.fn(), findPendingRequests: vi.fn(), findFriendIdsByUserId: vi.fn(),
   },
 }));
 
@@ -29,6 +29,7 @@ vi.mock('@/infra/integrations/igdb/igdb.service',    () => ({ igdbService:   {} 
 vi.mock('@/infra/integrations/epic/epic.service',    () => ({ epicService:   {} }));
 
 import { presenceRepository } from '@/core/repositories/presence.repository';
+import { friendRepository }   from '@/core/repositories/friend.repository';
 import { userRepository }     from '@/core/repositories/user.repository';
 
 const mockUser = {
@@ -48,7 +49,9 @@ describe('Presence Routes', () => {
 
   describe('POST /presence', () => {
     it('retorna 200 atualizando para ONLINE', async () => {
-      vi.mocked(presenceRepository.set).mockResolvedValue(undefined);
+      vi.mocked(presenceRepository.set).mockResolvedValue(mockPresence);
+      vi.mocked(friendRepository.findFriendIdsByUserId).mockResolvedValue(['friend-id-1']);
+      vi.mocked(presenceRepository.publishScopedUpdate).mockResolvedValue(undefined);
 
       const app   = await buildApp();
       const token = generateTestToken(app);
@@ -61,11 +64,15 @@ describe('Presence Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
+      expect(friendRepository.findFriendIdsByUserId).toHaveBeenCalledWith('user-id-1');
+      expect(presenceRepository.publishScopedUpdate).toHaveBeenCalledWith(mockPresence, ['friend-id-1']);
       await app.close();
     });
 
     it('retorna 200 atualizando para IN_GAME', async () => {
-      vi.mocked(presenceRepository.set).mockResolvedValue(undefined);
+      vi.mocked(presenceRepository.set).mockResolvedValue(mockPresence);
+      vi.mocked(friendRepository.findFriendIdsByUserId).mockResolvedValue([]);
+      vi.mocked(presenceRepository.publishScopedUpdate).mockResolvedValue(undefined);
 
       const app   = await buildApp();
       const token = generateTestToken(app);

--- a/backend/tests/unit/repositories/friend.repository.test.ts
+++ b/backend/tests/unit/repositories/friend.repository.test.ts
@@ -77,6 +77,19 @@ describe('friendRepository', () => {
     });
   });
 
+  describe('findRequestById', () => {
+    it('retorna pedido quando ele existe', async () => {
+      vi.mocked(prisma.friendRequest.findUnique).mockResolvedValue(mockRequest);
+
+      const result = await friendRepository.findRequestById('request-id-1');
+
+      expect(result).toEqual(mockRequest);
+      expect(prisma.friendRequest.findUnique).toHaveBeenCalledWith({
+        where: { id: 'request-id-1' },
+      });
+    });
+  });
+
   // ── existsFriendship ───────────────────────────────────────
   describe('existsFriendship', () => {
     it('retorna true quando amizade existe', async () => {
@@ -134,6 +147,23 @@ describe('friendRepository', () => {
       expect(prisma.friendship.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: { userId: 'user-id-1' } }),
       );
+    });
+  });
+
+  describe('findFriendIdsByUserId', () => {
+    it('retorna apenas os ids dos amigos do usuário', async () => {
+      vi.mocked(prisma.friendship.findMany).mockResolvedValue([
+        { friendId: 'friend-id-1' },
+        { friendId: 'friend-id-2' },
+      ] as never);
+
+      const result = await friendRepository.findFriendIdsByUserId('user-id-1');
+
+      expect(result).toEqual(['friend-id-1', 'friend-id-2']);
+      expect(prisma.friendship.findMany).toHaveBeenCalledWith({
+        where:  { userId: 'user-id-1' },
+        select: { friendId: true },
+      });
     });
   });
 

--- a/backend/tests/unit/repositories/post.repository.test.ts
+++ b/backend/tests/unit/repositories/post.repository.test.ts
@@ -184,6 +184,25 @@ describe('postRepository', () => {
     });
   });
 
+  describe('findInteraction', () => {
+    it('retorna interaction quando ela existe', async () => {
+      vi.mocked(prisma.interaction.findUnique).mockResolvedValue(mockInteraction);
+
+      const result = await postRepository.findInteraction('post-id-1', 'user-id-1', 'GG');
+
+      expect(result).toEqual(mockInteraction);
+      expect(prisma.interaction.findUnique).toHaveBeenCalledWith({
+        where: {
+          postId_userId_type: {
+            postId: 'post-id-1',
+            userId: 'user-id-1',
+            type:   'GG',
+          },
+        },
+      });
+    });
+  });
+
   // ── createComment ──────────────────────────────────────────
   describe('createComment', () => {
     it('cria comentário corretamente', async () => {

--- a/backend/tests/unit/repositories/presence.repository.test.ts
+++ b/backend/tests/unit/repositories/presence.repository.test.ts
@@ -15,6 +15,8 @@ vi.mock('@/infra/cache/redis', () => ({
   },
   REDIS_KEYS: {
     presence:       (userId: string) => `presence:${userId}`,
+    presenceFeed:   (userId: string) => `realtime:presence:${userId}`,
+    notifications:  (userId: string) => `notifications:${userId}`,
     friendsList:    (userId: string) => `friends:${userId}`,
     presenceUpdate: 'presence:updates',
   },
@@ -64,7 +66,6 @@ describe('presenceRepository', () => {
   describe('set', () => {
     it('salva no Redis com TTL correto', async () => {
       vi.mocked(redis.setex).mockResolvedValue('OK');
-      vi.mocked(redis.publish).mockResolvedValue(1);
       vi.mocked(prisma.userPresence.upsert).mockResolvedValue(mockDbPresence);
 
       await presenceRepository.set('user-id-1', { status: 'ONLINE' });
@@ -78,7 +79,6 @@ describe('presenceRepository', () => {
 
     it('atualiza Postgres via upsert', async () => {
       vi.mocked(redis.setex).mockResolvedValue('OK');
-      vi.mocked(redis.publish).mockResolvedValue(1);
       vi.mocked(prisma.userPresence.upsert).mockResolvedValue(mockDbPresence);
 
       await presenceRepository.set('user-id-1', { status: 'IN_GAME', currentGame: 'Valorant' });
@@ -91,18 +91,6 @@ describe('presenceRepository', () => {
       );
     });
 
-    it('publica no canal Redis Pub/Sub', async () => {
-      vi.mocked(redis.setex).mockResolvedValue('OK');
-      vi.mocked(redis.publish).mockResolvedValue(1);
-      vi.mocked(prisma.userPresence.upsert).mockResolvedValue(mockDbPresence);
-
-      await presenceRepository.set('user-id-1', { status: 'ONLINE' });
-
-      expect(redis.publish).toHaveBeenCalledWith(
-        'presence:updates',
-        expect.any(String),
-      );
-    });
   });
 
   // ── get ────────────────────────────────────────────────────
@@ -142,7 +130,6 @@ describe('presenceRepository', () => {
   describe('setOffline', () => {
     it('remove chave do Redis', async () => {
       vi.mocked(redis.del).mockResolvedValue(1);
-      vi.mocked(redis.publish).mockResolvedValue(1);
       vi.mocked(prisma.userPresence.upsert).mockResolvedValue(mockDbPresence);
 
       await presenceRepository.setOffline('user-id-1');
@@ -152,7 +139,6 @@ describe('presenceRepository', () => {
 
     it('atualiza status para OFFLINE no Postgres', async () => {
       vi.mocked(redis.del).mockResolvedValue(1);
-      vi.mocked(redis.publish).mockResolvedValue(1);
       vi.mocked(prisma.userPresence.upsert).mockResolvedValue(mockDbPresence);
 
       await presenceRepository.setOffline('user-id-1');
@@ -187,6 +173,35 @@ describe('presenceRepository', () => {
       expect(result).toHaveLength(2);
       expect(result[0]?.status).toBe('ONLINE');
       expect(result[1]?.status).toBe('OFFLINE');
+    });
+  });
+
+  describe('publishScopedUpdate', () => {
+    it('publica apenas para destinatários autorizados e exclui o próprio usuário', async () => {
+      vi.mocked(redis.publish).mockResolvedValue(1);
+
+      await presenceRepository.publishScopedUpdate(mockPresenceData, [
+        'friend-id-1',
+        'user-id-1',
+        'friend-id-1',
+        'friend-id-2',
+      ]);
+
+      expect(redis.publish).toHaveBeenCalledTimes(2);
+      expect(redis.publish).toHaveBeenCalledWith(
+        'realtime:presence:friend-id-1',
+        expect.any(String),
+      );
+      expect(redis.publish).toHaveBeenCalledWith(
+        'realtime:presence:friend-id-2',
+        expect.any(String),
+      );
+    });
+
+    it('não publica quando não há destinatários autorizados', async () => {
+      await presenceRepository.publishScopedUpdate(mockPresenceData, ['user-id-1']);
+
+      expect(redis.publish).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/tests/unit/services/notification.service.test.ts
+++ b/backend/tests/unit/services/notification.service.test.ts
@@ -27,6 +27,8 @@ vi.mock('@/infra/cache/redis', () => ({
   },
   REDIS_KEYS: {
     presence:       (id: string) => `presence:${id}`,
+    presenceFeed:   (id: string) => `realtime:presence:${id}`,
+    notifications:  (id: string) => `notifications:${id}`,
     presenceUpdate: 'presence:updates',
   },
   REDIS_TTL: { presence: 300 },


### PR DESCRIPTION
## Summary
- publish presence updates only to authorized friend recipients instead of using a global broadcast
- subscribe the Go presence service to per-user presence and notification channels so realtime delivery stays scoped to the connected user
- wire realtime notifications to friend request, friend accepted, post like and post comment domain events with regression coverage

## Testing
- npm.cmd --prefix backend run test -- tests/integration/routes/presence.routes.test.ts tests/integration/routes/friends.routes.test.ts tests/integration/routes/posts.routes.test.ts tests/integration/routes/notifications.routes.test.ts tests/unit/repositories/presence.repository.test.ts tests/unit/services/notification.service.test.ts
- npm.cmd --prefix backend run typecheck
- npm.cmd --prefix backend run lint
- go test ./...

Closes #107