### PR TITLE
feat(feed): add read-only feed foundation

### DIFF
--- a/frontend/src/app/(app)/feed/page.tsx
+++ b/frontend/src/app/(app)/feed/page.tsx
@@ -1,0 +1,5 @@
+import { FeedPageContent } from '@/components/feed/feed-page-content';
+
+export default function FeedPage() {
+  return <FeedPageContent />;
+}

--- a/frontend/src/components/feed/feed-page-content.tsx
+++ b/frontend/src/components/feed/feed-page-content.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { PostCard } from '@/components/feed/post-card';
+import { Card } from '@/components/ui/card';
+import { useAuth } from '@/hooks/use-auth';
+import { fetchFeed } from '@/services/feed';
+
+function FeedLoadingState() {
+  return (
+    <div className="space-y-4" data-testid="feed-loading">
+      <Card>
+        <div className="h-8 w-48 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-4 h-6 w-full animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-2 h-6 w-2/3 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+      <Card>
+        <div className="h-8 w-40 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-4 h-6 w-full animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+    </div>
+  );
+}
+
+function FeedEmptyState() {
+  return (
+    <Card data-testid="feed-empty">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Feed</p>
+        <h1 className="font-display text-3xl font-semibold text-primary">
+          Nenhum post no feed ainda
+        </h1>
+        <p className="text-sm leading-6 text-secondary">
+          Assim que voce e seus amigos publicarem, os posts aparecem aqui.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function FeedErrorState() {
+  return (
+    <Card data-testid="feed-error">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Feed</p>
+        <h1 className="font-display text-3xl font-semibold text-primary">
+          Nao foi possivel carregar o feed
+        </h1>
+        <p className="text-sm leading-6 text-secondary">
+          Tente novamente em alguns instantes.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+export function FeedPageContent() {
+  const { status, user } = useAuth();
+  const userId = user?.id;
+
+  const feedQuery = useQuery({
+    queryKey: ['feed', userId],
+    enabled: typeof userId === 'string' && userId.length > 0,
+    queryFn: () =>
+      fetchFeed({
+        userId: userId as string,
+      }),
+  });
+
+  if (status === 'loading' || feedQuery.isPending) {
+    return <FeedLoadingState />;
+  }
+
+  if (!userId || status !== 'authenticated') {
+    return <FeedErrorState />;
+  }
+
+  if (feedQuery.isError) {
+    return <FeedErrorState />;
+  }
+
+  if (feedQuery.data.posts.length === 0) {
+    return <FeedEmptyState />;
+  }
+
+  return (
+    <section className="space-y-section" data-testid="feed-success">
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Feed</p>
+        <h1 className="font-display text-3xl font-semibold text-primary">
+          Social feed
+        </h1>
+        <p className="text-sm leading-6 text-secondary">
+          Linha do tempo read-only com base no contrato real do backend.
+        </p>
+      </header>
+
+      <div className="space-y-4">
+        {feedQuery.data.posts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/feed/post-card.tsx
+++ b/frontend/src/components/feed/post-card.tsx
@@ -1,0 +1,79 @@
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { type FeedPost } from '@/schemas/feed';
+
+type PostCardProps = {
+  post: FeedPost;
+};
+
+function formatPostDate(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+export function PostCard({ post }: PostCardProps) {
+  const displayName =
+    post.author.profile?.displayName && post.author.profile.displayName.length > 0
+      ? post.author.profile.displayName
+      : post.author.username;
+  const avatarFallback = post.author.username.slice(0, 2).toUpperCase();
+
+  return (
+    <Card data-testid="feed-post-card">
+      <article className="space-y-4">
+        <header className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 items-start gap-3">
+            <Avatar
+              src={post.author.profile?.avatarUrl}
+              alt={post.author.username}
+              fallback={avatarFallback}
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-primary">
+                {displayName}
+              </p>
+              <p className="truncate text-xs text-secondary">@{post.author.username}</p>
+            </div>
+          </div>
+          <Badge tone="neutral">{post.type}</Badge>
+        </header>
+
+        {post.contentText ? (
+          <p className="text-sm leading-6 text-primary">{post.contentText}</p>
+        ) : null}
+
+        {post.mediaUrl ? (
+          <div
+            className="h-44 w-full rounded-control border border-border bg-cover bg-center"
+            style={{ backgroundImage: `url(${post.mediaUrl})` }}
+            role="img"
+            aria-label={`Midia do post ${post.id}`}
+          />
+        ) : null}
+
+        {post.gameContext ? (
+          <p className="text-xs text-secondary">
+            Jogando {post.gameContext.gameName || 'desconhecido'} em{' '}
+            {post.gameContext.platform || 'plataforma nao informada'}
+          </p>
+        ) : null}
+
+        <footer className="flex flex-wrap items-center justify-between gap-2 text-xs text-secondary">
+          <span>{formatPostDate(post.createdAt)}</span>
+          <span>
+            {post._count.interactions} reacoes • {post._count.comments} comentarios
+          </span>
+        </footer>
+      </article>
+    </Card>
+  );
+}

--- a/frontend/src/schemas/feed.ts
+++ b/frontend/src/schemas/feed.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+export const feedPostTypeSchema = z.enum([
+  'TEXT',
+  'IMAGE',
+  'ACHIEVEMENT',
+  'GAME_SESSION',
+]);
+
+export const feedPostSchema = z.object({
+  id: z.string().min(1),
+  contentText: z.string().nullable(),
+  mediaUrl: z.string().nullable(),
+  type: feedPostTypeSchema,
+  gameContext: z
+    .object({
+      gameName: z.string().nullable(),
+      platform: z.string().nullable(),
+      capturedAt: z.string().min(1),
+    })
+    .nullable(),
+  createdAt: z.string().min(1),
+  author: z.object({
+    id: z.string().min(1),
+    username: z.string().min(1),
+    profile: z
+      .object({
+        displayName: z.string().nullable(),
+        avatarUrl: z.string().nullable(),
+        accentColor: z.string().nullable(),
+      })
+      .nullable(),
+  }),
+  _count: z.object({
+    interactions: z.number(),
+    comments: z.number(),
+  }),
+});
+
+export const feedResponseSchema = z.object({
+  posts: z.array(feedPostSchema),
+  nextCursor: z.string().nullable(),
+});
+
+export type FeedPost = z.infer<typeof feedPostSchema>;
+export type FeedResponse = z.infer<typeof feedResponseSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -5,3 +5,4 @@ export {
   loginRequestSchema,
   loginSessionSchema,
 } from './auth';
+export { feedResponseSchema } from './feed';

--- a/frontend/src/services/feed.ts
+++ b/frontend/src/services/feed.ts
@@ -1,0 +1,76 @@
+import { apiRequest } from '@/lib/api';
+import { feedResponseSchema, type FeedResponse } from '@/schemas/feed';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+type FeedRequestInput = {
+  userId: string;
+  cursor?: string;
+  limit?: number;
+};
+
+export class FeedRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'FeedRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchFeed(input: FeedRequestInput): Promise<FeedResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (input.cursor) {
+    searchParams.set('cursor', input.cursor);
+  }
+
+  if (typeof input.limit === 'number') {
+    searchParams.set('limit', String(input.limit));
+  }
+
+  const path = `/posts/feed/${encodeURIComponent(input.userId)}${
+    searchParams.size > 0 ? `?${searchParams.toString()}` : ''
+  }`;
+
+  const response = await apiRequest(path, { method: 'GET' });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FeedRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar o feed agora.'),
+    );
+  }
+
+  return feedResponseSchema.parse(payload);
+}

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,3 +1,4 @@
 export { buildApiUrl } from './http/client';
 export { login, AuthRequestError } from './auth';
 export { fetchAuthSession, logoutAuthSession } from './session';
+export { fetchFeed, FeedRequestError } from './feed';

--- a/frontend/tests/unit/components/feed-page-content.test.tsx
+++ b/frontend/tests/unit/components/feed-page-content.test.tsx
@@ -1,0 +1,139 @@
+import React, { type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FeedPageContent } from '@/components/feed/feed-page-content';
+import { fetchFeed } from '@/services/feed';
+import { useAuth } from '@/hooks/use-auth';
+
+vi.mock('@/services/feed', () => ({
+  fetchFeed: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+const mockedFetchFeed = vi.mocked(fetchFeed);
+const mockedUseAuth = vi.mocked(useAuth);
+
+function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('FeedPageContent', () => {
+  beforeEach(() => {
+    mockedFetchFeed.mockReset();
+    mockedUseAuth.mockReset();
+  });
+
+  it('renders loading state', () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'loading',
+      user: null,
+      logout: vi.fn(),
+    });
+
+    renderWithQuery(<FeedPageContent />);
+
+    expect(screen.getByTestId('feed-loading')).toBeInTheDocument();
+  });
+
+  it('renders feed posts on success', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchFeed.mockResolvedValue({
+      posts: [
+        {
+          id: 'post-1',
+          contentText: 'Primeiro post',
+          mediaUrl: null,
+          type: 'TEXT',
+          gameContext: null,
+          createdAt: '2026-03-31T10:00:00.000Z',
+          author: {
+            id: 'user-2',
+            username: 'pixelsamurai',
+            profile: {
+              displayName: 'Pixel Samurai',
+              avatarUrl: null,
+              accentColor: '#06B6D4',
+            },
+          },
+          _count: {
+            interactions: 3,
+            comments: 2,
+          },
+        },
+      ],
+      nextCursor: null,
+    });
+
+    renderWithQuery(<FeedPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feed-success')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/primeiro post/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId('feed-post-card')).toHaveLength(1);
+  });
+
+  it('renders empty state', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchFeed.mockResolvedValue({
+      posts: [],
+      nextCursor: null,
+    });
+
+    renderWithQuery(<FeedPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feed-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('renders generic error state', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchFeed.mockRejectedValue(new Error('network'));
+
+    renderWithQuery(<FeedPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('feed-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/unit/services/feed.test.ts
+++ b/frontend/tests/unit/services/feed.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import { fetchFeed } from '@/services/feed';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+describe('feed service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('returns parsed feed response', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          posts: [
+            {
+              id: 'post-1',
+              contentText: 'Primeiro post',
+              mediaUrl: null,
+              type: 'TEXT',
+              gameContext: null,
+              createdAt: '2026-03-31T10:00:00.000Z',
+              author: {
+                id: 'user-1',
+                username: 'clutchplayer',
+                profile: {
+                  displayName: 'CLUTCH Player',
+                  avatarUrl: null,
+                  accentColor: '#7C3AED',
+                },
+              },
+              _count: {
+                interactions: 3,
+                comments: 2,
+              },
+            },
+          ],
+          nextCursor: null,
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const response = await fetchFeed({ userId: 'user-1' });
+
+    expect(response.posts).toHaveLength(1);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/posts/feed/user-1', {
+      method: 'GET',
+    });
+  });
+
+  it('keeps cursor and limit query params for future pagination', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ posts: [], nextCursor: 'post-2' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await fetchFeed({ userId: 'user-1', cursor: 'post-1', limit: 10 });
+
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/posts/feed/user-1?cursor=post-1&limit=10',
+      {
+        method: 'GET',
+      },
+    );
+  });
+
+  it('throws when backend responds with error', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Falha ao carregar feed.' }), {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await expect(fetchFeed({ userId: 'user-1' })).rejects.toMatchObject({
+      name: 'FeedRequestError',
+      status: 500,
+      message: 'Falha ao carregar feed.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `/feed` authenticated page with read-only social timeline foundation
- consume real backend contract `GET /posts/feed/:userId` using session `userId`
- add typed feed schema/service with support for `cursor` and `limit` params to prepare future pagination
- add `PostCard` read-only UI for author, content, media, game context and counters
- implement explicit states: loading, error, and empty feed

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Refs #92