### PR TITLE
feat(profile): implement username profile page

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -18,5 +18,13 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/login', '/register', '/feed/:path*', '/notifications/:path*', '/settings/:path*'],
+  matcher: [
+    '/',
+    '/login',
+    '/register',
+    '/:username',
+    '/feed/:path*',
+    '/notifications/:path*',
+    '/settings/:path*',
+  ],
 };

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,6 +3,14 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/(app)/[username]/page.tsx
+++ b/frontend/src/app/(app)/[username]/page.tsx
@@ -1,0 +1,13 @@
+import { ProfilePageContent } from '@/components/profile/profile-page-content';
+
+type ProfilePageProps = {
+  params: Promise<{
+    username: string;
+  }>;
+};
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
+  const { username } = await params;
+
+  return <ProfilePageContent username={username} />;
+}

--- a/frontend/src/components/profile/game-library-preview.tsx
+++ b/frontend/src/components/profile/game-library-preview.tsx
@@ -1,0 +1,64 @@
+import Image from 'next/image';
+import { Card } from '@/components/ui/card';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type GameLibraryPreviewProps = {
+  games: ProfileResponse['gameLibrary'];
+};
+
+export function GameLibraryPreview({ games }: GameLibraryPreviewProps) {
+  const visibleGames = games.slice(0, 6);
+
+  return (
+    <Card>
+      <div className="space-y-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Biblioteca
+          </p>
+          <h3 className="mt-2 font-display text-2xl font-semibold text-primary">
+            Jogos recentes
+          </h3>
+        </div>
+
+        {visibleGames.length === 0 ? (
+          <p className="rounded-control border border-border bg-background-tertiary/65 px-4 py-3 text-sm text-secondary">
+            Este perfil ainda nao possui jogos cadastrados na biblioteca.
+          </p>
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {visibleGames.map((game) => (
+              <li
+                key={`${game.platform}-${game.gameName}`}
+                className="overflow-hidden rounded-control border border-border bg-background-tertiary/70"
+              >
+                <div className="relative h-28 w-full">
+                  {game.coverUrl ? (
+                    <Image
+                      src={game.coverUrl}
+                      alt={game.gameName}
+                      fill
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-background-primary text-xs uppercase tracking-[0.25em] text-secondary">
+                      Sem capa
+                    </div>
+                  )}
+                </div>
+                <div className="space-y-1 px-3 py-3">
+                  <p className="truncate text-sm font-semibold text-primary">
+                    {game.gameName}
+                  </p>
+                  <p className="text-xs uppercase tracking-[0.24em] text-secondary">
+                    {game.platform}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -1,0 +1,76 @@
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { PresenceBadge } from '@/components/profile/presence-badge';
+import { PlatformBadges } from '@/components/profile/platform-badges';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type GamerCardProps = {
+  profile: ProfileResponse;
+};
+
+export function GamerCard({ profile }: GamerCardProps) {
+  const displayName = profile.profile.displayName || profile.username;
+  const badgeList = profile.profile.badges.slice(0, 4);
+  const initials = profile.username.slice(0, 2).toUpperCase();
+
+  return (
+    <Card className="overflow-hidden p-0">
+      <div
+        className="relative h-40 w-full border-b border-border bg-gradient-to-r from-[rgba(124,58,237,0.34)] via-[rgba(6,182,212,0.22)] to-[rgba(10,10,15,0.92)]"
+        style={
+          profile.profile.bannerUrl
+            ? {
+                backgroundImage: `linear-gradient(135deg, rgba(124,58,237,0.42), rgba(6,182,212,0.28)), url(${profile.profile.bannerUrl})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }
+            : undefined
+        }
+      />
+
+      <div className="space-y-5 p-card">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-4">
+            <Avatar
+              src={profile.profile.avatarUrl}
+              alt={profile.username}
+              fallback={initials}
+              size="lg"
+              className="h-16 w-16 text-lg"
+            />
+            <div className="min-w-0 space-y-1">
+              <h1 className="truncate font-display text-3xl font-semibold text-primary">
+                {displayName}
+              </h1>
+              <p className="truncate text-sm text-secondary">@{profile.username}</p>
+              <PresenceBadge
+                status={profile.presence.status}
+                currentGame={profile.presence.currentGame}
+                platform={profile.presence.platform}
+              />
+            </div>
+          </div>
+
+          <Badge tone="accent">Nv. {profile.stats.level}</Badge>
+        </div>
+
+        <p className="text-sm leading-6 text-secondary">
+          {profile.profile.bio || 'Sem bio configurada por enquanto.'}
+        </p>
+
+        <PlatformBadges integrations={profile.platformIntegrations} />
+
+        {badgeList.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {badgeList.map((badge) => (
+              <Badge key={badge} tone="neutral">
+                {badge}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/platform-badges.tsx
+++ b/frontend/src/components/profile/platform-badges.tsx
@@ -1,0 +1,22 @@
+import { Badge } from '@/components/ui/badge';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type PlatformBadgesProps = {
+  integrations: ProfileResponse['platformIntegrations'];
+};
+
+export function PlatformBadges({ integrations }: PlatformBadgesProps) {
+  if (integrations.length === 0) {
+    return <Badge tone="neutral">Sem integracoes conectadas</Badge>;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {integrations.map((integration) => (
+        <Badge key={integration.platform} tone="accent">
+          {integration.platform}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/presence-badge.tsx
+++ b/frontend/src/components/profile/presence-badge.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Badge } from '@/components/ui/badge';
+import { type ProfilePresenceStatus } from '@/schemas/profile';
+
+type PresenceBadgeProps = {
+  status: ProfilePresenceStatus;
+  currentGame: string | null;
+  platform: string | null;
+};
+
+const toneByStatus: Record<
+  ProfilePresenceStatus,
+  'success' | 'accent' | 'warning' | 'neutral'
+> = {
+  ONLINE: 'success',
+  IN_GAME: 'accent',
+  AFK: 'warning',
+  OFFLINE: 'neutral',
+};
+
+const labelByStatus: Record<ProfilePresenceStatus, string> = {
+  ONLINE: 'Online',
+  IN_GAME: 'In game',
+  AFK: 'AFK',
+  OFFLINE: 'Offline',
+};
+
+export function PresenceBadge({
+  status,
+  currentGame,
+  platform,
+}: PresenceBadgeProps) {
+  const detail =
+    status === 'IN_GAME' && currentGame
+      ? `Jogando ${currentGame}`
+      : platform
+        ? `Disponivel em ${platform}`
+        : 'Sem atividade ativa';
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge tone={toneByStatus[status]}>
+        <motion.span
+          initial={{ opacity: 0.55 }}
+          animate={{ opacity: [0.55, 1, 0.55] }}
+          transition={{ duration: 1.4, repeat: Number.POSITIVE_INFINITY }}
+          className="mr-1 inline-block h-2 w-2 rounded-full bg-current"
+          aria-hidden="true"
+        />
+        {labelByStatus[status]}
+      </Badge>
+      <span className="text-sm text-secondary">{detail}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profile-page-content.tsx
+++ b/frontend/src/components/profile/profile-page-content.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Card } from '@/components/ui/card';
+import { GamerCard } from '@/components/profile/gamer-card';
+import { GameLibraryPreview } from '@/components/profile/game-library-preview';
+import { ProfileStats } from '@/components/profile/profile-stats';
+import {
+  fetchProfileByUsername,
+  ProfileRequestError,
+} from '@/services/profile';
+
+type ProfilePageContentProps = {
+  username: string;
+};
+
+function ProfileLoadingState() {
+  return (
+    <div className="space-y-section" data-testid="profile-loading">
+      <Card className="p-0">
+        <div className="h-40 w-full animate-pulse bg-background-tertiary" />
+        <div className="space-y-4 p-card">
+          <div className="h-8 w-56 animate-pulse rounded-control bg-background-tertiary" />
+          <div className="h-5 w-72 animate-pulse rounded-control bg-background-tertiary" />
+          <div className="h-5 w-44 animate-pulse rounded-control bg-background-tertiary" />
+        </div>
+      </Card>
+      <Card>
+        <div className="h-28 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+    </div>
+  );
+}
+
+function ProfileNotFoundState() {
+  return (
+    <Card data-testid="profile-not-found">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+          Perfil
+        </p>
+        <h1 className="font-display text-3xl font-semibold text-primary">
+          Perfil nao encontrado
+        </h1>
+        <p className="text-sm leading-6 text-secondary">
+          Verifique o username e tente novamente.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function ProfileErrorState() {
+  return (
+    <Card data-testid="profile-error">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+          Perfil
+        </p>
+        <h1 className="font-display text-3xl font-semibold text-primary">
+          Nao foi possivel carregar o perfil
+        </h1>
+        <p className="text-sm leading-6 text-secondary">
+          Tente novamente em instantes.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+export function ProfilePageContent({ username }: ProfilePageContentProps) {
+  const profileQuery = useQuery({
+    queryKey: ['profile', username],
+    queryFn: () => fetchProfileByUsername(username),
+  });
+
+  if (profileQuery.isPending) {
+    return <ProfileLoadingState />;
+  }
+
+  if (profileQuery.isError) {
+    if (
+      profileQuery.error instanceof ProfileRequestError &&
+      profileQuery.error.status === 404
+    ) {
+      return <ProfileNotFoundState />;
+    }
+
+    return <ProfileErrorState />;
+  }
+
+  return (
+    <div className="space-y-section" data-testid="profile-success">
+      <GamerCard profile={profileQuery.data} />
+      <ProfileStats stats={profileQuery.data.stats} />
+      <GameLibraryPreview games={profileQuery.data.gameLibrary} />
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profile-stats.tsx
+++ b/frontend/src/components/profile/profile-stats.tsx
@@ -1,0 +1,41 @@
+import { Card } from '@/components/ui/card';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type ProfileStatsProps = {
+  stats: ProfileResponse['stats'];
+};
+
+type StatItem = {
+  label: string;
+  value: number;
+};
+
+export function ProfileStats({ stats }: ProfileStatsProps) {
+  const items: StatItem[] = [
+    { label: 'Amigos', value: stats.friendCount },
+    { label: 'Posts', value: stats.postCount },
+    { label: 'Reputacao', value: stats.reputation },
+    { label: 'Nivel', value: stats.level },
+    { label: 'XP', value: stats.xp },
+  ];
+
+  return (
+    <Card>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        {items.map((item) => (
+          <div
+            key={item.label}
+            className="rounded-control border border-border bg-background-tertiary/70 px-4 py-3"
+          >
+            <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+              {item.label}
+            </p>
+            <p className="mt-2 font-display text-xl font-semibold text-primary">
+              {item.value.toLocaleString('pt-BR')}
+            </p>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/lib/auth/routes.ts
+++ b/frontend/src/lib/auth/routes.ts
@@ -1,7 +1,15 @@
 const PROTECTED_PREFIXES = ['/feed', '/notifications', '/settings'];
 const PUBLIC_ENTRY_PATHS = ['/', '/login', '/register'];
+const PROFILE_PATH_REGEX = /^\/[a-zA-Z0-9_]{3,30}$/;
 
 export function isProtectedPath(pathname: string): boolean {
+  if (
+    PROFILE_PATH_REGEX.test(pathname) &&
+    !PUBLIC_ENTRY_PATHS.includes(pathname)
+  ) {
+    return true;
+  }
+
   return PROTECTED_PREFIXES.some((prefix) => {
     return pathname === prefix || pathname.startsWith(`${prefix}/`);
   });

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -5,3 +5,4 @@ export {
   loginRequestSchema,
   loginSessionSchema,
 } from './auth';
+export { profileResponseSchema } from './profile';

--- a/frontend/src/schemas/profile.ts
+++ b/frontend/src/schemas/profile.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+export const profilePresenceStatusSchema = z.enum([
+  'ONLINE',
+  'IN_GAME',
+  'AFK',
+  'OFFLINE',
+]);
+
+export const profileIntegrationPlatformSchema = z.enum([
+  'STEAM',
+  'EPIC',
+  'DISCORD',
+  'XBOX',
+  'PSN',
+  'RIOT',
+  'ANILIST',
+  'MYANIMELIST',
+]);
+
+export const profileResponseSchema = z.object({
+  id: z.string().min(1),
+  username: z.string().min(1),
+  createdAt: z.string().min(1),
+  profile: z.object({
+    displayName: z.string().nullable(),
+    bio: z.string().nullable(),
+    avatarUrl: z.string().nullable(),
+    bannerUrl: z.string().nullable(),
+    accentColor: z.string().nullable(),
+    badges: z.array(z.string()),
+  }),
+  stats: z.object({
+    level: z.number(),
+    xp: z.number(),
+    reputation: z.number(),
+    friendCount: z.number(),
+    postCount: z.number(),
+  }),
+  presence: z.object({
+    status: profilePresenceStatusSchema,
+    currentGame: z.string().nullable(),
+    gameDetails: z.record(z.unknown()).nullable(),
+    platform: z.string().nullable(),
+    updatedAt: z.string().min(1),
+  }),
+  platformIntegrations: z.array(
+    z.object({
+      platform: profileIntegrationPlatformSchema,
+      metadata: z.record(z.unknown()).nullable(),
+    }),
+  ),
+  gameLibrary: z.array(
+    z.object({
+      gameName: z.string().min(1),
+      coverUrl: z.string().nullable(),
+      platform: z.string().min(1),
+      hoursPlayed: z.number().nullable(),
+      lastPlayedAt: z.string().nullable(),
+    }),
+  ),
+});
+
+export type ProfileResponse = z.infer<typeof profileResponseSchema>;
+export type ProfilePresenceStatus = z.infer<typeof profilePresenceStatusSchema>;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,3 +1,4 @@
 export { buildApiUrl } from './http/client';
 export { login, AuthRequestError } from './auth';
 export { fetchAuthSession, logoutAuthSession } from './session';
+export { fetchProfileByUsername, ProfileRequestError } from './profile';

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -1,0 +1,66 @@
+import { apiRequest } from '@/lib/api';
+import { profileResponseSchema, type ProfileResponse } from '@/schemas/profile';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+export class ProfileRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ProfileRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchProfileByUsername(
+  username: string,
+): Promise<ProfileResponse> {
+  const response = await apiRequest(`/profiles/${encodeURIComponent(username)}`, {
+    method: 'GET',
+  });
+
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    const fallbackMessage =
+      response.status === 404
+        ? 'Perfil nao encontrado.'
+        : 'Nao foi possivel carregar o perfil agora.';
+
+    throw new ProfileRequestError(
+      response.status,
+      resolveErrorMessage(payload, fallbackMessage),
+    );
+  }
+
+  return profileResponseSchema.parse(payload);
+}

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -1,0 +1,138 @@
+import React, { type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProfilePageContent } from '@/components/profile/profile-page-content';
+import {
+  fetchProfileByUsername,
+  ProfileRequestError,
+} from '@/services/profile';
+import { type ProfileResponse } from '@/schemas/profile';
+
+vi.mock('@/services/profile', () => ({
+  fetchProfileByUsername: vi.fn(),
+  ProfileRequestError: class ProfileRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'ProfileRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedFetchProfile = vi.mocked(fetchProfileByUsername);
+
+const profileFixture: ProfileResponse = {
+  id: 'user-1',
+  username: 'clutchplayer',
+  createdAt: '2026-03-29T22:15:00.000Z',
+  profile: {
+    displayName: 'CLUTCH Player',
+    bio: 'Bio de teste',
+    avatarUrl: null,
+    bannerUrl: null,
+    accentColor: '#7C3AED',
+    badges: ['Founder'],
+  },
+  stats: {
+    level: 18,
+    xp: 4820,
+    reputation: 215,
+    friendCount: 2,
+    postCount: 2,
+  },
+  presence: {
+    status: 'IN_GAME',
+    currentGame: 'Valorant',
+    gameDetails: null,
+    platform: 'PC',
+    updatedAt: '2026-03-29T22:15:00.000Z',
+  },
+  platformIntegrations: [
+    {
+      platform: 'STEAM',
+      metadata: null,
+    },
+  ],
+  gameLibrary: [
+    {
+      gameName: 'Valorant',
+      coverUrl: null,
+      platform: 'PC',
+      hoursPlayed: 120,
+      lastPlayedAt: '2026-03-29T22:15:00.000Z',
+    },
+  ],
+};
+
+function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('ProfilePageContent', () => {
+  beforeEach(() => {
+    mockedFetchProfile.mockReset();
+  });
+
+  it('renders loading state', () => {
+    mockedFetchProfile.mockImplementation(
+      () =>
+        new Promise(() => {
+          return undefined;
+        }),
+    );
+
+    renderWithQuery(<ProfilePageContent username="clutchplayer" />);
+
+    expect(screen.getByTestId('profile-loading')).toBeInTheDocument();
+  });
+
+  it('renders success state', async () => {
+    mockedFetchProfile.mockResolvedValue(profileFixture);
+
+    renderWithQuery(<ProfilePageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-success')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('heading', { name: /clutch player/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
+  });
+
+  it('renders not found state', async () => {
+    mockedFetchProfile.mockRejectedValue(
+      new ProfileRequestError(404, 'Perfil nao encontrado.'),
+    );
+
+    renderWithQuery(<ProfilePageContent username="unknownuser" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-not-found')).toBeInTheDocument();
+    });
+  });
+
+  it('renders generic error state', async () => {
+    mockedFetchProfile.mockRejectedValue(new Error('network'));
+
+    renderWithQuery(<ProfilePageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/unit/lib/auth-routes.test.ts
+++ b/frontend/tests/unit/lib/auth-routes.test.ts
@@ -6,6 +6,8 @@ describe('auth route helpers', () => {
     expect(isProtectedPath('/feed')).toBe(true);
     expect(isProtectedPath('/feed/new')).toBe(true);
     expect(isProtectedPath('/settings')).toBe(true);
+    expect(isProtectedPath('/clutchplayer')).toBe(true);
+    expect(isProtectedPath('/ab')).toBe(false);
     expect(isProtectedPath('/login')).toBe(false);
   });
 

--- a/frontend/tests/unit/services/profile.test.ts
+++ b/frontend/tests/unit/services/profile.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import {
+  fetchProfileByUsername,
+  ProfileRequestError,
+} from '@/services/profile';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+describe('profile service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('parses and returns the profile contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'user-1',
+          username: 'clutchplayer',
+          createdAt: '2026-03-29T22:15:00.000Z',
+          profile: {
+            displayName: 'CLUTCH Player',
+            bio: 'Bio',
+            avatarUrl: null,
+            bannerUrl: null,
+            accentColor: '#7C3AED',
+            badges: ['Founder'],
+          },
+          stats: {
+            level: 18,
+            xp: 4820,
+            reputation: 215,
+            friendCount: 2,
+            postCount: 2,
+          },
+          presence: {
+            status: 'ONLINE',
+            currentGame: null,
+            gameDetails: null,
+            platform: 'PC',
+            updatedAt: '2026-03-29T22:15:00.000Z',
+          },
+          platformIntegrations: [],
+          gameLibrary: [],
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const profile = await fetchProfileByUsername('clutchplayer');
+
+    expect(profile.username).toBe('clutchplayer');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/profiles/clutchplayer', {
+      method: 'GET',
+    });
+  });
+
+  it('maps 404 to ProfileRequestError', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Perfil nao encontrado.' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await expect(fetchProfileByUsername('missinguser')).rejects.toMatchObject({
+      name: 'ProfileRequestError',
+      status: 404,
+      message: 'Perfil nao encontrado.',
+    } satisfies Partial<ProfileRequestError>);
+  });
+
+  it('maps generic backend errors', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Erro interno.' }), {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await expect(fetchProfileByUsername('clutchplayer')).rejects.toMatchObject({
+      name: 'ProfileRequestError',
+      status: 500,
+      message: 'Erro interno.',
+    } satisfies Partial<ProfileRequestError>);
+  });
+});


### PR DESCRIPTION
## Summary
- add authenticated dynamic profile page at `/(app)/[username]` consuming the real backend contract `GET /profiles/:username`
- introduce typed profile data layer (`schema + service`) and reusable profile UI modules (`GamerCard`, `PresenceBadge`, `PlatformBadges`, `ProfileStats`, `GameLibraryPreview`)
- implement explicit states for loading, not-found (404), generic error, and success
- protect dynamic username routes in auth helpers/middleware so profile pages follow the authenticated app flow
- add remote image allowlist for seeded avatar/banner/game covers

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #91