### PR TITLE
feat(auth): add login page with backend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ npm run build
 
 Esta etapa entrega apenas a base do app: Next.js 15, TypeScript strict, Tailwind v3, aliases, shell inicial e setup de testes.
 
+### Login local
+Depois da foundation e da issue `#87`, o login do frontend fica em:
+
+```txt
+http://localhost:3000/login
+```
+
+Use a conta demo seeded no backend:
+
+```txt
+Email: clutchplayer@clutch.gg
+Senha: clutch123
+```
+
 ---
 
 ## 🧪 Testes

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { LoginForm } from '@/components/auth/login-form';
+
+export default function LoginPage() {
+  return (
+    <section className="grid w-full gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+      <Card tone="accent" className="p-card shadow-glow">
+        <div className="flex h-full flex-col justify-between gap-section">
+          <div className="space-y-4">
+            <Badge tone="accent">CLUTCH auth</Badge>
+            <SectionHeading
+              level="h2"
+              eyebrow="Identity shell"
+              title="Acesse o currículo vivo do CLUTCH."
+              description="A tela de login já conversa com o contrato real do backend e prepara a base para a proteção de rotas que vem na próxima issue."
+            />
+          </div>
+
+          <div className="space-y-4 text-sm leading-6 text-secondary">
+            <p>
+              O fluxo usa a conta demo seeded localmente para facilitar validação sem
+              dependências externas.
+            </p>
+            <p>
+              Se você quiser revisar a página pública, volte para{' '}
+              <Link
+                href="/"
+                className="font-medium text-accent-cyan underline-offset-4 transition hover:text-primary hover:underline"
+              >
+                a entrada pública
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <LoginForm />
+    </section>
+  );
+}

