### PR TITLE
test(backend): add critical contract coverage for integrations

### DIFF
--- a/backend/tests/integration/routes/integrations.routes.test.ts
+++ b/backend/tests/integration/routes/integrations.routes.test.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildApp, generateTestToken } from '../../helpers/build-app';
+
+vi.mock('@/core/repositories/user.repository', () => ({
+  userRepository: {
+    findById: vi.fn(),
+    findByEmail: vi.fn(),
+    findByUsername: vi.fn(),
+    existsByEmailOrUsername: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/profile.repository', () => ({
+  profileRepository: {
+    findFullProfileByUsername: vi.fn(),
+    updateByUserId: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/friend.repository', () => ({
+  friendRepository: {
+    createRequest: vi.fn(),
+    findRequestById: vi.fn(),
+    existsRequest: vi.fn(),
+    existsFriendship: vi.fn(),
+    acceptRequest: vi.fn(),
+    removeFriendship: vi.fn(),
+    findFriendsByUserId: vi.fn(),
+    findPendingRequests: vi.fn(),
+    findFriendIdsByUserId: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/presence.repository', () => ({
+  presenceRepository: {
+    set: vi.fn(),
+    get: vi.fn(),
+    setOffline: vi.fn(),
+    publishScopedUpdate: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/post.repository', () => ({
+  postRepository: {
+    create: vi.fn(),
+    findById: vi.fn(),
+    deleteById: vi.fn(),
+    findFeedByUserId: vi.fn(),
+    toggleInteraction: vi.fn(),
+    createComment: vi.fn(),
+    findCommentsByPostId: vi.fn(),
+    findCommentById: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/notification.repository', () => ({
+  notificationRepository: {
+    findByUserId: vi.fn(),
+    findById: vi.fn(),
+    markAsRead: vi.fn(),
+    markAllAsRead: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/services/notification.service', () => ({
+  notificationService: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    platformIntegration: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+    userGameLibrary: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/infra/integrations/steam/steam.service', () => ({
+  steamService: {
+    validateSteamId: vi.fn(),
+    getOwnedGames: vi.fn(),
+  },
+}));
+
+vi.mock('@/infra/integrations/igdb/igdb.service', () => ({
+  igdbService: {
+    searchGame: vi.fn(),
+  },
+}));
+
+vi.mock('@/infra/integrations/epic/epic.service', () => ({
+  epicService: {
+    validateToken: vi.fn(),
+    getLibrary: vi.fn(),
+  },
+}));
+
+import { prisma } from '@/infra/database/client';
+import { epicService } from '@/infra/integrations/epic/epic.service';
+import { igdbService } from '@/infra/integrations/igdb/igdb.service';
+import { steamService } from '@/infra/integrations/steam/steam.service';
+
+const mockSteamGames = [
+  { appid: 730, name: 'Counter-Strike 2', playtime_forever: 6000, img_icon_url: '' },
+  { appid: 570, name: 'Dota 2', playtime_forever: 1200, img_icon_url: '' },
+];
+
+const mockEpicGames = [
+  { id: 'fortnite', title: 'Fortnite', namespace: 'fn', coverUrl: null },
+  { id: 'rocket-league', title: 'Rocket League', namespace: 'rl', coverUrl: 'https://cdn.clutch.gg/rocket.jpg' },
+];
+
+const mockSteamGame = mockSteamGames[0]!;
+
+describe('Integrations Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST /integrations/steam/connect', () => {
+    it('retorna 401 sem token', async () => {
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/steam/connect',
+        payload: { steamId: '76561198000000000' },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(vi.mocked(steamService.validateSteamId)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 400 com body invalido', async () => {
+      const app = await buildApp();
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/steam/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({ message: expect.any(String) });
+      expect(vi.mocked(prisma.platformIntegration.upsert)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 400 com SteamID invalido', async () => {
+      vi.mocked(steamService.validateSteamId).mockResolvedValue(false);
+
+      const app = await buildApp();
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/steam/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { steamId: 'private-profile' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(vi.mocked(prisma.platformIntegration.upsert)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 200 e importa jogos da Steam', async () => {
+      vi.mocked(steamService.validateSteamId).mockResolvedValue(true);
+      vi.mocked(steamService.getOwnedGames).mockResolvedValue(mockSteamGames);
+      vi.mocked(igdbService.searchGame)
+        .mockResolvedValueOnce({ id: 730, name: 'Counter-Strike 2', coverUrl: 'https://images.ct2.jpg', platforms: ['PC'], summary: null })
+        .mockResolvedValueOnce(null);
+      vi.mocked(prisma.platformIntegration.upsert).mockResolvedValue({ id: 'integration-id-1' } as never);
+      vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({ id: 'library-id-1' } as never);
+
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/steam/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { steamId: '76561198000000000' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        imported: 2,
+        message: 'Steam conectado. 2 jogos importados.',
+      });
+      expect(vi.mocked(prisma.platformIntegration.upsert)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(prisma.userGameLibrary.upsert)).toHaveBeenCalledTimes(2);
+      await app.close();
+    });
+  });
+
+  describe('POST /integrations/steam/sync', () => {
+    it('retorna 404 quando Steam nao esta conectada', async () => {
+      vi.mocked(prisma.platformIntegration.findUnique).mockResolvedValue(null);
+
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/steam/sync',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(vi.mocked(steamService.getOwnedGames)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 200 e sincroniza biblioteca existente', async () => {
+      vi.mocked(prisma.platformIntegration.findUnique).mockResolvedValue({
+        userId: 'user-id-1',
+        platform: 'STEAM',
+        externalId: '76561198000000000',
+      } as never);
+      vi.mocked(steamService.getOwnedGames).mockResolvedValue([mockSteamGame]);
+      vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({ id: 'library-id-1' } as never);
+
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/steam/sync',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        synced: 1,
+        message: '1 jogos sincronizados.',
+      });
+      expect(vi.mocked(steamService.getOwnedGames)).toHaveBeenCalledWith('76561198000000000');
+      expect(vi.mocked(prisma.userGameLibrary.upsert)).toHaveBeenCalledTimes(1);
+      await app.close();
+    });
+  });
+
+  describe('GET /integrations/igdb/search', () => {
+    it('retorna 400 com query curta', async () => {
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/igdb/search?q=a',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(vi.mocked(igdbService.searchGame)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 404 quando jogo nao e encontrado', async () => {
+      vi.mocked(igdbService.searchGame).mockResolvedValue(null);
+
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/igdb/search?q=unknown-game',
+      });
+
+      expect(response.statusCode).toBe(404);
+      await app.close();
+    });
+
+    it('retorna 200 com metadados do jogo', async () => {
+      vi.mocked(igdbService.searchGame).mockResolvedValue({
+        id: 730,
+        name: 'Counter-Strike 2',
+        coverUrl: 'https://images.ct2.jpg',
+        platforms: ['PC'],
+        summary: 'Competitive FPS',
+      });
+
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/igdb/search?q=Counter-Strike 2',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        id: 730,
+        name: 'Counter-Strike 2',
+      });
+      await app.close();
+    });
+  });
+
+  describe('POST /integrations/epic/connect', () => {
+    it('retorna 400 com body invalido', async () => {
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/epic/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(vi.mocked(epicService.validateToken)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 400 com token Epic invalido', async () => {
+      vi.mocked(epicService.validateToken).mockResolvedValue(false);
+
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/epic/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { authToken: 'expired-token' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(vi.mocked(epicService.getLibrary)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 503 quando o adapter Epic falha', async () => {
+      vi.mocked(epicService.validateToken).mockResolvedValue(true);
+      vi.mocked(epicService.getLibrary).mockRejectedValue(new Error('Python service offline'));
+
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/epic/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { authToken: 'valid-token' },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(vi.mocked(prisma.platformIntegration.upsert)).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 200 e importa jogos da Epic', async () => {
+      vi.mocked(epicService.validateToken).mockResolvedValue(true);
+      vi.mocked(epicService.getLibrary).mockResolvedValue(mockEpicGames);
+      vi.mocked(prisma.platformIntegration.upsert).mockResolvedValue({ id: 'integration-id-1' } as never);
+      vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({ id: 'library-id-1' } as never);
+
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/epic/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { authToken: 'valid-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        imported: 2,
+        message: 'Epic conectado. 2 jogos importados.',
+      });
+      expect(vi.mocked(prisma.platformIntegration.upsert)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(prisma.userGameLibrary.upsert)).toHaveBeenCalledTimes(2);
+      await app.close();
+    });
+  });
+});

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -1,29 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-// ─────────────────────────────────────────────────────────────
-// Mock axios e Redis antes de importar os services
-// ─────────────────────────────────────────────────────────────
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('axios');
 vi.mock('@/infra/cache/redis', () => ({
   redis: {
-    get:    vi.fn(),
-    setex:  vi.fn(),
+    get: vi.fn(),
+    setex: vi.fn(),
   },
 }));
 
-import axios         from 'axios';
-import { redis }     from '@/infra/cache/redis';
-import { igdbService }  from '@/infra/integrations/igdb/igdb.service';
+import axios from 'axios';
+import { redis } from '@/infra/cache/redis';
+import { epicService } from '@/infra/integrations/epic/epic.service';
+import { igdbService } from '@/infra/integrations/igdb/igdb.service';
 import { steamService } from '@/infra/integrations/steam/steam.service';
-import { epicService }  from '@/infra/integrations/epic/epic.service';
-
-// ─────────────────────────────────────────────────────────────
-// IGDB Service
-// ─────────────────────────────────────────────────────────────
 
 describe('igdbService', () => {
-
   beforeEach(() => vi.clearAllMocks());
 
   describe('searchGame', () => {
@@ -37,7 +28,7 @@ describe('igdbService', () => {
         })
         .mockResolvedValueOnce({
           data: [{
-            id:   1234,
+            id: 1234,
             name: 'Valorant',
             cover: { id: 1, url: '//images.igdb.com/igdb/image/upload/t_thumb/test.jpg' },
             platforms: [{ name: 'PC (Microsoft Windows)' }],
@@ -52,7 +43,7 @@ describe('igdbService', () => {
       expect(result?.coverUrl).toContain('t_cover_big');
     });
 
-    it('usa token do cache Redis quando disponível', async () => {
+    it('usa token do cache Redis quando disponivel', async () => {
       vi.mocked(redis.get).mockResolvedValue('cached-token');
       vi.mocked(axios.post).mockResolvedValueOnce({
         data: [{ id: 1, name: 'CS2', platforms: [], summary: null }],
@@ -63,7 +54,7 @@ describe('igdbService', () => {
       expect(axios.post).toHaveBeenCalledTimes(1);
     });
 
-    it('retorna null quando jogo não encontrado', async () => {
+    it('retorna null quando jogo nao encontrado', async () => {
       vi.mocked(redis.get).mockResolvedValue('cached-token');
       vi.mocked(axios.post).mockResolvedValueOnce({ data: [] });
 
@@ -71,27 +62,73 @@ describe('igdbService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('envia headers esperados para a busca no IGDB', async () => {
+      vi.mocked(redis.get).mockResolvedValue('cached-token');
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: [{ id: 1, name: 'Hades', platforms: [], summary: null }],
+      });
+
+      await igdbService.searchGame('Hades');
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://api.igdb.com/v4/games',
+        'search "Hades"; fields name,cover.url,platforms.name,summary; limit 1;',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer cached-token',
+            'Content-Type': 'text/plain',
+          }),
+        }),
+      );
+    });
   });
 
+  describe('getGameById', () => {
+    it('retorna jogo quando o id existe', async () => {
+      vi.mocked(redis.get).mockResolvedValue('cached-token');
+      vi.mocked(axios.post).mockResolvedValueOnce({
+        data: [{
+          id: 5678,
+          name: 'Helldivers 2',
+          cover: { id: 2, url: '//images.igdb.com/igdb/image/upload/t_thumb/helldivers.jpg' },
+          platforms: [{ name: 'PC (Microsoft Windows)' }],
+          summary: 'Co-op extraction shooter',
+        }],
+      });
+
+      const result = await igdbService.getGameById(5678);
+
+      expect(result).toMatchObject({
+        id: 5678,
+        name: 'Helldivers 2',
+      });
+      expect(result?.coverUrl).toContain('t_cover_big');
+    });
+
+    it('retorna null quando o id nao existe', async () => {
+      vi.mocked(redis.get).mockResolvedValue('cached-token');
+      vi.mocked(axios.post).mockResolvedValueOnce({ data: [] });
+
+      const result = await igdbService.getGameById(999999);
+
+      expect(result).toBeNull();
+    });
+  });
 });
 
-// ─────────────────────────────────────────────────────────────
-// Steam Service
-// ─────────────────────────────────────────────────────────────
-
 describe('steamService', () => {
-
   beforeEach(() => vi.clearAllMocks());
 
   describe('getOwnedGames', () => {
-    it('retorna biblioteca quando SteamID é válido', async () => {
+    it('retorna biblioteca quando SteamID e valido', async () => {
       vi.mocked(axios.get).mockResolvedValue({
         data: {
           response: {
             game_count: 2,
             games: [
-              { appid: 730,  name: 'Counter-Strike 2',    playtime_forever: 6000, img_icon_url: '' },
-              { appid: 570,  name: 'Dota 2',              playtime_forever: 1200, img_icon_url: '' },
+              { appid: 730, name: 'Counter-Strike 2', playtime_forever: 6000, img_icon_url: '' },
+              { appid: 570, name: 'Dota 2', playtime_forever: 1200, img_icon_url: '' },
             ],
           },
         },
@@ -101,9 +138,20 @@ describe('steamService', () => {
 
       expect(games).toHaveLength(2);
       expect(games[0]?.name).toBe('Counter-Strike 2');
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/',
+        expect.objectContaining({
+          timeout: 10_000,
+          params: expect.objectContaining({
+            steamid: '76561198000000000',
+            include_appinfo: true,
+            include_played_free_games: true,
+          }),
+        }),
+      );
     });
 
-    it('retorna array vazio quando perfil não tem jogos', async () => {
+    it('retorna array vazio quando perfil nao tem jogos', async () => {
       vi.mocked(axios.get).mockResolvedValue({
         data: { response: { game_count: 0 } },
       });
@@ -115,7 +163,7 @@ describe('steamService', () => {
   });
 
   describe('validateSteamId', () => {
-    it('retorna true quando SteamID é válido', async () => {
+    it('retorna true quando SteamID e valido', async () => {
       vi.mocked(axios.get).mockResolvedValue({
         data: {
           response: {
@@ -129,7 +177,7 @@ describe('steamService', () => {
       expect(result).toBe(true);
     });
 
-    it('retorna false quando SteamID é inválido', async () => {
+    it('retorna false quando SteamID e invalido', async () => {
       vi.mocked(axios.get).mockResolvedValue({
         data: { response: { players: [] } },
       });
@@ -139,15 +187,9 @@ describe('steamService', () => {
       expect(result).toBe(false);
     });
   });
-
 });
 
-// ─────────────────────────────────────────────────────────────
-// Epic Service
-// ─────────────────────────────────────────────────────────────
-
 describe('epicService', () => {
-
   beforeEach(() => vi.clearAllMocks());
 
   describe('getLibrary', () => {
@@ -156,7 +198,7 @@ describe('epicService', () => {
         data: {
           games: [
             { id: 'fortnite', title: 'Fortnite', namespace: 'fn', coverUrl: null },
-            { id: 'rocket',   title: 'Rocket League', namespace: 'rl', coverUrl: null },
+            { id: 'rocket', title: 'Rocket League', namespace: 'rl', coverUrl: null },
           ],
         },
       });
@@ -165,19 +207,33 @@ describe('epicService', () => {
 
       expect(games).toHaveLength(2);
       expect(games[0]?.title).toBe('Fortnite');
+      expect(axios.get).toHaveBeenCalledWith(
+        'http://localhost:8000/library',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer valid-token' },
+          timeout: 30_000,
+        }),
+      );
     });
   });
 
   describe('validateToken', () => {
-    it('retorna true quando token é válido', async () => {
+    it('retorna true quando token e valido', async () => {
       vi.mocked(axios.get).mockResolvedValue({ data: { valid: true } });
 
       const result = await epicService.validateToken('valid-token');
 
       expect(result).toBe(true);
+      expect(axios.get).toHaveBeenCalledWith(
+        'http://localhost:8000/validate',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer valid-token' },
+          timeout: 5_000,
+        }),
+      );
     });
 
-    it('retorna false quando token é inválido', async () => {
+    it('retorna false quando token e invalido', async () => {
       vi.mocked(axios.get).mockRejectedValue(new Error('Unauthorized'));
 
       const result = await epicService.validateToken('invalid-token');
@@ -185,5 +241,4 @@ describe('epicService', () => {
       expect(result).toBe(false);
     });
   });
-
 });


### PR DESCRIPTION
## Summary
- add integration contract tests for the hardened integrations routes
- extend adapter tests to cover IGDB lookup and timeout/header expectations
- validate the branch with typecheck, lint and coverage before review

## Testing
- npm.cmd --prefix backend run test -- tests/integration/routes/integrations.routes.test.ts tests/unit/services/integrations.service.test.ts
- npm.cmd --prefix backend run typecheck
- npm.cmd --prefix backend run lint
- npm.cmd --prefix backend run test:coverage

Closes #110