### PR TITLE
feat(auth): add session hydration and protected app routes

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { isProtectedPath, isPublicEntryPath } from '@/lib/auth/routes';
+import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const hasSession = Boolean(request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value);
+
+  if (hasSession && isPublicEntryPath(pathname)) {
+    return NextResponse.redirect(new URL('/feed', request.url));
+  }
+
+  if (!hasSession && isProtectedPath(pathname)) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/', '/login', '/register', '/feed/:path*', '/notifications/:path*', '/settings/:path*'],
+};

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+import { buildApiUrl } from '@/services/http/client';
+
+type RouteContext = {
+  params: Promise<{
+    path: string[];
+  }>;
+};
+
+async function proxyRequest(request: NextRequest, pathSegments: string[]) {
+  const backendUrl = new URL(buildApiUrl(`/${pathSegments.join('/')}`));
+  backendUrl.search = new URL(request.url).search;
+
+  const headers = new Headers(request.headers);
+  headers.delete('host');
+  headers.delete('cookie');
+
+  const sessionCookie = request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value;
+
+  if (sessionCookie) {
+    headers.set('Authorization', `Bearer ${sessionCookie}`);
+  }
+
+  const body =
+    request.method === 'GET' || request.method === 'HEAD'
+      ? undefined
+      : await request.text();
+
+  const backendResponse = await fetch(backendUrl, {
+    method: request.method,
+    headers,
+    body: body && body.length > 0 ? body : undefined,
+  });
+
+  const responseHeaders = new Headers(backendResponse.headers);
+  const responseBody = await backendResponse.text();
+  const response = new NextResponse(responseBody || null, {
+    status: backendResponse.status,
+    headers: responseHeaders,
+  });
+
+  if (backendResponse.status === 401) {
+    response.cookies.set(
+      AUTH_SESSION_COOKIE_NAME,
+      '',
+      getClearedAuthSessionCookieOptions(),
+    );
+  }
+
+  return response;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { path } = await context.params;
+  return proxyRequest(request, path);
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const { path } = await context.params;
+  return proxyRequest(request, path);
+}
+
+export async function PUT(request: NextRequest, context: RouteContext) {
+  const { path } = await context.params;
+  return proxyRequest(request, path);
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const { path } = await context.params;
+  return proxyRequest(request, path);
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const { path } = await context.params;
+  return proxyRequest(request, path);
+}

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+
+export async function POST(_request: NextRequest) {
+  const response = NextResponse.json({ message: 'Sessão encerrada.' }, { status: 200 });
+
+  response.cookies.set(
+    AUTH_SESSION_COOKIE_NAME,
+    '',
+    getClearedAuthSessionCookieOptions(),
+  );
+
+  return response;
+}

--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { authSessionSchema } from '@/schemas/auth';
+import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+import { buildApiUrl } from '@/services/http/client';
+
+export async function GET(request: NextRequest) {
+  const token = request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json({ message: 'Sessão inexistente.' }, { status: 401 });
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(buildApiUrl('/auth/me'), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { message: 'Não foi possível contatar o backend de autenticação.' },
+      { status: 502 },
+    );
+  }
+
+  const payload = await backendResponse.json().catch(() => null);
+
+  if (!backendResponse.ok) {
+    const response = NextResponse.json(
+      {
+        message:
+          backendResponse.status === 401
+            ? 'Token inválido ou expirado.'
+            : 'Falha ao restaurar a sessão.',
+      },
+      { status: backendResponse.status },
+    );
+
+    if (backendResponse.status === 401) {
+      response.cookies.set(
+        AUTH_SESSION_COOKIE_NAME,
+        '',
+        getClearedAuthSessionCookieOptions(),
+      );
+    }
+
+    return response;
+  }
+
+  const parsed = authSessionSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { message: 'Resposta inválida do backend de sessão.' },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json(parsed.data, { status: 200 });
+}

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useState, type ReactNode } from 'react';
+import { AuthProvider } from '@/components/auth/auth-provider';
 import { makeQueryClient } from '@/lib/query/make-query-client';
 
 type ProvidersProps = {
@@ -11,5 +12,9 @@ type ProvidersProps = {
 export function Providers({ children }: ProvidersProps) {
   const [queryClient] = useState(makeQueryClient);
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </AuthProvider>
+  );
 }

--- a/frontend/src/components/auth/auth-provider.tsx
+++ b/frontend/src/components/auth/auth-provider.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useRef, type ReactNode } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { isProtectedPath, isPublicEntryPath } from '@/lib/auth/routes';
+import { fetchAuthSession } from '@/services/session';
+import { useAuthStore } from '@/store/auth-store';
+
+type AuthProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const bootstrapped = useRef(false);
+  const status = useAuthStore((state) => state.status);
+  const clearSession = useAuthStore((state) => state.clearSession);
+  const setLoading = useAuthStore((state) => state.setLoading);
+  const setSession = useAuthStore((state) => state.setSession);
+
+  useEffect(() => {
+    let isActive = true;
+
+    if (bootstrapped.current) {
+      return undefined;
+    }
+
+    bootstrapped.current = true;
+    setLoading();
+
+    void (async () => {
+      const session = await fetchAuthSession();
+
+      if (!isActive) {
+        return;
+      }
+
+      if (session) {
+        setSession(session);
+        return;
+      }
+
+      clearSession();
+    })();
+
+    return () => {
+      isActive = false;
+    };
+  }, [clearSession, setLoading, setSession]);
+
+  useEffect(() => {
+    if (status === 'authenticated' && isPublicEntryPath(pathname)) {
+      router.replace('/feed');
+      router.refresh();
+      return;
+    }
+
+    if (status === 'unauthenticated' && isProtectedPath(pathname)) {
+      router.replace('/login');
+      router.refresh();
+    }
+  }, [pathname, router, status]);
+
+  return children;
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,9 +1,11 @@
 'use client';
