### PR TITLE
feat(auth): implement register page with auto-login flow

### DIFF
--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { RegisterForm } from '@/components/auth/register-form';
+
+export default function RegisterPage() {
+  return (
+    <section className="grid w-full gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+      <Card tone="accent" className="p-card shadow-glow">
+        <div className="flex h-full flex-col justify-between gap-section">
+          <div className="space-y-4">
+            <Badge tone="accent">CLUTCH auth</Badge>
+            <SectionHeading
+              level="h2"
+              eyebrow="Identity onboarding"
+              title="Crie seu perfil e entre direto no CLUTCH."
+              description="A rota de cadastro usa o contrato real do backend com sessao protegida por cookie httpOnly."
+            />
+          </div>
+
+          <div className="space-y-4 text-sm leading-6 text-secondary">
+            <p>
+              Username: 3 a 30 caracteres com letras, numeros e underscore.
+            </p>
+            <p>
+              Se preferir voltar para a entrada publica, acesse{' '}
+              <Link
+                href="/"
+                className="font-medium text-accent-cyan underline-offset-4 transition hover:text-primary hover:underline"
+              >
+                a home
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <RegisterForm />
+    </section>
+  );
+}

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server';
+import {
+  registerBackendResponseSchema,
+  registerRequestSchema,
+} from '@/schemas/auth';
+import {
+  AUTH_SESSION_COOKIE_NAME,
+  getAuthSessionCookieOptions,
+} from '@/lib/auth/session';
+import { buildApiUrl } from '@/services/http/client';
+
+type ErrorBody = {
+  message?: string;
+};
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorBody).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function POST(request: Request) {
+  let parsedBody: unknown;
+
+  try {
+    parsedBody = await request.json();
+  } catch {
+    return NextResponse.json(
+      { message: 'Requisicao de cadastro invalida.' },
+      { status: 400 },
+    );
+  }
+
+  const registerResult = registerRequestSchema.safeParse(parsedBody);
+
+  if (!registerResult.success) {
+    return NextResponse.json(
+      { message: 'Username, email e senha sao obrigatorios.' },
+      { status: 400 },
+    );
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(buildApiUrl('/auth/register'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(registerResult.data),
+    });
+  } catch {
+    return NextResponse.json(
+      { message: 'Nao foi possivel contatar o backend de autenticacao.' },
+      { status: 502 },
+    );
+  }
+
+  const payload = await readJsonBody(backendResponse);
+
+  if (!backendResponse.ok) {
+    return NextResponse.json(
+      {
+        message: resolveMessage(
+          payload,
+          backendResponse.status === 409
+            ? 'Email ou username ja esta em uso.'
+            : 'Falha ao registrar.',
+        ),
+      },
+      { status: backendResponse.status },
+    );
+  }
+
+  const sessionResult = registerBackendResponseSchema.safeParse(payload);
+
+  if (!sessionResult.success) {
+    return NextResponse.json(
+      { message: 'Resposta invalida do backend de autenticacao.' },
+      { status: 502 },
+    );
+  }
+
+  const response = NextResponse.json(
+    {
+      id: sessionResult.data.id,
+      username: sessionResult.data.username,
+      message: 'Conta criada com sucesso.',
+    },
+    { status: 201 },
+  );
+
+  response.cookies.set(
+    AUTH_SESSION_COOKIE_NAME,
+    sessionResult.data.token,
+    getAuthSessionCookieOptions(),
+  );
+
+  return response;
+}