--- a/frontend/src/app/(auth)/page.tsx
+++ b/frontend/src/app/(auth)/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { SectionHeading } from '@/components/ui/section-heading';
@@ -6,7 +7,7 @@ export default function AuthLandingPage() {
   return (
     <section className="grid w-full gap-4 lg:grid-cols-[1.15fr_0.85fr]">
       <Card tone="accent" className="p-card shadow-glow">
-        <div className="flex flex-col gap-section">
+        <div className="flex h-full flex-col justify-between gap-section">
           <Badge tone="accent">CLUTCH</Badge>
           <SectionHeading
             level="h1"
@@ -14,6 +15,18 @@ export default function AuthLandingPage() {
             title="The shell is ready for the authenticated product."
             description="The public entry stays light while the authenticated area gets its own navbar and sidebar shell for the next frontend issues."
           />
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              href="/login"
+              className="inline-flex h-11 items-center justify-center rounded-control border border-transparent bg-accent-purple px-control-x text-sm font-medium text-white transition hover:brightness-110"
+            >
+              Open login
+            </Link>
+            <span className="inline-flex h-11 items-center justify-center rounded-control border border-border bg-[rgba(26,26,39,0.88)] px-control-x text-sm font-medium text-secondary">
+              Demo ready
+            </span>
+          </div>
         </div>
       </Card>
 

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import { loginBackendResponseSchema, loginRequestSchema } from '@/schemas/auth';
+import { AUTH_SESSION_COOKIE_NAME, getAuthSessionCookieOptions } from '@/lib/auth/session';
+import { buildApiUrl } from '@/services/http/client';
+
+type ErrorBody = {
+  message?: string;
+};
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorBody).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function POST(request: Request) {
+  let parsedBody: unknown;
+
+  try {
+    parsedBody = await request.json();
+  } catch {
+    return NextResponse.json(
+      { message: 'Requisição de login inválida.' },
+      { status: 400 },
+    );
+  }
+
+  const credentialsResult = loginRequestSchema.safeParse(parsedBody);
+
+  if (!credentialsResult.success) {
+    return NextResponse.json(
+      { message: 'Email e senha são obrigatórios.' },
+      { status: 400 },
+    );
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(buildApiUrl('/auth/login'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(credentialsResult.data),
+    });
+  } catch {
+    return NextResponse.json(
+      { message: 'Não foi possível contatar o backend de autenticação.' },
+      { status: 502 },
+    );
+  }
+
+  const payload = await readJsonBody(backendResponse);
+
+  if (!backendResponse.ok) {
+    return NextResponse.json(
+      {
+        message: resolveMessage(
+          payload,
+          backendResponse.status === 401
+            ? 'Credenciais inválidas.'
+            : 'Falha ao autenticar.',
+        ),
+      },
+      { status: backendResponse.status },
+    );
+  }
+
+  const sessionResult = loginBackendResponseSchema.safeParse(payload);
+
+  if (!sessionResult.success) {
+    return NextResponse.json(
+      { message: 'Resposta inválida do backend de autenticação.' },
+      { status: 502 },
+    );
+  }
+
+  const response = NextResponse.json(
+    {
+      id: sessionResult.data.id,
+      username: sessionResult.data.username,
+      message: sessionResult.data.message,
+    },
+    { status: 200 },
+  );
+
+  response.cookies.set(
+    AUTH_SESSION_COOKIE_NAME,
+    sessionResult.data.token,
+    getAuthSessionCookieOptions(),
+  );
+
+  return response;
+}

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { loginRequestSchema, type LoginRequestValues } from '@/schemas/auth';
+import { AuthRequestError, login } from '@/services/auth';
+
+const demoCredentials: LoginRequestValues = {
+  email: 'clutchplayer@clutch.gg',
+  password: 'clutch123',
+};
+
+const fieldClassName = 'space-y-2';
+
+export function LoginForm() {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginRequestValues>({
+    resolver: zodResolver(loginRequestSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    mode: 'onTouched',
+  });
+
+  const handleDemoFill = () => {
+    setServerError(null);
+    setValue('email', demoCredentials.email, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+    setValue('password', demoCredentials.password, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  };
+
+  const onSubmit = handleSubmit(async (values) => {
+    setServerError(null);
+
+    try {
+      await login(values);
+      router.replace('/feed');
+      router.refresh();
+    } catch (error) {
+      if (error instanceof AuthRequestError) {
+        setServerError(error.message);
+        return;
+      }
+
+      setServerError('Não foi possível entrar agora. Tente novamente.');
+    }
+  });
+
+  return (
+    <Card className="p-card shadow-glow">
+      <form className="space-y-section" onSubmit={onSubmit} noValidate>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-3">
+            <Badge tone="accent">Acesso autenticado</Badge>
+            <SectionHeading
+              level="h1"
+              eyebrow="CLUTCH login"
+              title="Entre com sua conta do CLUTCH."
+              description="Use a conta demo seeded no backend ou a sua credencial real para acessar a área autenticada."
+            />
+          </div>
+
+          <Button type="button" variant="secondary" size="sm" onClick={handleDemoFill}>
+            Usar demo local
+          </Button>
+        </div>
+
+        {serverError ? (
+          <div
+            role="alert"
+            className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm leading-6 text-primary"
+          >
+            {serverError}
+          </div>
+        ) : null}
+
+        <div className="space-y-4">
+          <label className={fieldClassName}>
+            <span className="text-sm font-medium text-primary">Email</span>
+            <Input
+              type="email"
+              autoComplete="email"
+              placeholder="seu-email@clutch.gg"
+              aria-invalid={Boolean(errors.email)}
+              aria-describedby={errors.email ? 'login-email-error' : undefined}
+              {...register('email')}
+            />
+            {errors.email ? (
+              <span id="login-email-error" className="text-sm text-status-afk">
+                {errors.email.message}
+              </span>
+            ) : null}
+          </label>
+
+          <label className={fieldClassName}>
+            <span className="text-sm font-medium text-primary">Senha</span>
+            <Input
+              type="password"
+              autoComplete="current-password"
+              placeholder="Sua senha"
+              aria-invalid={Boolean(errors.password)}
+              aria-describedby={errors.password ? 'login-password-error' : undefined}
+              {...register('password')}
+            />
+            {errors.password ? (
+              <span id="login-password-error" className="text-sm text-status-afk">
+                {errors.password.message}
+              </span>
+            ) : null}
+          </label>
+        </div>
+
+        <div className="space-y-4">
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? 'Entrando...' : 'Entrar'}
+          </Button>
+
+          <p className="text-center text-sm text-secondary">
+            Ainda não tem conta?{' '}
+            <Link
+              href="/register"
+              className="font-medium text-accent-cyan underline-offset-4 transition hover:text-primary hover:underline"
+            >
+              Criar conta
+            </Link>
+          </p>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -1,0 +1,13 @@
+export const AUTH_SESSION_COOKIE_NAME = 'clutch_session';
+
+export const AUTH_SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
+
+export function getAuthSessionCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: AUTH_SESSION_MAX_AGE_SECONDS,
+  };
+}

--- a/frontend/src/schemas/auth.ts
+++ b/frontend/src/schemas/auth.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const loginRequestSchema = z.object({
+  email: z.string().trim().email('Digite um email válido.'),
+  password: z
+    .string()
+    .min(6, 'A senha precisa ter pelo menos 6 caracteres.'),
+});
+
+export const loginBackendResponseSchema = z.object({
+  id: z.string().min(1),
+  username: z.string().min(1),
+  token: z.string().min(1),
+  message: z.string().min(1),
+});
+
+export const loginSessionSchema = loginBackendResponseSchema.pick({
+  id: true,
+  username: true,
+  message: true,
+});
+
+export type LoginRequestValues = z.infer<typeof loginRequestSchema>;
+export type LoginSession = z.infer<typeof loginSessionSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -1,1 +1,6 @@
 export {};
+export {
+  loginBackendResponseSchema,
+  loginRequestSchema,
+  loginSessionSchema,
+} from './auth';

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,69 @@
+import { loginRequestSchema, loginSessionSchema, type LoginRequestValues, type LoginSession } from '@/schemas/auth';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+export class AuthRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'AuthRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function login(input: LoginRequestValues): Promise<LoginSession> {
+  const credentials = loginRequestSchema.parse(input);
+
+  const response = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    const fallbackMessage =
+      response.status === 401
+        ? 'Credenciais inválidas.'
+        : 'Não foi possível autenticar agora.';
+
+    throw new AuthRequestError(
+      response.status,
+      resolveErrorMessage(payload, fallbackMessage),
+    );
+  }
+
+  return loginSessionSchema.parse(payload);
+}

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,1 +1,2 @@
 export { buildApiUrl } from './http/client';
+export { login, AuthRequestError } from './auth';

--- a/frontend/tests/unit/components/login-page.test.tsx
+++ b/frontend/tests/unit/components/login-page.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LoginPage from '@/app/(auth)/login/page';
+import { AuthRequestError, login as mockedLogin } from '@/services/auth';
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+const refreshMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock('@/services/auth', () => ({
+  login: vi.fn(),
+  AuthRequestError: class AuthRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'AuthRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedLoginFn = vi.mocked(mockedLogin);
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    refreshMock.mockReset();
+    mockedLoginFn.mockReset();
+  });
+
+  it('renders the login page shell', () => {
+    render(<LoginPage />);
+
+    expect(screen.getByRole('heading', { name: /acesse o currículo vivo do clutch/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /entre com sua conta do clutch/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /entrar/i })).toBeInTheDocument();
+  });
+
+  it('shows validation errors for empty fields', async () => {
+    render(<LoginPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    expect(await screen.findByText(/digite um email válido/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/a senha precisa ter pelo menos 6 caracteres/i),
+    ).toBeInTheDocument();
+    expect(mockedLoginFn).not.toHaveBeenCalled();
+  });
+
+  it('submits the form and navigates to the authenticated area', async () => {
+    mockedLoginFn.mockResolvedValue({
+      id: 'user-1',
+      username: 'clutchplayer',
+      message: 'Acesso autorizado.',
+    });
+
+    render(<LoginPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /usar demo local/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toHaveValue('clutchplayer@clutch.gg');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    await waitFor(() => {
+      expect(mockedLoginFn).toHaveBeenCalledWith({
+        email: 'clutchplayer@clutch.gg',
+        password: 'clutch123',
+      });
+    });
+
+    expect(replaceMock).toHaveBeenCalledWith('/feed');
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  it('renders backend credential errors', async () => {
+    mockedLoginFn.mockRejectedValue(
+      new AuthRequestError(401, 'Credenciais inválidas.'),
+    );
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'clutchplayer@clutch.gg' },
+    });
+    fireEvent.change(screen.getByLabelText(/senha/i), {
+      target: { value: 'wrong-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /credenciais inválidas/i,
+    );
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/routes/auth-login-route.test.ts
+++ b/frontend/tests/unit/routes/auth-login-route.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '@/app/api/auth/login/route';
+import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
+
+const originalEnv = process.env.NEXT_PUBLIC_API_URL;
+
+describe('auth login route', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sets an httpOnly cookie when login succeeds', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            id: 'user-1',
+            username: 'clutchplayer',
+            token: 'jwt-token',
+            message: 'Acesso autorizado.',
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        );
+      }) as typeof fetch,
+    );
+
+    const response = await POST(
+      new Request('http://localhost/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'clutchplayer@clutch.gg',
+          password: 'clutch123',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain(AUTH_SESSION_COOKIE_NAME);
+    expect(response.headers.get('set-cookie')).toContain('HttpOnly');
+    expect(response.headers.get('set-cookie')).toContain('jwt-token');
+  });
+
+  it('propagates invalid credentials without setting a session cookie', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ message: 'Credenciais inválidas.' }), {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      }) as typeof fetch,
+    );
+
+    const response = await POST(
+      new Request('http://localhost/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'clutchplayer@clutch.gg',
+          password: 'wrong-password',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('set-cookie')).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      message: 'Credenciais inválidas.',
+    });
+  });
+});
+
+afterAll(() => {
+  if (typeof originalEnv === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_API_URL = originalEnv;
+});


### PR DESCRIPTION
Closes #87

## Summary
- Adds the `/login` page with React Hook Form + Zod validation.
- Integrates the frontend with the backend auth contract through a local app route that stores the JWT in an httpOnly cookie.
- Adds loading, validation, invalid-credential, and unexpected-error states.
- Links the public auth entry to the login route and keeps the authenticated shell redirect target aligned with the next issue.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`