### PR TITLE
fix(posts): enforce comment parent validation and delete stats

### DIFF
--- a/backend/src/api/routes/posts.routes.ts
+++ b/backend/src/api/routes/posts.routes.ts
@@ -102,6 +102,17 @@ export async function postRoutes(app: FastifyInstance): Promise<void> {
       const post = await postRepository.findById(result.data.postId);
       if (!post) return reply.status(404).send({ message: 'Post não encontrado.' });
 
+      if (result.data.parentId) {
+        const parentComment = await postRepository.findCommentById(result.data.parentId);
+        if (!parentComment || parentComment.postId !== post.id) {
+          return reply.status(400).send({ message: 'Comentário pai inválido para este post.' });
+        }
+
+        if (parentComment.parentId) {
+          return reply.status(400).send({ message: 'Apenas um nível de resposta é permitido.' });
+        }
+      }
+
       const comment = await postRepository.createComment(
         result.data.postId, request.userId, result.data.content, result.data.parentId,
       );

--- a/backend/src/core/repositories/post.repository.ts
+++ b/backend/src/core/repositories/post.repository.ts
@@ -83,10 +83,13 @@ export const postRepository = {
   },
 
   async deleteById(id: string): Promise<void> {
-    await prisma.post.delete({ where: { id } });
+    const deletedPost = await prisma.post.delete({
+      where:  { id },
+      select: { userId: true },
+    });
 
     await prisma.userStats.updateMany({
-      where: { userId: (await prisma.post.findUnique({ where: { id } }))?.userId ?? '' },
+      where: { userId: deletedPost.userId },
       data:  { postCount: { decrement: 1 } },
     });
   },
@@ -200,6 +203,10 @@ export const postRepository = {
     return prisma.comment.create({
       data: { postId, userId, content, parentId: parentId ?? null },
     });
+  },
+
+  async findCommentById(id: string): Promise<Comment | null> {
+    return prisma.comment.findUnique({ where: { id } });
   },
 
   async findCommentsByPostId(postId: string): Promise<CommentWithAuthor[]> {

--- a/backend/tests/integration/routes/posts.routes.test.ts
+++ b/backend/tests/integration/routes/posts.routes.test.ts
@@ -3,9 +3,14 @@ import { buildApp, generateTestToken } from '../../helpers/build-app';
 
 vi.mock('@/core/repositories/post.repository', () => ({
   postRepository: {
-    create: vi.fn(), findById: vi.fn(), deleteById: vi.fn(),
-    findFeedByUserId: vi.fn(), toggleInteraction: vi.fn(),
-    createComment: vi.fn(), findCommentsByPostId: vi.fn(),
+    create: vi.fn(),
+    findById: vi.fn(),
+    deleteById: vi.fn(),
+    findFeedByUserId: vi.fn(),
+    toggleInteraction: vi.fn(),
+    createComment: vi.fn(),
+    findCommentsByPostId: vi.fn(),
+    findCommentById: vi.fn(),
   },
 }));
 
@@ -103,7 +108,7 @@ describe('Posts Routes', () => {
       await app.close();
     });
 
-    it('retorna 400 sem conteúdo', async () => {
+    it('retorna 400 sem conteudo', async () => {
       vi.mocked(presenceRepository.get).mockResolvedValue(mockPresenceOffline);
 
       const app   = await buildApp();
@@ -141,7 +146,7 @@ describe('Posts Routes', () => {
       await app.close();
     });
 
-    it('retorna 404 quando usuário não existe', async () => {
+    it('retorna 404 quando usuario nao existe', async () => {
       vi.mocked(userRepository.findById).mockResolvedValue(null);
 
       const app      = await buildApp();
@@ -171,7 +176,7 @@ describe('Posts Routes', () => {
       await app.close();
     });
 
-    it('retorna 400 ao reagir ao próprio post', async () => {
+    it('retorna 400 ao reagir ao proprio post', async () => {
       vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
 
       const app   = await buildApp();
@@ -207,11 +212,11 @@ describe('Posts Routes', () => {
   });
 
   describe('POST /posts/comments', () => {
-    it('retorna 201 com comentário criado', async () => {
+    it('retorna 201 com comentario criado', async () => {
       vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
       vi.mocked(postRepository.createComment).mockResolvedValue({
         id: 'c1', postId: 'post-id-1', userId: 'user-id-2',
-        parentId: null, content: 'Ótimo post!', createdAt: new Date(),
+        parentId: null, content: 'Otimo post!', createdAt: new Date(),
       });
 
       const app   = await buildApp();
@@ -221,16 +226,68 @@ describe('Posts Routes', () => {
         method:  'POST',
         url:     '/posts/comments',
         headers: { Authorization: `Bearer ${token}` },
-        payload: { postId: 'post-id-1', content: 'Ótimo post!' },
+        payload: { postId: 'post-id-1', content: 'Otimo post!' },
       });
 
       expect(response.statusCode).toBe(201);
       await app.close();
     });
+
+    it('retorna 400 quando parentId pertence a outro post', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
+      vi.mocked(postRepository.findCommentById).mockResolvedValue({
+        id: 'parent-1',
+        postId: 'other-post-id',
+        userId: 'user-id-3',
+        parentId: null,
+        content: 'Comentario pai',
+        createdAt: new Date(),
+      } as never);
+
+      const app   = await buildApp();
+      const token = generateTestToken(app, 'user-id-2');
+
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts/comments',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { postId: 'post-id-1', content: 'Resposta invalida', parentId: 'parent-1' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(postRepository.createComment).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 400 quando parentId ja e reply aninhado', async () => {
+      vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
+      vi.mocked(postRepository.findCommentById).mockResolvedValue({
+        id: 'reply-1',
+        postId: 'post-id-1',
+        userId: 'user-id-3',
+        parentId: 'parent-1',
+        content: 'Reply existente',
+        createdAt: new Date(),
+      } as never);
+
+      const app   = await buildApp();
+      const token = generateTestToken(app, 'user-id-2');
+
+      const response = await app.inject({
+        method:  'POST',
+        url:     '/posts/comments',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { postId: 'post-id-1', content: 'Resposta invalida', parentId: 'reply-1' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(postRepository.createComment).not.toHaveBeenCalled();
+      await app.close();
+    });
   });
 
   describe('DELETE /posts/:id', () => {
-    it('retorna 200 deletando post do próprio usuário', async () => {
+    it('retorna 200 deletando post do proprio usuario', async () => {
       vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
       vi.mocked(postRepository.deleteById).mockResolvedValue(undefined);
 
@@ -247,7 +304,7 @@ describe('Posts Routes', () => {
       await app.close();
     });
 
-    it('retorna 403 deletando post de outro usuário', async () => {
+    it('retorna 403 deletando post de outro usuario', async () => {
       vi.mocked(postRepository.findById).mockResolvedValue(mockPost);
 
       const app   = await buildApp();

--- a/backend/tests/unit/repositories/post.repository.test.ts
+++ b/backend/tests/unit/repositories/post.repository.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/infra/database/client', () => ({
     },
     comment: {
       create:   vi.fn(),
+      findUnique: vi.fn(),
       findMany: vi.fn(),
     },
     friendship: {
@@ -118,6 +119,24 @@ describe('postRepository', () => {
     });
   });
 
+  describe('deleteById', () => {
+    it('deleta post e decrementa postCount do autor correto', async () => {
+      vi.mocked(prisma.post.delete).mockResolvedValue({ userId: 'user-id-1' } as never);
+      vi.mocked(prisma.userStats.updateMany).mockResolvedValue({ count: 1 });
+
+      await postRepository.deleteById('post-id-1');
+
+      expect(prisma.post.delete).toHaveBeenCalledWith({
+        where:  { id: 'post-id-1' },
+        select: { userId: true },
+      });
+      expect(prisma.userStats.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-id-1' },
+        data:  { postCount: { decrement: 1 } },
+      });
+    });
+  });
+
   // ── findFeedByUserId ───────────────────────────────────────
   describe('findFeedByUserId', () => {
     it('retorna feed com posts do usuário e amigos', async () => {
@@ -203,6 +222,19 @@ describe('postRepository', () => {
           content:  'Comentário de teste',
           parentId: null,
         },
+      });
+    });
+  });
+
+  describe('findCommentById', () => {
+    it('retorna comentario quando existe', async () => {
+      vi.mocked(prisma.comment.findUnique).mockResolvedValue(mockComment);
+
+      const result = await postRepository.findCommentById('comment-id-1');
+
+      expect(result).toEqual(mockComment);
+      expect(prisma.comment.findUnique).toHaveBeenCalledWith({
+        where: { id: 'comment-id-1' },
       });
     });
   });


### PR DESCRIPTION
## Summary
- fix post deletion to decrement postCount using the deleted post owner instead of querying a missing row
- reject invalid comment parentId values when the parent belongs to another post or exceeds the supported reply depth
- add regression coverage for repository consistency and route-level validation errors

## Testing
- npm.cmd --prefix backend run test -- tests/integration/routes/posts.routes.test.ts tests/unit/repositories/post.repository.test.ts
- npm.cmd --prefix backend run typecheck
- npm.cmd --prefix backend run lint

Closes #109