--- a/frontend/src/components/auth/register-form.tsx
+++ b/frontend/src/components/auth/register-form.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { SectionHeading } from '@/components/ui/section-heading';
+import {
+  registerRequestSchema,
+  type RegisterRequestValues,
+} from '@/schemas/auth';
+import { AuthRequestError, register as registerAccount } from '@/services/auth';
+
+const fieldClassName = 'space-y-2';
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterRequestValues>({
+    resolver: zodResolver(registerRequestSchema),
+    defaultValues: {
+      username: '',
+      email: '',
+      password: '',
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    setServerError(null);
+
+    try {
+      await registerAccount(values);
+      router.replace('/feed');
+      router.refresh();
+    } catch (error) {
+      if (error instanceof AuthRequestError) {
+        if (error.status === 409) {
+          setServerError('Email ou username ja estao em uso.');
+          return;
+        }
+
+        setServerError(error.message);
+        return;
+      }
+
+      setServerError('Nao foi possivel criar sua conta agora. Tente novamente.');
+    }
+  });
+
+  return (
+    <Card className="p-card shadow-glow">
+      <form className="space-y-section" onSubmit={onSubmit} noValidate>
+        <div className="space-y-3">
+          <Badge tone="accent">Criar conta</Badge>
+          <SectionHeading
+            level="h1"
+            eyebrow="CLUTCH register"
+            title="Comece sua conta gamer no CLUTCH."
+            description="Cadastro com contrato real do backend e sessao local segura via cookie httpOnly."
+          />
+        </div>
+
+        {serverError ? (
+          <div
+            role="alert"
+            className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm leading-6 text-primary"
+          >
+            {serverError}
+          </div>
+        ) : null}
+
+        <div className="space-y-4">
+          <label className={fieldClassName}>
+            <span className="text-sm font-medium text-primary">Username</span>
+            <Input
+              type="text"
+              autoComplete="username"
+              placeholder="clutch_player"
+              aria-invalid={Boolean(errors.username)}
+              aria-describedby={errors.username ? 'register-username-error' : undefined}
+              {...register('username')}
+            />
+            {errors.username ? (
+              <span id="register-username-error" className="text-sm text-status-afk">
+                {errors.username.message}
+              </span>
+            ) : null}
+          </label>
+
+          <label className={fieldClassName}>
+            <span className="text-sm font-medium text-primary">Email</span>
+            <Input
+              type="email"
+              autoComplete="email"
+              placeholder="seu-email@clutch.gg"
+              aria-invalid={Boolean(errors.email)}
+              aria-describedby={errors.email ? 'register-email-error' : undefined}
+              {...register('email')}
+            />
+            {errors.email ? (
+              <span id="register-email-error" className="text-sm text-status-afk">
+                {errors.email.message}
+              </span>
+            ) : null}
+          </label>
+
+          <label className={fieldClassName}>
+            <span className="text-sm font-medium text-primary">Senha</span>
+            <Input
+              type="password"
+              autoComplete="new-password"
+              placeholder="Pelo menos 6 caracteres"
+              aria-invalid={Boolean(errors.password)}
+              aria-describedby={errors.password ? 'register-password-error' : undefined}
+              {...register('password')}
+            />
+            {errors.password ? (
+              <span id="register-password-error" className="text-sm text-status-afk">
+                {errors.password.message}
+              </span>
+            ) : null}
+          </label>
+        </div>
+
+        <div className="space-y-4">
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? 'Criando conta...' : 'Criar conta'}
+          </Button>
+
+          <p className="text-center text-sm text-secondary">
+            Ja tem conta?{' '}
+            <Link
+              href="/login"
+              className="font-medium text-accent-cyan underline-offset-4 transition hover:text-primary hover:underline"
+            >
+              Entrar
+            </Link>
+          </p>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/src/schemas/auth.ts
+++ b/frontend/src/schemas/auth.ts
@@ -7,6 +7,22 @@ export const loginRequestSchema = z.object({
     .min(6, 'A senha precisa ter pelo menos 6 caracteres.'),
 });
 
+export const registerRequestSchema = z.object({
+  username: z
+    .string()
+    .trim()
+    .min(3, 'O username precisa ter no mínimo 3 caracteres.')
+    .max(30, 'O username precisa ter no máximo 30 caracteres.')
+    .regex(
+      /^[a-zA-Z0-9_]+$/,
+      'O username aceita apenas letras, números e underscore.',
+    ),
+  email: z.string().trim().email('Digite um email válido.'),
+  password: z
+    .string()
+    .min(6, 'A senha precisa ter pelo menos 6 caracteres.'),
+});
+
 export const loginBackendResponseSchema = z.object({
   id: z.string().min(1),
   username: z.string().min(1),
@@ -14,10 +30,21 @@ export const loginBackendResponseSchema = z.object({
   message: z.string().min(1),
 });
 
+export const registerBackendResponseSchema = z.object({
+  id: z.string().min(1),
+  username: z.string().min(1),
+  token: z.string().min(1),
+});
+
 export const loginSessionSchema = loginBackendResponseSchema.pick({
   id: true,
   username: true,
   message: true,
+});
+
+export const registerSessionSchema = registerBackendResponseSchema.pick({
+  id: true,
+  username: true,
 });
 
 export const authSessionSchema = z.object({
@@ -28,4 +55,6 @@ export const authSessionSchema = z.object({
 
 export type LoginRequestValues = z.infer<typeof loginRequestSchema>;
 export type LoginSession = z.infer<typeof loginSessionSchema>;
+export type RegisterRequestValues = z.infer<typeof registerRequestSchema>;
+export type RegisterSession = z.infer<typeof registerSessionSchema>;
 export type AuthSession = z.infer<typeof authSessionSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -4,4 +4,7 @@ export {
   loginBackendResponseSchema,
   loginRequestSchema,
   loginSessionSchema,
+  registerBackendResponseSchema,
+  registerRequestSchema,
+  registerSessionSchema,
 } from './auth';

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -3,6 +3,10 @@ import {
   loginSessionSchema,
   type LoginRequestValues,
   type LoginSession,
+  registerRequestSchema,
+  registerSessionSchema,
+  type RegisterRequestValues,
+  type RegisterSession,
 } from '@/schemas/auth';
 import { apiRequest } from '@/lib/api';
 
@@ -69,4 +73,31 @@ export async function login(input: LoginRequestValues): Promise<LoginSession> {
   }
 
   return loginSessionSchema.parse(payload);
+}
+
+export async function register(
+  input: RegisterRequestValues,
+): Promise<RegisterSession> {
+  const registration = registerRequestSchema.parse(input);
+
+  const response = await apiRequest('/auth/register', {
+    method: 'POST',
+    body: registration,
+  });
+
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    const fallbackMessage =
+      response.status === 409
+        ? 'Email ou username ja esta em uso.'
+        : 'Nao foi possivel criar a conta agora.';
+
+    throw new AuthRequestError(
+      response.status,
+      resolveErrorMessage(payload, fallbackMessage),
+    );
+  }
+
+  return registerSessionSchema.parse(payload);
 }

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,3 +1,3 @@
 export { buildApiUrl } from './http/client';
-export { login, AuthRequestError } from './auth';
+export { login, register, AuthRequestError } from './auth';
 export { fetchAuthSession, logoutAuthSession } from './session';

--- a/frontend/tests/unit/components/register-page.test.tsx
+++ b/frontend/tests/unit/components/register-page.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RegisterPage from '@/app/(auth)/register/page';
+import { AuthRequestError, register as mockedRegister } from '@/services/auth';
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+const refreshMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock('@/services/auth', () => ({
+  register: vi.fn(),
+  AuthRequestError: class AuthRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'AuthRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedRegisterFn = vi.mocked(mockedRegister);
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    refreshMock.mockReset();
+    mockedRegisterFn.mockReset();
+  });
+
+  it('renders the register page shell', () => {
+    render(<RegisterPage />);
+
+    expect(
+      screen.getByRole('heading', { name: /crie seu perfil e entre direto no clutch/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /comece sua conta gamer no clutch/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /criar conta/i })).toBeInTheDocument();
+  });
+
+  it('validates inputs in real time', async () => {
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'ab' },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/o username precisa ter no m/i),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'email-invalido' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/digite um email v/i)).toBeInTheDocument();
+    });
+  });
+
+  it('submits with success and redirects to /feed', async () => {
+    mockedRegisterFn.mockResolvedValue({
+      id: 'user-10',
+      username: 'new_player',
+    });
+
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'new_player' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'new_player@clutch.gg' },
+    });
+    fireEvent.change(screen.getByLabelText(/senha/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /criar conta/i }));
+
+    await waitFor(() => {
+      expect(mockedRegisterFn).toHaveBeenCalledWith({
+        username: 'new_player',
+        email: 'new_player@clutch.gg',
+        password: 'secret123',
+      });
+    });
+
+    expect(replaceMock).toHaveBeenCalledWith('/feed');
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  it('shows friendly conflict message for 409', async () => {
+    mockedRegisterFn.mockRejectedValue(
+      new AuthRequestError(409, 'Email ou username ja esta em uso.'),
+    );
+
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'clutchplayer' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'clutchplayer@clutch.gg' },
+    });
+    fireEvent.change(screen.getByLabelText(/senha/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /criar conta/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /email ou username ja estao em uso/i,
+    );
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('shows generic message for unexpected error', async () => {
+    mockedRegisterFn.mockRejectedValue(new Error('network'));
+
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'gamer_ok' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'gamer_ok@clutch.gg' },
+    });
+    fireEvent.change(screen.getByLabelText(/senha/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /criar conta/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /nao foi possivel criar sua conta agora/i,
+    );
+  });
+});