+
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { cn } from '@/lib/utils/cn';
+import { useAuth } from '@/hooks/use-auth';
 
 type SidebarProps = {
   isOpen: boolean;
@@ -45,15 +47,6 @@ const sidebarItems: SidebarItem[] = [
   },
 ];
 
-const mockUser = {
-  username: 'clutchplayer',
-  displayName: 'CLUTCH Player',
-  status: 'ONLINE',
-  statusTone: 'success',
-  currentGame: 'Valorant',
-  platform: 'PC',
-} as const;
-
 function SidebarNavItem({ item }: { item: SidebarItem }) {
   return (
     <button
@@ -75,6 +68,23 @@ function SidebarNavItem({ item }: { item: SidebarItem }) {
 }
 
 export function Sidebar({ isOpen, onClose, className }: SidebarProps) {
+  const { user, status, logout } = useAuth();
+
+  const displayUser = user ?? {
+    id: 'demo-user',
+    username: 'clutchplayer',
+    email: 'clutchplayer@clutch.gg',
+  };
+
+  const sessionLabel =
+    status === 'authenticated'
+      ? 'Sessão ativa'
+      : status === 'loading'
+        ? 'Restaurando sessão'
+        : 'Sessão offline';
+
+  const logoutLabel = status === 'authenticated' ? 'Sair' : 'Aguardando sessão';
+
   return (
     <>
       <button
@@ -120,27 +130,47 @@ export function Sidebar({ isOpen, onClose, className }: SidebarProps) {
 
           <Card className="mt-auto" tone="neutral">
             <div className="flex items-start gap-4">
-              <Avatar alt="CLUTCH Player" fallback="CP" size="lg" />
+              <Avatar
+                alt={displayUser.username}
+                fallback={displayUser.username.slice(0, 2).toUpperCase()}
+                size="lg"
+              />
               <div className="min-w-0 flex-1">
                 <p className="text-xs uppercase tracking-[0.35em] text-secondary">
                   Connected user
                 </p>
                 <h3 className="mt-2 truncate font-display text-xl font-semibold text-primary">
-                  {mockUser.displayName}
+                  {displayUser.username}
                 </h3>
-                <p className="truncate text-sm text-secondary">@{mockUser.username}</p>
+                <p className="truncate text-sm text-secondary">{displayUser.email}</p>
               </div>
             </div>
 
             <div className="mt-5 flex flex-wrap items-center gap-2">
-              <Badge tone={mockUser.statusTone}>{mockUser.status}</Badge>
-              <Badge tone="neutral">{mockUser.platform}</Badge>
+              <Badge tone={status === 'authenticated' ? 'success' : 'neutral'}>
+                {sessionLabel}
+              </Badge>
+              <Badge tone="neutral">httpOnly cookie</Badge>
             </div>
 
             <p className="mt-4 text-sm leading-6 text-secondary">
-              Playing {mockUser.currentGame}. Status is mocked locally until the realtime
-              presence flow is wired in a later issue.
+              A sessão é hidratada do cookie do backend sem expor JWT no browser.
             </p>
+
+            <div className="mt-4 flex items-center justify-between gap-3">
+              <span className="text-xs uppercase tracking-[0.35em] text-secondary">
+                {logoutLabel}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => void logout()}
+                disabled={status !== 'authenticated'}
+              >
+                Sair
+              </Button>
+            </div>
           </Card>
         </div>
       </aside>

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export {};
+export { useAuth } from './use-auth';

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { logoutAuthSession } from '@/services/session';
+import { useAuthStore } from '@/store/auth-store';
+
+export function useAuth() {
+  const router = useRouter();
+  const user = useAuthStore((state) => state.user);
+  const status = useAuthStore((state) => state.status);
+
+  const logout = async () => {
+    await logoutAuthSession();
+    router.replace('/login');
+    router.refresh();
+  };
+
+  return {
+    user,
+    status,
+    logout,
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { buildApiUrl } from '@/services/http/client';
+import { useAuthStore } from '@/store/auth-store';
 
 type JsonBody = Record<string, unknown>;
 
@@ -15,6 +15,7 @@ export async function apiRequest(
   init: ApiRequestInit = {},
 ): Promise<Response> {
   const { body, headers, ...rest } = init;
+  const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
 
   const requestHeaders = new Headers(headers);
   let requestBody: BodyInit | undefined;
@@ -26,9 +27,16 @@ export async function apiRequest(
     requestBody = body;
   }
 
-  return fetch(buildApiUrl(pathname), {
+  const response = await fetch(`/api${normalizedPath}`, {
     ...rest,
+    credentials: 'include',
     headers: requestHeaders,
     body: requestBody,
   });
+
+  if (response.status === 401) {
+    useAuthStore.getState().clearSession();
+  }
+
+  return response;
 }

--- a/frontend/src/lib/auth/routes.ts
+++ b/frontend/src/lib/auth/routes.ts
@@ -1,0 +1,12 @@
+const PROTECTED_PREFIXES = ['/feed', '/notifications', '/settings'];
+const PUBLIC_ENTRY_PATHS = ['/', '/login', '/register'];
+
+export function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some((prefix) => {
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+  });
+}
+
+export function isPublicEntryPath(pathname: string): boolean {
+  return PUBLIC_ENTRY_PATHS.includes(pathname);
+}

--- a/frontend/src/lib/auth/session.ts
+++ b/frontend/src/lib/auth/session.ts
@@ -11,3 +11,14 @@ export function getAuthSessionCookieOptions() {
     maxAge: AUTH_SESSION_MAX_AGE_SECONDS,
   };
 }
+
+export function getClearedAuthSessionCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    expires: new Date(0),
+    maxAge: 0,
+  };
+}

--- a/frontend/src/schemas/auth.ts
+++ b/frontend/src/schemas/auth.ts
@@ -20,5 +20,12 @@ export const loginSessionSchema = loginBackendResponseSchema.pick({
   message: true,
 });
 
+export const authSessionSchema = z.object({
+  id: z.string().min(1),
+  username: z.string().min(1),
+  email: z.string().email('Email inválido.'),
+});
+
 export type LoginRequestValues = z.infer<typeof loginRequestSchema>;
 export type LoginSession = z.infer<typeof loginSessionSchema>;
+export type AuthSession = z.infer<typeof authSessionSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -1,5 +1,6 @@
 export {};
 export {
+  authSessionSchema,
   loginBackendResponseSchema,
   loginRequestSchema,
   loginSessionSchema,

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,4 +1,10 @@
-import { loginRequestSchema, loginSessionSchema, type LoginRequestValues, type LoginSession } from '@/schemas/auth';
+import {
+  loginRequestSchema,
+  loginSessionSchema,
+  type LoginRequestValues,
+  type LoginSession,
+} from '@/schemas/auth';
+import { apiRequest } from '@/lib/api';
 
 type ErrorResponse = {
   message?: string;
@@ -43,12 +49,9 @@ function resolveErrorMessage(payload: unknown, fallback: string): string {
 export async function login(input: LoginRequestValues): Promise<LoginSession> {
   const credentials = loginRequestSchema.parse(input);
 
-  const response = await fetch('/api/auth/login', {
+  const response = await apiRequest('/auth/login', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(credentials),
+    body: credentials,
   });
 
   const payload = await readJson(response);

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,2 +1,3 @@
 export { buildApiUrl } from './http/client';
 export { login, AuthRequestError } from './auth';
+export { fetchAuthSession, logoutAuthSession } from './session';

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -1,0 +1,42 @@
+import { apiRequest } from '@/lib/api';
+import { authSessionSchema, type AuthSession } from '@/schemas/auth';
+import { useAuthStore } from '@/store/auth-store';
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchAuthSession(): Promise<AuthSession | null> {
+  const response = await apiRequest('/auth/me', {
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = await readJson(response);
+  const parsed = authSessionSchema.safeParse(payload);
+
+  return parsed.success ? parsed.data : null;
+}
+
+export async function logoutAuthSession(): Promise<void> {
+  try {
+    await apiRequest('/auth/logout', {
+      method: 'POST',
+    });
+  } finally {
+    useAuthStore.getState().clearSession();
+  }
+}

--- a/frontend/src/store/auth-store.ts
+++ b/frontend/src/store/auth-store.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+export type AuthUser = {
+  id: string;
+  username: string;
+  email: string;
+};
+
+type AuthState = {
+  status: AuthStatus;
+  user: AuthUser | null;
+  setLoading: () => void;
+  setSession: (user: AuthUser) => void;
+  clearSession: () => void;
+};
+
+const initialState = {
+  status: 'loading' as AuthStatus,
+  user: null as AuthUser | null,
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  ...initialState,
+  setLoading: () => set({ status: 'loading' }),
+  setSession: (user) => set({ status: 'authenticated', user }),
+  clearSession: () => set({ status: 'unauthenticated', user: null }),
+}));
+
+export function resetAuthStore(): void {
+  useAuthStore.setState(initialState);
+}

--- a/frontend/tests/smoke/app-shell.test.tsx
+++ b/frontend/tests/smoke/app-shell.test.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { AppShell } from '@/components/layout/app-shell';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
 
 describe('AppShell', () => {
   it('renders the authenticated shell and toggles the mobile sidebar', () => {
@@ -24,6 +31,6 @@ describe('AppShell', () => {
       'data-open',
       'true',
     );
-    expect(screen.getByText('CLUTCH Player')).toBeInTheDocument();
+    expect(screen.getByText('clutchplayer@clutch.gg')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/auth-provider.test.tsx
+++ b/frontend/tests/unit/components/auth-provider.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider } from '@/components/auth/auth-provider';
+import { resetAuthStore, useAuthStore } from '@/store/auth-store';
+
+const replaceMock = vi.fn();
+const refreshMock = vi.fn();
+const { fetchAuthSessionMock } = vi.hoisted(() => ({
+  fetchAuthSessionMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/feed',
+  useRouter: () => ({
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock('@/services/session', () => ({
+  fetchAuthSession: fetchAuthSessionMock,
+}));
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    resetAuthStore();
+    replaceMock.mockReset();
+    refreshMock.mockReset();
+    fetchAuthSessionMock.mockReset();
+  });
+
+  it('hydrates the authenticated session', async () => {
+    fetchAuthSessionMock.mockResolvedValue({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+
+    render(
+      <AuthProvider>
+        <div>content</div>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().status).toBe('authenticated');
+      expect(useAuthStore.getState().user).toEqual({
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      });
+    });
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects protected routes when the session is missing', async () => {
+    fetchAuthSessionMock.mockResolvedValue(null);
+
+    render(
+      <AuthProvider>
+        <div>content</div>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith('/login');
+      expect(refreshMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/tests/unit/lib/auth-routes.test.ts
+++ b/frontend/tests/unit/lib/auth-routes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isProtectedPath, isPublicEntryPath } from '@/lib/auth/routes';
+
+describe('auth route helpers', () => {
+  it('identifies protected app routes', () => {
+    expect(isProtectedPath('/feed')).toBe(true);
+    expect(isProtectedPath('/feed/new')).toBe(true);
+    expect(isProtectedPath('/settings')).toBe(true);
+    expect(isProtectedPath('/login')).toBe(false);
+  });
+
+  it('identifies public entry routes', () => {
+    expect(isPublicEntryPath('/')).toBe(true);
+    expect(isPublicEntryPath('/login')).toBe(true);
+    expect(isPublicEntryPath('/register')).toBe(true);
+    expect(isPublicEntryPath('/feed')).toBe(false);
+  });
+});

--- a/frontend/tests/unit/routes/api-proxy-route.test.ts
+++ b/frontend/tests/unit/routes/api-proxy-route.test.ts
@@ -1,0 +1,85 @@
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '@/app/api/[...path]/route';
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+describe('api proxy route', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    vi.restoreAllMocks();
+  });
+
+  it('forwards the bearer token from the session cookie', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.headers).toBeDefined();
+      const headers = new Headers(init?.headers);
+      expect(headers.get('authorization')).toBe('Bearer jwt-token');
+
+      return new Response(
+        JSON.stringify({
+          id: 'user-1',
+          username: 'clutchplayer',
+          email: 'clutchplayer@clutch.gg',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const request = new NextRequest('http://localhost/api/profiles/clutchplayer', {
+      headers: {
+        cookie: 'clutch_session=jwt-token',
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ['profiles', 'clutchplayer'] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the session cookie on backend 401 responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      }) as typeof fetch,
+    );
+
+    const request = new NextRequest('http://localhost/api/profiles/clutchplayer', {
+      headers: {
+        cookie: 'clutch_session=expired-token',
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ['profiles', 'clutchplayer'] }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+  });
+});
+
+afterAll(() => {
+  if (typeof originalApiUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+});

--- a/frontend/tests/unit/routes/auth-logout-route.test.ts
+++ b/frontend/tests/unit/routes/auth-logout-route.test.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+import { POST } from '@/app/api/auth/logout/route';
+
+describe('auth logout route', () => {
+  it('clears the session cookie', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/auth/logout', {
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+  });
+});

--- a/frontend/tests/unit/routes/auth-me-route.test.ts
+++ b/frontend/tests/unit/routes/auth-me-route.test.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '@/app/api/auth/me/route';
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+describe('auth me route', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    vi.restoreAllMocks();
+  });
+
+  it('returns the hydrated session when the cookie is valid', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            id: 'user-1',
+            username: 'clutchplayer',
+            email: 'clutchplayer@clutch.gg',
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        );
+      }) as typeof fetch,
+    );
+
+    const request = new NextRequest('http://localhost/api/auth/me', {
+      headers: {
+        cookie: 'clutch_session=jwt-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+  });
+
+  it('clears the cookie when the backend rejects the token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      }) as typeof fetch,
+    );
+
+    const request = new NextRequest('http://localhost/api/auth/me', {
+      headers: {
+        cookie: 'clutch_session=expired-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+  });
+});
+
+afterAll(() => {
+  if (typeof originalApiUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+});

--- a/frontend/tests/unit/services/session.test.ts
+++ b/frontend/tests/unit/services/session.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchAuthSession, logoutAuthSession } from '@/services/session';
+import { resetAuthStore, useAuthStore } from '@/store/auth-store';
+
+const { apiRequestMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: apiRequestMock,
+}));
+
+describe('session service', () => {
+  beforeEach(() => {
+    resetAuthStore();
+    apiRequestMock.mockReset();
+  });
+
+  it('hydrates the session from the auth me contract', async () => {
+    apiRequestMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'user-1',
+          username: 'clutchplayer',
+          email: 'clutchplayer@clutch.gg',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    await expect(fetchAuthSession()).resolves.toEqual({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+  });
+
+  it('clears the local session on logout', async () => {
+    useAuthStore.getState().setSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+
+    apiRequestMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    await logoutAuthSession();
+
+    expect(apiRequestMock).toHaveBeenCalledWith('/auth/logout', {
+      method: 'POST',
+    });
+    expect(useAuthStore.getState().status).toBe('unauthenticated');
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+});

--- a/frontend/tests/unit/store/auth-store.test.ts
+++ b/frontend/tests/unit/store/auth-store.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resetAuthStore, useAuthStore } from '@/store/auth-store';
+
+describe('auth store', () => {
+  beforeEach(() => {
+    resetAuthStore();
+  });
+
+  it('starts in loading state with no user', () => {
+    const state = useAuthStore.getState();
+
+    expect(state.status).toBe('loading');
+    expect(state.user).toBeNull();
+  });
+
+  it('stores and clears the authenticated user', () => {
+    useAuthStore.getState().setSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+
+    expect(useAuthStore.getState().status).toBe('authenticated');
+    expect(useAuthStore.getState().user).toEqual({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+
+    useAuthStore.getState().clearSession();
+
+    expect(useAuthStore.getState().status).toBe('unauthenticated');
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #89

## Summary
- Adds a global auth store for the hydrated session user.
- Restores the session from the httpOnly auth cookie via `/api/auth/me`.
- Protects authenticated routes with middleware and auth-aware redirects.
- Centralizes HTTP through the local `/api` proxy, with `401` clearing the session and logout clearing cookie + state.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`