--- a/frontend/tests/unit/routes/auth-register-route.test.ts
+++ b/frontend/tests/unit/routes/auth-register-route.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '@/app/api/auth/register/route';
+import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+describe('auth register route', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    vi.restoreAllMocks();
+  });
+
+  it('sets an httpOnly cookie when register succeeds', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            id: 'user-2',
+            username: 'new_player',
+            token: 'jwt-register-token',
+          }),
+          {
+            status: 201,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        );
+      }) as typeof fetch,
+    );
+
+    const response = await POST(
+      new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'new_player',
+          email: 'new_player@clutch.gg',
+          password: 'secret123',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get('set-cookie')).toContain(AUTH_SESSION_COOKIE_NAME);
+    expect(response.headers.get('set-cookie')).toContain('HttpOnly');
+    expect(response.headers.get('set-cookie')).toContain('jwt-register-token');
+  });
+
+  it('returns friendly 409 without setting cookie', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ message: 'Email ou username ja esta em uso.' }), {
+          status: 409,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      }) as typeof fetch,
+    );
+
+    const response = await POST(
+      new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'clutchplayer',
+          email: 'clutchplayer@clutch.gg',
+          password: 'secret123',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get('set-cookie')).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      message: 'Email ou username ja esta em uso.',
+    });
+  });
+
+  it('returns 400 when body does not match register contract', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username: 'ab',
+          email: 'invalid',
+          password: '123',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Username, email e senha sao obrigatorios.',
+    });
+  });
+});
+
+afterAll(() => {
+  if (typeof originalApiUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+});


### PR DESCRIPTION
## Summary
- add `/register` page under `(auth)` with RHF + Zod real-time validation for username/email/password
- add local BFF route `POST /api/auth/register` that calls backend `POST /auth/register`, sets httpOnly session cookie, and handles `409` conflicts
- extend auth service/schemas with register contract and reuse existing auth session flow for auto-login + redirect to `/feed`
- add focused tests for register page UX and register API route contract/error behavior

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #88