### PR TITLE
feat(feed): complete social feed interactions

### DIFF
--- a/frontend/src/components/feed/comment-section.tsx
+++ b/frontend/src/components/feed/comment-section.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { commentContentSchema, type PostComment } from '@/schemas/feed';
+import {
+  createPostComment,
+  FeedRequestError,
+  fetchPostComments,
+} from '@/services/feed';
+
+type CommentSectionProps = {
+  postId: string;
+  initialCommentCount: number;
+};
+
+type CommentComposerProps = {
+  placeholder: string;
+  submitLabel: string;
+  disabled: boolean;
+  onSubmit: (content: string) => Promise<void>;
+};
+
+function formatCommentDate(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function resolveCommentAuthorName(comment: PostComment | PostComment['replies'][number]) {
+  return comment.author.profile?.displayName && comment.author.profile.displayName.length > 0
+    ? comment.author.profile.displayName
+    : comment.author.username;
+}
+
+function CommentComposer({
+  placeholder,
+  submitLabel,
+  disabled,
+  onSubmit,
+}: CommentComposerProps) {
+  const [content, setContent] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  return (
+    <form
+      className="space-y-2"
+      onSubmit={async (event) => {
+        event.preventDefault();
+
+        const result = commentContentSchema.safeParse(content);
+
+        if (!result.success) {
+          setValidationError(result.error.issues[0]?.message ?? 'Comentario invalido.');
+          return;
+        }
+
+        setValidationError(null);
+        try {
+          await onSubmit(result.data);
+          setContent('');
+        } catch {
+          return;
+        }
+      }}
+    >
+      <label className="block space-y-2">
+        <span className="sr-only">{placeholder}</span>
+        <textarea
+          className="min-h-24 w-full rounded-control border border-border bg-background-tertiary px-control-x py-control-y text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/30"
+          placeholder={placeholder}
+          value={content}
+          disabled={disabled}
+          onChange={(event) => {
+            setContent(event.target.value);
+            if (validationError) {
+              setValidationError(null);
+            }
+          }}
+        />
+      </label>
+
+      {validationError ? (
+        <p role="alert" className="text-sm text-status-afk">
+          {validationError}
+        </p>
+      ) : null}
+
+      <div className="flex justify-end">
+        <Button type="submit" size="sm" disabled={disabled}>
+          {disabled ? 'Enviando...' : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function CommentItem({
+  comment,
+  disabled,
+  onReply,
+}: {
+  comment: PostComment;
+  disabled: boolean;
+  onReply: (parentId: string, content: string) => Promise<void>;
+}) {
+  const [isReplying, setIsReplying] = useState(false);
+  const authorName = resolveCommentAuthorName(comment);
+  const avatarFallback = comment.author.username.slice(0, 2).toUpperCase();
+
+  return (
+    <article className="space-y-3 rounded-control border border-border/80 bg-background-secondary/60 p-4">
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <Avatar
+            src={comment.author.profile?.avatarUrl}
+            alt={comment.author.username}
+            fallback={avatarFallback}
+          />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-primary">{authorName}</p>
+            <p className="truncate text-xs text-secondary">@{comment.author.username}</p>
+          </div>
+        </div>
+
+        <span className="text-xs text-secondary">{formatCommentDate(comment.createdAt)}</span>
+      </header>
+
+      <p className="text-sm leading-6 text-primary">{comment.content}</p>
+
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-secondary">
+          {comment.replies.length} resposta{comment.replies.length === 1 ? '' : 's'}
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={disabled}
+          onClick={() => {
+            setIsReplying((current) => !current);
+          }}
+        >
+          {isReplying ? 'Cancelar reply' : 'Responder'}
+        </Button>
+      </div>
+
+      {isReplying ? (
+        <CommentComposer
+          placeholder={`Responder ${authorName}`}
+          submitLabel="Enviar reply"
+          disabled={disabled}
+          onSubmit={async (content) => {
+            await onReply(comment.id, content);
+            setIsReplying(false);
+          }}
+        />
+      ) : null}
+
+      {comment.replies.length > 0 ? (
+        <div className="space-y-3 border-l border-border/80 pl-4">
+          {comment.replies.map((reply) => {
+            const replyAuthorName = resolveCommentAuthorName(reply);
+            const replyFallback = reply.author.username.slice(0, 2).toUpperCase();
+
+            return (
+              <article
+                key={reply.id}
+                className="space-y-2 rounded-control bg-background-primary/60 p-3"
+              >
+                <header className="flex items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <Avatar
+                      src={reply.author.profile?.avatarUrl}
+                      alt={reply.author.username}
+                      fallback={replyFallback}
+                    />
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-primary">
+                        {replyAuthorName}
+                      </p>
+                      <p className="truncate text-xs text-secondary">
+                        @{reply.author.username}
+                      </p>
+                    </div>
+                  </div>
+
+                  <span className="text-xs text-secondary">
+                    {formatCommentDate(reply.createdAt)}
+                  </span>
+                </header>
+
+                <p className="text-sm leading-6 text-primary">{reply.content}</p>
+              </article>
+            );
+          })}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export function CommentSection({
+  postId,
+  initialCommentCount,
+}: CommentSectionProps) {
+  const queryClient = useQueryClient();
+  const [isOpen, setIsOpen] = useState(false);
+  const [commentCount, setCommentCount] = useState(initialCommentCount);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCommentCount(initialCommentCount);
+  }, [initialCommentCount]);
+
+  const commentsQuery = useQuery({
+    queryKey: ['post-comments', postId],
+    queryFn: () => fetchPostComments(postId),
+    enabled: isOpen,
+  });
+
+  const createCommentMutation = useMutation({
+    mutationFn: createPostComment,
+    onSuccess: async () => {
+      setServerError(null);
+      setCommentCount((current) => current + 1);
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['post-comments', postId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['feed'],
+        }),
+      ]);
+    },
+    onError: (error) => {
+      if (error instanceof FeedRequestError) {
+        setServerError(error.message);
+        return;
+      }
+
+      setServerError('Nao foi possivel enviar o comentario agora.');
+    },
+  });
+
+  const submitComment = async (content: string, parentId?: string) => {
+    setServerError(null);
+    await createCommentMutation.mutateAsync({
+      postId,
+      content,
+      parentId,
+    });
+  };
+
+  return (
+    <section className="space-y-4" data-testid="comment-section">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            setIsOpen((current) => !current);
+          }}
+        >
+          {isOpen ? 'Ocultar comentarios' : 'Abrir comentarios'}
+        </Button>
+        <span className="text-xs text-secondary">
+          {commentCount} comentario{commentCount === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {isOpen ? (
+        <div className="space-y-4">
+          <CommentComposer
+            placeholder="Escreva um comentario"
+            submitLabel="Comentar"
+            disabled={createCommentMutation.isPending}
+            onSubmit={async (content) => {
+              await submitComment(content);
+            }}
+          />
+
+          {serverError ? (
+            <p role="alert" className="text-sm text-status-afk">
+              {serverError}
+            </p>
+          ) : null}
+
+          {commentsQuery.isPending ? (
+            <div className="rounded-control border border-border/80 bg-background-secondary/60 p-4 text-sm text-secondary">
+              Carregando comentarios...
+            </div>
+          ) : null}
+
+          {commentsQuery.isError ? (
+            <div className="rounded-control border border-border/80 bg-background-secondary/60 p-4 text-sm text-status-afk">
+              Nao foi possivel carregar os comentarios deste post.
+            </div>
+          ) : null}
+
+          {commentsQuery.data && commentsQuery.data.length === 0 ? (
+            <div className="rounded-control border border-border/80 bg-background-secondary/60 p-4 text-sm text-secondary">
+              Ainda nao existem comentarios para este post.
+            </div>
+          ) : null}
+
+          {commentsQuery.data && commentsQuery.data.length > 0 ? (
+            <div className="space-y-4">
+              {commentsQuery.data.map((comment) => (
+                <CommentItem
+                  key={comment.id}
+                  comment={comment}
+                  disabled={createCommentMutation.isPending}
+                  onReply={async (parentId, content) => {
+                    await submitComment(content, parentId);
+                  }}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/feed/create-post-form.tsx
+++ b/frontend/src/components/feed/create-post-form.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  createPostRequestSchema,
+  type CreatePostRequest,
+} from '@/schemas/feed';
+import { createPost, FeedRequestError } from '@/services/feed';
+
+type CreatePostFormProps = {
+  userId: string;
+};
+
+const postTypeOptions: Array<{
+  value: CreatePostRequest['type'];
+  label: string;
+}> = [
+  { value: 'TEXT', label: 'Texto' },
+  { value: 'IMAGE', label: 'Imagem' },
+  { value: 'ACHIEVEMENT', label: 'Conquista' },
+  { value: 'GAME_SESSION', label: 'Sessao' },
+];
+
+export function CreatePostForm({ userId }: CreatePostFormProps) {
+  const queryClient = useQueryClient();
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreatePostRequest>({
+    resolver: zodResolver(createPostRequestSchema),
+    defaultValues: {
+      contentText: '',
+      mediaUrl: '',
+      type: 'TEXT',
+    },
+    mode: 'onChange',
+  });
+
+  const createPostMutation = useMutation({
+    mutationFn: createPost,
+    onSuccess: async () => {
+      setServerError(null);
+      setFeedbackMessage('Post publicado com sucesso.');
+      reset({
+        contentText: '',
+        mediaUrl: '',
+        type: 'TEXT',
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['feed', userId],
+      });
+    },
+    onError: (error) => {
+      setFeedbackMessage(null);
+
+      if (error instanceof FeedRequestError) {
+        setServerError(error.message);
+        return;
+      }
+
+      setServerError('Nao foi possivel publicar agora. Tente novamente.');
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    setFeedbackMessage(null);
+    setServerError(null);
+
+    try {
+      await createPostMutation.mutateAsync(values);
+    } catch {
+      return;
+    }
+  });
+
+  return (
+    <Card>
+      <form className="space-y-4" onSubmit={onSubmit} noValidate>
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Novo post
+          </p>
+          <h2 className="font-display text-2xl font-semibold text-primary">
+            Compartilhe algo com sua timeline
+          </h2>
+          <p className="text-sm leading-6 text-secondary">
+            O backend decide sozinho se o post recebe game context com base na sua
+            presenca atual.
+          </p>
+        </div>
+
+        {feedbackMessage ? (
+          <div
+            role="status"
+            className="rounded-control border border-status-online/30 bg-[rgba(16,185,129,0.12)] px-control-x py-control-y text-sm text-primary"
+          >
+            {feedbackMessage}
+          </div>
+        ) : null}
+
+        {serverError ? (
+          <div
+            role="alert"
+            className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary"
+          >
+            {serverError}
+          </div>
+        ) : null}
+
+        <label className="block space-y-2">
+          <span className="text-sm font-medium text-primary">Conteudo</span>
+          <textarea
+            className="min-h-32 w-full rounded-control border border-border bg-background-tertiary px-control-x py-control-y text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/30"
+            placeholder="O que voce quer compartilhar hoje?"
+            aria-invalid={Boolean(errors.contentText)}
+            aria-describedby={errors.contentText ? 'post-content-error' : undefined}
+            {...register('contentText')}
+          />
+          {errors.contentText ? (
+            <span id="post-content-error" className="text-sm text-status-afk">
+              {errors.contentText.message}
+            </span>
+          ) : null}
+        </label>
+
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_13rem]">
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-primary">
+              URL de midia
+            </span>
+            <Input
+              placeholder="https://..."
+              aria-invalid={Boolean(errors.mediaUrl)}
+              aria-describedby={errors.mediaUrl ? 'post-media-error' : undefined}
+              {...register('mediaUrl')}
+            />
+            {errors.mediaUrl ? (
+              <span id="post-media-error" className="text-sm text-status-afk">
+                {errors.mediaUrl.message}
+              </span>
+            ) : null}
+          </label>
+
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-primary">Tipo</span>
+            <select
+              className="h-11 rounded-control border border-border bg-background-tertiary px-control-x text-sm text-primary outline-none transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/30"
+              {...register('type')}
+            >
+              {postTypeOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex items-center justify-end">
+          <Button type="submit" disabled={createPostMutation.isPending}>
+            {createPostMutation.isPending ? 'Publicando...' : 'Publicar post'}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/src/components/feed/feed-page-content.tsx
+++ b/frontend/src/components/feed/feed-page-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { CreatePostForm } from '@/components/feed/create-post-form';
 import { PostCard } from '@/components/feed/post-card';
 import { Card } from '@/components/ui/card';
 import { useAuth } from '@/hooks/use-auth';
@@ -91,9 +92,11 @@ export function FeedPageContent() {
           Social feed
         </h1>
         <p className="text-sm leading-6 text-secondary">
-          Linha do tempo read-only com base no contrato real do backend.
+          Timeline do CLUTCH com publicacao integrada ao contrato real do backend.
         </p>
       </header>
+
+      <CreatePostForm userId={userId} />
 
       <div className="space-y-4">
         {feedQuery.data.posts.map((post) => (

--- a/frontend/src/components/feed/feed-page-content.tsx
+++ b/frontend/src/components/feed/feed-page-content.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { CreatePostForm } from '@/components/feed/create-post-form';
+import { InfiniteScroll } from '@/components/feed/infinite-scroll';
 import { PostCard } from '@/components/feed/post-card';
 import { Card } from '@/components/ui/card';
 import { useAuth } from '@/hooks/use-auth';
@@ -28,9 +29,9 @@ function FeedEmptyState() {
     <Card data-testid="feed-empty">
       <div className="space-y-3">
         <p className="text-xs uppercase tracking-[0.35em] text-secondary">Feed</p>
-        <h1 className="font-display text-3xl font-semibold text-primary">
+        <h2 className="font-display text-2xl font-semibold text-primary">
           Nenhum post no feed ainda
-        </h1>
+        </h2>
         <p className="text-sm leading-6 text-secondary">
           Assim que voce e seus amigos publicarem, os posts aparecem aqui.
         </p>
@@ -44,9 +45,9 @@ function FeedErrorState() {
     <Card data-testid="feed-error">
       <div className="space-y-3">
         <p className="text-xs uppercase tracking-[0.35em] text-secondary">Feed</p>
-        <h1 className="font-display text-3xl font-semibold text-primary">
+        <h2 className="font-display text-2xl font-semibold text-primary">
           Nao foi possivel carregar o feed
-        </h1>
+        </h2>
         <p className="text-sm leading-6 text-secondary">
           Tente novamente em alguns instantes.
         </p>
@@ -55,20 +56,33 @@ function FeedErrorState() {
   );
 }
 
+function FeedLoadMoreError() {
+  return (
+    <Card data-testid="feed-load-more-error">
+      <p className="text-sm leading-6 text-status-afk">
+        Nao foi possivel carregar mais posts agora. Role novamente para tentar de novo.
+      </p>
+    </Card>
+  );
+}
+
 export function FeedPageContent() {
   const { status, user } = useAuth();
   const userId = user?.id;
 
-  const feedQuery = useQuery({
+  const feedQuery = useInfiniteQuery({
     queryKey: ['feed', userId],
     enabled: typeof userId === 'string' && userId.length > 0,
-    queryFn: () =>
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
       fetchFeed({
         userId: userId as string,
+        cursor: pageParam,
       }),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
-  if (status === 'loading' || feedQuery.isPending) {
+  if (status === 'loading') {
     return <FeedLoadingState />;
   }
 
@@ -76,13 +90,9 @@ export function FeedPageContent() {
     return <FeedErrorState />;
   }
 
-  if (feedQuery.isError) {
-    return <FeedErrorState />;
-  }
-
-  if (feedQuery.data.posts.length === 0) {
-    return <FeedEmptyState />;
-  }
+  const posts = feedQuery.data?.pages.flatMap((page) => page.posts) ?? [];
+  const showInitialLoading = feedQuery.isPending && posts.length === 0;
+  const showInitialError = feedQuery.isError && posts.length === 0;
 
   return (
     <section className="space-y-section" data-testid="feed-success">
@@ -92,17 +102,38 @@ export function FeedPageContent() {
           Social feed
         </h1>
         <p className="text-sm leading-6 text-secondary">
-          Timeline do CLUTCH com publicacao integrada ao contrato real do backend.
+          Timeline do CLUTCH com publicacao, reactions e comentarios ligados ao
+          contrato real do backend.
         </p>
       </header>
 
       <CreatePostForm userId={userId} />
 
-      <div className="space-y-4">
-        {feedQuery.data.posts.map((post) => (
-          <PostCard key={post.id} post={post} />
-        ))}
-      </div>
+      {showInitialLoading ? <FeedLoadingState /> : null}
+      {showInitialError ? <FeedErrorState /> : null}
+      {!showInitialLoading && !showInitialError && posts.length === 0 ? (
+        <FeedEmptyState />
+      ) : null}
+
+      {posts.length > 0 ? (
+        <div className="space-y-4">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+      ) : null}
+
+      {feedQuery.isError && posts.length > 0 ? <FeedLoadMoreError /> : null}
+
+      {posts.length > 0 ? (
+        <InfiniteScroll
+          hasNextPage={Boolean(feedQuery.hasNextPage)}
+          isFetchingNextPage={feedQuery.isFetchingNextPage}
+          onLoadMore={() => {
+            void feedQuery.fetchNextPage();
+          }}
+        />
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/components/feed/game-context-badge.tsx
+++ b/frontend/src/components/feed/game-context-badge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@/components/ui/badge';
+import { type FeedGameContext } from '@/schemas/feed';
+
+type GameContextBadgeProps = {
+  gameContext: FeedGameContext;
+};
+
+export function GameContextBadge({ gameContext }: GameContextBadgeProps) {
+  const gameName = gameContext.gameName ?? 'jogo nao identificado';
+  const platformLabel = gameContext.platform
+    ? ` • ${gameContext.platform}`
+    : '';
+
+  return (
+    <Badge
+      tone="accent"
+      className="normal-case tracking-[0.02em] text-accent-cyan"
+    >
+      Jogando {gameName}
+      {platformLabel}
+    </Badge>
+  );
+}

--- a/frontend/src/components/feed/infinite-scroll.tsx
+++ b/frontend/src/components/feed/infinite-scroll.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type InfiniteScrollProps = {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+};
+
+export function InfiniteScroll({
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: InfiniteScrollProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const latestStateRef = useRef({
+    hasNextPage,
+    isFetchingNextPage,
+    onLoadMore,
+  });
+
+  useEffect(() => {
+    latestStateRef.current = {
+      hasNextPage,
+      isFetchingNextPage,
+      onLoadMore,
+    };
+  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+
+    if (!sentinel || typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      const state = latestStateRef.current;
+
+      if (!entry?.isIntersecting || state.isFetchingNextPage || !state.hasNextPage) {
+        return;
+      }
+
+      state.onLoadMore();
+    }, {
+      rootMargin: '160px 0px',
+      threshold: 0.1,
+    });
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  if (!hasNextPage && !isFetchingNextPage) {
+    return (
+      <div className="py-4 text-center text-xs uppercase tracking-[0.28em] text-muted">
+        Voce chegou ao fim do feed
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={sentinelRef}
+      data-testid="feed-infinite-scroll"
+      className="py-4 text-center text-xs uppercase tracking-[0.28em] text-secondary"
+    >
+      {isFetchingNextPage ? 'Carregando mais posts...' : 'Role para carregar mais'}
+    </div>
+  );
+}

--- a/frontend/src/components/feed/post-card.tsx
+++ b/frontend/src/components/feed/post-card.tsx
@@ -1,7 +1,16 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { CommentSection } from '@/components/feed/comment-section';
+import { GameContextBadge } from '@/components/feed/game-context-badge';
+import { ReactionBar } from '@/components/feed/reaction-bar';
+import { useAuth } from '@/hooks/use-auth';
 import { type FeedPost } from '@/schemas/feed';
+import { deletePost, FeedRequestError } from '@/services/feed';
 
 type PostCardProps = {
   post: FeedPost;
@@ -21,15 +30,33 @@ function formatPostDate(value: string): string {
 }
 
 export function PostCard({ post }: PostCardProps) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
   const displayName =
     post.author.profile?.displayName && post.author.profile.displayName.length > 0
       ? post.author.profile.displayName
       : post.author.username;
   const avatarFallback = post.author.username.slice(0, 2).toUpperCase();
+  const isOwnPost = user?.id === post.author.id;
+
+  const deletePostMutation = useMutation({
+    mutationFn: deletePost,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['feed'],
+      });
+    },
+  });
+
+  const deleteErrorMessage = deletePostMutation.error instanceof FeedRequestError
+    ? deletePostMutation.error.message
+    : deletePostMutation.isError
+      ? 'Nao foi possivel excluir este post agora.'
+      : null;
 
   return (
     <Card data-testid="feed-post-card">
-      <article className="space-y-4">
+      <article className="space-y-5">
         <header className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 items-start gap-3">
             <Avatar
@@ -61,17 +88,42 @@ export function PostCard({ post }: PostCardProps) {
         ) : null}
 
         {post.gameContext ? (
-          <p className="text-xs text-secondary">
-            Jogando {post.gameContext.gameName || 'desconhecido'} em{' '}
-            {post.gameContext.platform || 'plataforma nao informada'}
-          </p>
+          <GameContextBadge gameContext={post.gameContext} />
         ) : null}
 
-        <footer className="flex flex-wrap items-center justify-between gap-2 text-xs text-secondary">
-          <span>{formatPostDate(post.createdAt)}</span>
-          <span>
-            {post._count.interactions} reacoes • {post._count.comments} comentarios
-          </span>
+        <ReactionBar
+          postId={post.id}
+          initialReactionCount={post._count.interactions}
+          canInteract={!isOwnPost}
+        />
+
+        <CommentSection
+          postId={post.id}
+          initialCommentCount={post._count.comments}
+        />
+
+        <footer className="space-y-3 border-t border-border/70 pt-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-secondary">
+            <span>{formatPostDate(post.createdAt)}</span>
+            {isOwnPost ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={deletePostMutation.isPending}
+                onClick={() => {
+                  deletePostMutation.mutate(post.id);
+                }}
+              >
+                {deletePostMutation.isPending ? 'Excluindo...' : 'Excluir post'}
+              </Button>
+            ) : null}
+          </div>
+
+          {deleteErrorMessage ? (
+            <p role="alert" className="text-sm text-status-afk">
+              {deleteErrorMessage}
+            </p>
+          ) : null}
         </footer>
       </article>
     </Card>

--- a/frontend/src/components/feed/reaction-bar.tsx
+++ b/frontend/src/components/feed/reaction-bar.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { type InteractionType } from '@/schemas/feed';
+import { FeedRequestError, togglePostInteraction } from '@/services/feed';
+
+type ReactionBarProps = {
+  postId: string;
+  initialReactionCount: number;
+  canInteract: boolean;
+};
+
+const reactionOptions: Array<{
+  type: InteractionType;
+  label: string;
+  emoji: string;
+}> = [
+  { type: 'GG', label: 'GG', emoji: '⚡' },
+  { type: 'F', label: 'F', emoji: '💀' },
+  { type: 'CLAP', label: 'Clap', emoji: '👏' },
+  { type: 'HYPE', label: 'Hype', emoji: '🔥' },
+  { type: 'LIKE', label: 'Like', emoji: '❤️' },
+];
+
+export function ReactionBar({
+  postId,
+  initialReactionCount,
+  canInteract,
+}: ReactionBarProps) {
+  const queryClient = useQueryClient();
+  const [reactionCount, setReactionCount] = useState(initialReactionCount);
+  const [selectedTypes, setSelectedTypes] = useState<InteractionType[]>([]);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setReactionCount(initialReactionCount);
+  }, [initialReactionCount]);
+
+  useEffect(() => {
+    setSelectedTypes([]);
+  }, [postId]);
+
+  const toggleReactionMutation = useMutation({
+    mutationFn: togglePostInteraction,
+    onSuccess: async ({ added }, variables) => {
+      setServerError(null);
+      setReactionCount((current) => Math.max(0, current + (added ? 1 : -1)));
+      setSelectedTypes((current) => {
+        const next = new Set(current);
+
+        if (added) {
+          next.add(variables.type);
+        } else {
+          next.delete(variables.type);
+        }
+
+        return Array.from(next);
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: ['feed'],
+      });
+    },
+    onError: (error) => {
+      if (error instanceof FeedRequestError) {
+        setServerError(error.message);
+        return;
+      }
+
+      setServerError('Nao foi possivel reagir a este post agora.');
+    },
+  });
+
+  return (
+    <div className="space-y-3" data-testid="reaction-bar">
+      <div className="flex flex-wrap items-center gap-2">
+        {reactionOptions.map((option) => {
+          const isSelected = selectedTypes.includes(option.type);
+
+          return (
+            <Button
+              key={option.type}
+              size="sm"
+              variant={isSelected ? 'primary' : 'secondary'}
+              disabled={!canInteract || toggleReactionMutation.isPending}
+              aria-pressed={isSelected}
+              onClick={() => {
+                setServerError(null);
+                toggleReactionMutation.mutate({
+                  postId,
+                  type: option.type,
+                });
+              }}
+            >
+              <span aria-hidden="true">{option.emoji}</span>
+              <span>{option.label}</span>
+            </Button>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-secondary">
+        <span>{reactionCount} reacoes no total</span>
+        {!canInteract ? (
+          <span>Voce nao pode reagir ao proprio post.</span>
+        ) : null}
+      </div>
+
+      {serverError ? (
+        <p role="alert" className="text-sm text-status-afk">
+          {serverError}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/schemas/feed.ts
+++ b/frontend/src/schemas/feed.ts
@@ -7,6 +7,29 @@ export const feedPostTypeSchema = z.enum([
   'GAME_SESSION',
 ]);
 
+export const createPostRequestSchema = z
+  .object({
+    contentText: z.string().trim().max(500, 'O post aceita no maximo 500 caracteres.'),
+    mediaUrl: z
+      .string()
+      .trim()
+      .url('Digite uma URL de midia valida.')
+      .or(z.literal('')),
+    type: feedPostTypeSchema,
+  })
+  .superRefine((value, context) => {
+    const hasText = value.contentText.trim().length > 0;
+    const hasMedia = value.mediaUrl.trim().length > 0;
+
+    if (!hasText && !hasMedia) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Adicione texto ou uma URL de midia para publicar.',
+        path: ['contentText'],
+      });
+    }
+  });
+
 export const feedPostSchema = z.object({
   id: z.string().min(1),
   contentText: z.string().nullable(),
@@ -42,5 +65,17 @@ export const feedResponseSchema = z.object({
   nextCursor: z.string().nullable(),
 });
 
+export const createPostResponseSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  contentText: z.string().nullable(),
+  mediaUrl: z.string().nullable(),
+  type: feedPostTypeSchema,
+  gameContext: z.record(z.unknown()).nullable().optional(),
+  createdAt: z.string().min(1),
+});
+
 export type FeedPost = z.infer<typeof feedPostSchema>;
 export type FeedResponse = z.infer<typeof feedResponseSchema>;
+export type CreatePostRequest = z.infer<typeof createPostRequestSchema>;
+export type CreatePostResponse = z.infer<typeof createPostResponseSchema>;

--- a/frontend/src/schemas/feed.ts
+++ b/frontend/src/schemas/feed.ts
@@ -7,6 +7,26 @@ export const feedPostTypeSchema = z.enum([
   'GAME_SESSION',
 ]);
 
+export const interactionTypeSchema = z.enum([
+  'LIKE',
+  'GG',
+  'F',
+  'CLAP',
+  'HYPE',
+]);
+
+export const commentContentSchema = z
+  .string()
+  .trim()
+  .min(1, 'Digite um comentario antes de enviar.')
+  .max(300, 'O comentario aceita no maximo 300 caracteres.');
+
+export const gameContextSchema = z.object({
+  gameName: z.string().nullable(),
+  platform: z.string().nullable(),
+  capturedAt: z.string().min(1),
+});
+
 export const createPostRequestSchema = z
   .object({
     contentText: z.string().trim().max(500, 'O post aceita no maximo 500 caracteres.'),
@@ -35,13 +55,7 @@ export const feedPostSchema = z.object({
   contentText: z.string().nullable(),
   mediaUrl: z.string().nullable(),
   type: feedPostTypeSchema,
-  gameContext: z
-    .object({
-      gameName: z.string().nullable(),
-      platform: z.string().nullable(),
-      capturedAt: z.string().min(1),
-    })
-    .nullable(),
+  gameContext: gameContextSchema.nullable(),
   createdAt: z.string().min(1),
   author: z.object({
     id: z.string().min(1),
@@ -65,6 +79,67 @@ export const feedResponseSchema = z.object({
   nextCursor: z.string().nullable(),
 });
 
+export const createPostCommentRequestSchema = z.object({
+  postId: z.string().min(1),
+  content: commentContentSchema,
+  parentId: z.string().min(1).optional(),
+});
+
+export const createPostCommentResponseSchema = z.object({
+  id: z.string().min(1),
+  postId: z.string().min(1),
+  userId: z.string().min(1),
+  parentId: z.string().nullable(),
+  content: z.string().min(1),
+  createdAt: z.string().min(1),
+});
+
+export const postCommentReplySchema = z.object({
+  id: z.string().min(1),
+  content: z.string().min(1),
+  parentId: z.string().nullable(),
+  createdAt: z.string().min(1),
+  author: z.object({
+    id: z.string().min(1),
+    username: z.string().min(1),
+    profile: z
+      .object({
+        displayName: z.string().nullable(),
+        avatarUrl: z.string().nullable(),
+      })
+      .nullable(),
+  }),
+  replies: z.array(z.never()),
+});
+
+export const postCommentSchema = z.object({
+  id: z.string().min(1),
+  content: z.string().min(1),
+  parentId: z.string().nullable(),
+  createdAt: z.string().min(1),
+  author: z.object({
+    id: z.string().min(1),
+    username: z.string().min(1),
+    profile: z
+      .object({
+        displayName: z.string().nullable(),
+        avatarUrl: z.string().nullable(),
+      })
+      .nullable(),
+  }),
+  replies: z.array(postCommentReplySchema),
+});
+
+export const postCommentsResponseSchema = z.array(postCommentSchema);
+
+export const toggleInteractionRequestSchema = z.object({
+  type: interactionTypeSchema,
+});
+
+export const toggleInteractionResponseSchema = z.object({
+  added: z.boolean(),
+});
+
 export const createPostResponseSchema = z.object({
   id: z.string().min(1),
   userId: z.string().min(1),
@@ -75,7 +150,18 @@ export const createPostResponseSchema = z.object({
   createdAt: z.string().min(1),
 });
 
+export const deletePostResponseSchema = z.object({
+  message: z.string().min(1),
+});
+
 export type FeedPost = z.infer<typeof feedPostSchema>;
 export type FeedResponse = z.infer<typeof feedResponseSchema>;
 export type CreatePostRequest = z.infer<typeof createPostRequestSchema>;
 export type CreatePostResponse = z.infer<typeof createPostResponseSchema>;
+export type FeedGameContext = z.infer<typeof gameContextSchema>;
+export type InteractionType = z.infer<typeof interactionTypeSchema>;
+export type CreatePostCommentRequest = z.infer<typeof createPostCommentRequestSchema>;
+export type CreatePostCommentResponse = z.infer<typeof createPostCommentResponseSchema>;
+export type PostComment = z.infer<typeof postCommentSchema>;
+export type ToggleInteractionRequest = z.infer<typeof toggleInteractionRequestSchema>;
+export type ToggleInteractionResponse = z.infer<typeof toggleInteractionResponseSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -8,5 +8,9 @@ export {
   registerRequestSchema,
   registerSessionSchema,
 } from './auth';
-export { feedResponseSchema } from './feed';
+export {
+  createPostRequestSchema,
+  createPostResponseSchema,
+  feedResponseSchema,
+} from './feed';
 export { profileResponseSchema } from './profile';

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -9,8 +9,17 @@ export {
   registerSessionSchema,
 } from './auth';
 export {
+  commentContentSchema,
   createPostRequestSchema,
+  createPostCommentRequestSchema,
+  createPostCommentResponseSchema,
   createPostResponseSchema,
   feedResponseSchema,
+  deletePostResponseSchema,
+  interactionTypeSchema,
+  postCommentsResponseSchema,
+  postCommentSchema,
+  toggleInteractionRequestSchema,
+  toggleInteractionResponseSchema,
 } from './feed';
 export { profileResponseSchema } from './profile';

--- a/frontend/src/services/feed.ts
+++ b/frontend/src/services/feed.ts
@@ -1,5 +1,12 @@
 import { apiRequest } from '@/lib/api';
-import { feedResponseSchema, type FeedResponse } from '@/schemas/feed';
+import {
+  createPostRequestSchema,
+  createPostResponseSchema,
+  feedResponseSchema,
+  type CreatePostRequest,
+  type CreatePostResponse,
+  type FeedResponse,
+} from '@/schemas/feed';
 
 type ErrorResponse = {
   message?: string;
@@ -73,4 +80,30 @@ export async function fetchFeed(input: FeedRequestInput): Promise<FeedResponse> 
   }
 
   return feedResponseSchema.parse(payload);
+}
+
+export async function createPost(
+  input: CreatePostRequest,
+): Promise<CreatePostResponse> {
+  const payload = createPostRequestSchema.parse(input);
+  const normalizedPayload = {
+    contentText: payload.contentText.trim() || undefined,
+    mediaUrl: payload.mediaUrl.trim() || undefined,
+    type: payload.type,
+  };
+
+  const response = await apiRequest('/posts', {
+    method: 'POST',
+    body: normalizedPayload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FeedRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel publicar agora.'),
+    );
+  }
+
+  return createPostResponseSchema.parse(responsePayload);
 }

--- a/frontend/src/services/feed.ts
+++ b/frontend/src/services/feed.ts
@@ -1,11 +1,22 @@
 import { apiRequest } from '@/lib/api';
 import {
+  createPostCommentRequestSchema,
+  createPostCommentResponseSchema,
   createPostRequestSchema,
   createPostResponseSchema,
+  deletePostResponseSchema,
   feedResponseSchema,
+  postCommentsResponseSchema,
+  toggleInteractionRequestSchema,
+  toggleInteractionResponseSchema,
   type CreatePostRequest,
+  type CreatePostCommentRequest,
+  type CreatePostCommentResponse,
   type CreatePostResponse,
   type FeedResponse,
+  type InteractionType,
+  type PostComment,
+  type ToggleInteractionResponse,
 } from '@/schemas/feed';
 
 type ErrorResponse = {
@@ -106,4 +117,79 @@ export async function createPost(
   }
 
   return createPostResponseSchema.parse(responsePayload);
+}
+
+export async function togglePostInteraction(input: {
+  postId: string;
+  type: InteractionType;
+}): Promise<ToggleInteractionResponse> {
+  const payload = toggleInteractionRequestSchema.parse({ type: input.type });
+
+  const response = await apiRequest(`/posts/${encodeURIComponent(input.postId)}/interactions`, {
+    method: 'POST',
+    body: payload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FeedRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel atualizar a reacao agora.'),
+    );
+  }
+
+  return toggleInteractionResponseSchema.parse(responsePayload);
+}
+
+export async function fetchPostComments(postId: string): Promise<PostComment[]> {
+  const response = await apiRequest(`/posts/comments/${encodeURIComponent(postId)}`, {
+    method: 'GET',
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FeedRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel carregar os comentarios agora.'),
+    );
+  }
+
+  return postCommentsResponseSchema.parse(responsePayload);
+}
+
+export async function createPostComment(
+  input: CreatePostCommentRequest,
+): Promise<CreatePostCommentResponse> {
+  const payload = createPostCommentRequestSchema.parse(input);
+
+  const response = await apiRequest('/posts/comments', {
+    method: 'POST',
+    body: payload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FeedRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel enviar o comentario agora.'),
+    );
+  }
+
+  return createPostCommentResponseSchema.parse(responsePayload);
+}
+
+export async function deletePost(postId: string): Promise<void> {
+  const response = await apiRequest(`/posts/${encodeURIComponent(postId)}`, {
+    method: 'DELETE',
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FeedRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel excluir o post agora.'),
+    );
+  }
+
+  deletePostResponseSchema.parse(responsePayload);
 }

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,5 +1,5 @@
 export { buildApiUrl } from './http/client';
 export { login, register, AuthRequestError } from './auth';
 export { fetchAuthSession, logoutAuthSession } from './session';
-export { fetchFeed, FeedRequestError } from './feed';
+export { createPost, fetchFeed, FeedRequestError } from './feed';
 export { fetchProfileByUsername, ProfileRequestError } from './profile';

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,5 +1,13 @@
 export { buildApiUrl } from './http/client';
 export { login, register, AuthRequestError } from './auth';
 export { fetchAuthSession, logoutAuthSession } from './session';
-export { createPost, fetchFeed, FeedRequestError } from './feed';
+export {
+  createPost,
+  createPostComment,
+  deletePost,
+  fetchFeed,
+  fetchPostComments,
+  FeedRequestError,
+  togglePostInteraction,
+} from './feed';
 export { fetchProfileByUsername, ProfileRequestError } from './profile';

--- a/frontend/tests/unit/components/comment-section.test.tsx
+++ b/frontend/tests/unit/components/comment-section.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommentSection } from '@/components/feed/comment-section';
+import {
+  createPostComment,
+  fetchPostComments,
+} from '@/services/feed';
+
+vi.mock('@/services/feed', () => ({
+  fetchPostComments: vi.fn(),
+  createPostComment: vi.fn(),
+}));
+
+const mockedFetchPostComments = vi.mocked(fetchPostComments);
+const mockedCreatePostComment = vi.mocked(createPostComment);
+
+function renderCommentSection(initialCommentCount = 1) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CommentSection
+        postId="post-1"
+        initialCommentCount={initialCommentCount}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CommentSection', () => {
+  beforeEach(() => {
+    mockedFetchPostComments.mockReset();
+    mockedCreatePostComment.mockReset();
+  });
+
+  it('loads and renders comments when opened', async () => {
+    mockedFetchPostComments.mockResolvedValue([
+      {
+        id: 'comment-1',
+        content: 'Boa run!',
+        parentId: null,
+        createdAt: '2026-03-31T10:00:00.000Z',
+        author: {
+          id: 'user-2',
+          username: 'pixelsamurai',
+          profile: {
+            displayName: 'Pixel Samurai',
+            avatarUrl: null,
+          },
+        },
+        replies: [],
+      },
+    ]);
+
+    renderCommentSection(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir comentarios/i }));
+    expect(await screen.findByText(/boa run!/i)).toBeInTheDocument();
+    expect(mockedFetchPostComments).toHaveBeenCalledWith('post-1');
+  });
+
+  it('creates a top-level comment', async () => {
+    mockedFetchPostComments.mockResolvedValue([]);
+    mockedCreatePostComment.mockResolvedValue({
+      id: 'comment-2',
+      postId: 'post-1',
+      userId: 'user-1',
+      parentId: null,
+      content: 'Novo comentario',
+      createdAt: '2026-03-31T10:05:00.000Z',
+    });
+
+    renderCommentSection(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir comentarios/i }));
+    await screen.findByText(/ainda nao existem comentarios/i);
+
+    fireEvent.change(screen.getByPlaceholderText(/escreva um comentario/i), {
+      target: { value: 'Novo comentario' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^comentar$/i }));
+
+    await waitFor(() => {
+      expect(mockedCreatePostComment).toHaveBeenCalled();
+    });
+    expect(mockedCreatePostComment.mock.calls[0]?.[0]).toEqual({
+      postId: 'post-1',
+      content: 'Novo comentario',
+      parentId: undefined,
+    });
+  });
+
+  it('creates a reply for a top-level comment', async () => {
+    mockedFetchPostComments.mockResolvedValue([
+      {
+        id: 'comment-1',
+        content: 'Comentario pai',
+        parentId: null,
+        createdAt: '2026-03-31T10:00:00.000Z',
+        author: {
+          id: 'user-2',
+          username: 'pixelsamurai',
+          profile: {
+            displayName: 'Pixel Samurai',
+            avatarUrl: null,
+          },
+        },
+        replies: [],
+      },
+    ]);
+    mockedCreatePostComment.mockResolvedValue({
+      id: 'reply-1',
+      postId: 'post-1',
+      userId: 'user-1',
+      parentId: 'comment-1',
+      content: 'Reply de teste',
+      createdAt: '2026-03-31T10:07:00.000Z',
+    });
+
+    renderCommentSection(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir comentarios/i }));
+    await screen.findByText(/comentario pai/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /responder/i }));
+    fireEvent.change(screen.getByPlaceholderText(/responder pixel samurai/i), {
+      target: { value: 'Reply de teste' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /enviar reply/i }));
+
+    await waitFor(() => {
+      expect(mockedCreatePostComment).toHaveBeenCalled();
+    });
+    expect(mockedCreatePostComment.mock.calls[0]?.[0]).toEqual({
+      postId: 'post-1',
+      content: 'Reply de teste',
+      parentId: 'comment-1',
+    });
+  });
+});

--- a/frontend/tests/unit/components/create-post-form.test.tsx
+++ b/frontend/tests/unit/components/create-post-form.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreatePostForm } from '@/components/feed/create-post-form';
+import { createPost, FeedRequestError } from '@/services/feed';
+
+vi.mock('@/services/feed', () => ({
+  createPost: vi.fn(),
+  FeedRequestError: class FeedRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'FeedRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedCreatePost = vi.mocked(createPost);
+
+function renderCreatePostForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CreatePostForm userId="user-1" />
+    </QueryClientProvider>,
+  );
+
+  return { invalidateQueriesSpy };
+}
+
+describe('CreatePostForm', () => {
+  beforeEach(() => {
+    mockedCreatePost.mockReset();
+  });
+
+  it('renders the form fields', () => {
+    renderCreatePostForm();
+
+    expect(
+      screen.getByRole('heading', { name: /compartilhe algo com sua timeline/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /publicar post/i })).toBeInTheDocument();
+  });
+
+  it('validates when both content and media are empty', async () => {
+    renderCreatePostForm();
+
+    fireEvent.click(screen.getByRole('button', { name: /publicar post/i }));
+
+    expect(
+      await screen.findByText(/adicione texto ou uma url de midia para publicar/i),
+    ).toBeInTheDocument();
+    expect(mockedCreatePost).not.toHaveBeenCalled();
+  });
+
+  it('submits successfully and invalidates the feed query', async () => {
+    mockedCreatePost.mockResolvedValue({
+      id: 'post-10',
+      userId: 'user-1',
+      contentText: 'Novo post',
+      mediaUrl: null,
+      type: 'TEXT',
+      gameContext: null,
+      createdAt: '2026-03-31T12:00:00.000Z',
+    });
+
+    const { invalidateQueriesSpy } = renderCreatePostForm();
+
+    fireEvent.change(screen.getByLabelText(/conteudo/i), {
+      target: { value: 'Novo post' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /publicar post/i }));
+
+    await waitFor(() => {
+      expect(mockedCreatePost).toHaveBeenCalled();
+    });
+    expect(mockedCreatePost.mock.calls[0]?.[0]).toEqual({
+      contentText: 'Novo post',
+      mediaUrl: '',
+      type: 'TEXT',
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ['feed', 'user-1'],
+      });
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /post publicado com sucesso/i,
+    );
+  });
+
+  it('renders backend errors on submit failure', async () => {
+    mockedCreatePost.mockRejectedValue(
+      new FeedRequestError(400, 'Post precisa ter texto ou midia.'),
+    );
+
+    renderCreatePostForm();
+
+    fireEvent.change(screen.getByLabelText(/conteudo/i), {
+      target: { value: 'Falha de teste' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /publicar post/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /post precisa ter texto ou midia/i,
+    );
+  });
+});

--- a/frontend/tests/unit/components/feed-page-content.test.tsx
+++ b/frontend/tests/unit/components/feed-page-content.test.tsx
@@ -3,11 +3,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FeedPageContent } from '@/components/feed/feed-page-content';
-import { fetchFeed } from '@/services/feed';
+import { createPost, fetchFeed } from '@/services/feed';
 import { useAuth } from '@/hooks/use-auth';
 
 vi.mock('@/services/feed', () => ({
   fetchFeed: vi.fn(),
+  createPost: vi.fn(),
 }));
 
 vi.mock('@/hooks/use-auth', () => ({
@@ -15,6 +16,7 @@ vi.mock('@/hooks/use-auth', () => ({
 }));
 
 const mockedFetchFeed = vi.mocked(fetchFeed);
+const mockedCreatePost = vi.mocked(createPost);
 const mockedUseAuth = vi.mocked(useAuth);
 
 function renderWithQuery(ui: ReactElement) {
@@ -34,6 +36,7 @@ function renderWithQuery(ui: ReactElement) {
 describe('FeedPageContent', () => {
   beforeEach(() => {
     mockedFetchFeed.mockReset();
+    mockedCreatePost.mockReset();
     mockedUseAuth.mockReset();
   });
 
@@ -85,6 +88,15 @@ describe('FeedPageContent', () => {
       ],
       nextCursor: null,
     });
+    mockedCreatePost.mockResolvedValue({
+      id: 'post-created',
+      userId: 'user-1',
+      contentText: 'Novo post',
+      mediaUrl: null,
+      type: 'TEXT',
+      gameContext: null,
+      createdAt: '2026-03-31T12:00:00.000Z',
+    });
 
     renderWithQuery(<FeedPageContent />);
 
@@ -92,6 +104,9 @@ describe('FeedPageContent', () => {
       expect(screen.getByTestId('feed-success')).toBeInTheDocument();
     });
 
+    expect(
+      screen.getByRole('heading', { name: /compartilhe algo com sua timeline/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText(/primeiro post/i)).toBeInTheDocument();
     expect(screen.getAllByTestId('feed-post-card')).toHaveLength(1);
   });

--- a/frontend/tests/unit/components/feed-page-content.test.tsx
+++ b/frontend/tests/unit/components/feed-page-content.test.tsx
@@ -1,22 +1,53 @@
 import React, { type ReactElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FeedPageContent } from '@/components/feed/feed-page-content';
-import { createPost, fetchFeed } from '@/services/feed';
+import { fetchFeed } from '@/services/feed';
 import { useAuth } from '@/hooks/use-auth';
 
 vi.mock('@/services/feed', () => ({
   fetchFeed: vi.fn(),
-  createPost: vi.fn(),
 }));
 
 vi.mock('@/hooks/use-auth', () => ({
   useAuth: vi.fn(),
 }));
 
+vi.mock('@/components/feed/create-post-form', () => ({
+  CreatePostForm: ({ userId }: { userId: string }) => (
+    <div data-testid="create-post-form">create-post:{userId}</div>
+  ),
+}));
+
+vi.mock('@/components/feed/post-card', () => ({
+  PostCard: ({ post }: { post: { id: string; contentText: string | null } }) => (
+    <article data-testid="feed-post-card">{post.contentText ?? post.id}</article>
+  ),
+}));
+
+vi.mock('@/components/feed/infinite-scroll', () => ({
+  InfiniteScroll: ({
+    hasNextPage,
+    onLoadMore,
+  }: {
+    hasNextPage: boolean;
+    onLoadMore: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="feed-infinite-scroll"
+      disabled={!hasNextPage}
+      onClick={() => {
+        onLoadMore();
+      }}
+    >
+      load-more
+    </button>
+  ),
+}));
+
 const mockedFetchFeed = vi.mocked(fetchFeed);
-const mockedCreatePost = vi.mocked(createPost);
 const mockedUseAuth = vi.mocked(useAuth);
 
 function renderWithQuery(ui: ReactElement) {
@@ -33,14 +64,37 @@ function renderWithQuery(ui: ReactElement) {
   );
 }
 
+function buildPost(id: string, contentText: string) {
+  return {
+    id,
+    contentText,
+    mediaUrl: null,
+    type: 'TEXT' as const,
+    gameContext: null,
+    createdAt: '2026-03-31T10:00:00.000Z',
+    author: {
+      id: `author-${id}`,
+      username: `user-${id}`,
+      profile: {
+        displayName: `User ${id}`,
+        avatarUrl: null,
+        accentColor: '#06B6D4',
+      },
+    },
+    _count: {
+      interactions: 0,
+      comments: 0,
+    },
+  };
+}
+
 describe('FeedPageContent', () => {
   beforeEach(() => {
     mockedFetchFeed.mockReset();
-    mockedCreatePost.mockReset();
     mockedUseAuth.mockReset();
   });
 
-  it('renders loading state', () => {
+  it('renders loading state while auth is loading', () => {
     mockedUseAuth.mockReturnValue({
       status: 'loading',
       user: null,
@@ -63,55 +117,19 @@ describe('FeedPageContent', () => {
       logout: vi.fn(),
     });
     mockedFetchFeed.mockResolvedValue({
-      posts: [
-        {
-          id: 'post-1',
-          contentText: 'Primeiro post',
-          mediaUrl: null,
-          type: 'TEXT',
-          gameContext: null,
-          createdAt: '2026-03-31T10:00:00.000Z',
-          author: {
-            id: 'user-2',
-            username: 'pixelsamurai',
-            profile: {
-              displayName: 'Pixel Samurai',
-              avatarUrl: null,
-              accentColor: '#06B6D4',
-            },
-          },
-          _count: {
-            interactions: 3,
-            comments: 2,
-          },
-        },
-      ],
+      posts: [buildPost('post-1', 'Primeiro post')],
       nextCursor: null,
-    });
-    mockedCreatePost.mockResolvedValue({
-      id: 'post-created',
-      userId: 'user-1',
-      contentText: 'Novo post',
-      mediaUrl: null,
-      type: 'TEXT',
-      gameContext: null,
-      createdAt: '2026-03-31T12:00:00.000Z',
     });
 
     renderWithQuery(<FeedPageContent />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('feed-success')).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByRole('heading', { name: /compartilhe algo com sua timeline/i }),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/primeiro post/i)).toBeInTheDocument();
-    expect(screen.getAllByTestId('feed-post-card')).toHaveLength(1);
+    expect(screen.getByTestId('create-post-form')).toHaveTextContent(
+      'create-post:user-1',
+    );
+    expect(await screen.findByText(/primeiro post/i)).toBeInTheDocument();
   });
 
-  it('renders empty state', async () => {
+  it('renders empty state after loading with no posts', async () => {
     mockedUseAuth.mockReturnValue({
       status: 'authenticated',
       user: {
@@ -128,12 +146,11 @@ describe('FeedPageContent', () => {
 
     renderWithQuery(<FeedPageContent />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('feed-empty')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('feed-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('create-post-form')).toBeInTheDocument();
   });
 
-  it('renders generic error state', async () => {
+  it('renders generic error state when initial feed request fails', async () => {
     mockedUseAuth.mockReturnValue({
       status: 'authenticated',
       user: {
@@ -147,8 +164,46 @@ describe('FeedPageContent', () => {
 
     renderWithQuery(<FeedPageContent />);
 
+    expect(await screen.findByTestId('feed-error')).toBeInTheDocument();
+  });
+
+  it('loads the next feed page when pagination asks for more data', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchFeed
+      .mockResolvedValueOnce({
+        posts: [buildPost('post-1', 'Primeiro post')],
+        nextCursor: 'post-1',
+      })
+      .mockResolvedValueOnce({
+        posts: [buildPost('post-2', 'Segundo post')],
+        nextCursor: null,
+      });
+
+    renderWithQuery(<FeedPageContent />);
+
+    expect(await screen.findByText(/primeiro post/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('feed-infinite-scroll'));
+
     await waitFor(() => {
-      expect(screen.getByTestId('feed-error')).toBeInTheDocument();
+      expect(screen.getByText(/segundo post/i)).toBeInTheDocument();
+    });
+
+    expect(mockedFetchFeed).toHaveBeenNthCalledWith(1, {
+      userId: 'user-1',
+      cursor: undefined,
+    });
+    expect(mockedFetchFeed).toHaveBeenNthCalledWith(2, {
+      userId: 'user-1',
+      cursor: 'post-1',
     });
   });
 });

--- a/frontend/tests/unit/components/reaction-bar.test.tsx
+++ b/frontend/tests/unit/components/reaction-bar.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReactionBar } from '@/components/feed/reaction-bar';
+import { FeedRequestError, togglePostInteraction } from '@/services/feed';
+
+vi.mock('@/services/feed', () => ({
+  togglePostInteraction: vi.fn(),
+  FeedRequestError: class FeedRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'FeedRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedTogglePostInteraction = vi.mocked(togglePostInteraction);
+
+function renderReactionBar(canInteract = true) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ReactionBar
+        postId="post-1"
+        initialReactionCount={2}
+        canInteract={canInteract}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { invalidateQueriesSpy };
+}
+
+describe('ReactionBar', () => {
+  beforeEach(() => {
+    mockedTogglePostInteraction.mockReset();
+  });
+
+  it('toggles a reaction and updates the total count', async () => {
+    mockedTogglePostInteraction.mockResolvedValue({ added: true });
+    const { invalidateQueriesSpy } = renderReactionBar();
+
+    fireEvent.click(screen.getByRole('button', { name: /gg/i }));
+
+    await waitFor(() => {
+      expect(mockedTogglePostInteraction).toHaveBeenCalled();
+    });
+    expect(mockedTogglePostInteraction.mock.calls[0]?.[0]).toEqual({
+      postId: 'post-1',
+      type: 'GG',
+    });
+
+    expect(await screen.findByText(/3 reacoes no total/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /gg/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ['feed'],
+      });
+    });
+  });
+
+  it('renders backend errors from reaction toggle', async () => {
+    mockedTogglePostInteraction.mockRejectedValue(
+      new FeedRequestError(400, 'Voce nao pode reagir ao proprio post.'),
+    );
+
+    renderReactionBar();
+
+    fireEvent.click(screen.getByRole('button', { name: /gg/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /voce nao pode reagir ao proprio post/i,
+    );
+  });
+
+  it('disables reaction buttons when the user cannot interact', () => {
+    renderReactionBar(false);
+
+    expect(screen.getByRole('button', { name: /gg/i })).toBeDisabled();
+    expect(screen.getByText(/voce nao pode reagir ao proprio post/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/services/feed.test.ts
+++ b/frontend/tests/unit/services/feed.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiRequest } from '@/lib/api';
-import { fetchFeed } from '@/services/feed';
+import { createPost, fetchFeed } from '@/services/feed';
 
 vi.mock('@/lib/api', () => ({
   apiRequest: vi.fn(),
@@ -93,6 +93,67 @@ describe('feed service', () => {
       name: 'FeedRequestError',
       status: 500,
       message: 'Falha ao carregar feed.',
+    });
+  });
+
+  it('creates a post with the real backend payload', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'post-10',
+          userId: 'user-1',
+          contentText: 'Novo post',
+          mediaUrl: null,
+          type: 'TEXT',
+          gameContext: null,
+          createdAt: '2026-03-31T12:00:00.000Z',
+        }),
+        {
+          status: 201,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const response = await createPost({
+      contentText: 'Novo post',
+      mediaUrl: '',
+      type: 'TEXT',
+    });
+
+    expect(response.id).toBe('post-10');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/posts', {
+      method: 'POST',
+      body: {
+        contentText: 'Novo post',
+        mediaUrl: undefined,
+        type: 'TEXT',
+      },
+    });
+  });
+
+  it('throws when post creation fails', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Post precisa ter texto ou midia.' }), {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await expect(
+      createPost({
+        contentText: 'Post invalido',
+        mediaUrl: '',
+        type: 'TEXT',
+      }),
+    ).rejects.toMatchObject({
+      name: 'FeedRequestError',
+      status: 400,
+      message: 'Post precisa ter texto ou midia.',
     });
   });
 });

--- a/frontend/tests/unit/services/feed.test.ts
+++ b/frontend/tests/unit/services/feed.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiRequest } from '@/lib/api';
-import { createPost, fetchFeed } from '@/services/feed';
+import {
+  createPost,
+  createPostComment,
+  deletePost,
+  fetchFeed,
+  fetchPostComments,
+  togglePostInteraction,
+} from '@/services/feed';
 
 vi.mock('@/lib/api', () => ({
   apiRequest: vi.fn(),
@@ -59,7 +66,7 @@ describe('feed service', () => {
     });
   });
 
-  it('keeps cursor and limit query params for future pagination', async () => {
+  it('keeps cursor and limit query params for infinite scroll', async () => {
     mockedApiRequest.mockResolvedValue(
       new Response(JSON.stringify({ posts: [], nextCursor: 'post-2' }), {
         status: 200,
@@ -79,7 +86,7 @@ describe('feed service', () => {
     );
   });
 
-  it('throws when backend responds with error', async () => {
+  it('throws when backend responds with feed error', async () => {
     mockedApiRequest.mockResolvedValue(
       new Response(JSON.stringify({ message: 'Falha ao carregar feed.' }), {
         status: 500,
@@ -131,6 +138,138 @@ describe('feed service', () => {
         mediaUrl: undefined,
         type: 'TEXT',
       },
+    });
+  });
+
+  it('toggles a post interaction with the real backend payload', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ added: true }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    const response = await togglePostInteraction({
+      postId: 'post-1',
+      type: 'GG',
+    });
+
+    expect(response.added).toBe(true);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/posts/post-1/interactions', {
+      method: 'POST',
+      body: {
+        type: 'GG',
+      },
+    });
+  });
+
+  it('returns parsed post comments', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: 'comment-1',
+            content: 'Boa run!',
+            parentId: null,
+            createdAt: '2026-03-31T10:00:00.000Z',
+            author: {
+              id: 'user-2',
+              username: 'pixelsamurai',
+              profile: {
+                displayName: 'Pixel Samurai',
+                avatarUrl: null,
+              },
+            },
+            replies: [
+              {
+                id: 'reply-1',
+                content: 'Valeu!',
+                parentId: 'comment-1',
+                createdAt: '2026-03-31T10:02:00.000Z',
+                author: {
+                  id: 'user-1',
+                  username: 'clutchplayer',
+                  profile: {
+                    displayName: 'CLUTCH Player',
+                    avatarUrl: null,
+                  },
+                },
+                replies: [],
+              },
+            ],
+          },
+        ]),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const response = await fetchPostComments('post-1');
+
+    expect(response).toHaveLength(1);
+    expect(response[0]?.replies).toHaveLength(1);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/posts/comments/post-1', {
+      method: 'GET',
+    });
+  });
+
+  it('creates a comment with optional parentId', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'comment-2',
+          postId: 'post-1',
+          userId: 'user-1',
+          parentId: 'comment-1',
+          content: 'Concordo',
+          createdAt: '2026-03-31T10:03:00.000Z',
+        }),
+        {
+          status: 201,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const response = await createPostComment({
+      postId: 'post-1',
+      content: 'Concordo',
+      parentId: 'comment-1',
+    });
+
+    expect(response.parentId).toBe('comment-1');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/posts/comments', {
+      method: 'POST',
+      body: {
+        postId: 'post-1',
+        content: 'Concordo',
+        parentId: 'comment-1',
+      },
+    });
+  });
+
+  it('deletes a post with the real backend contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Post removido.' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    await deletePost('post-1');
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('/posts/post-1', {
+      method: 'DELETE',
     });
   });
 


### PR DESCRIPTION
## Summary
- complete the `/feed` experience with create-post, reactions, comments/replies and delete own post
- migrate the feed to cursor-based infinite scrolling with explicit loading, error and empty states
- add typed feed contracts and UI/service tests for pagination, creation, interactions and comments

## What Was Already In Place
- read-only `/feed` page with authenticated shell integration
- initial `PostCard` rendering wired to `GET /posts/feed/:userId`

## What This PR Adds
- `CreatePostForm` integrated into the clean #92 branch against `develop`
- `ReactionBar` with backend toggle flow and total reaction count updates
- `CommentSection` with comment listing, creation and one-level replies
- `GameContextBadge` rendered from backend-provided `gameContext`
- `InfiniteScroll` wired to the real `nextCursor` contract
- delete action for the current user's own posts

## Contract Notes
- The backend supports total interaction counts on the feed and toggle-by-type via `POST /posts/:id/interactions`.
- The backend does not expose initial per-type counts or the viewer's prior reaction state in the feed payload, so the UI intentionally reflects total count plus session-local toggle state without inventing an unsupported contract.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## Risks
- Richer per-reaction analytics/state still depends on backend contract expansion if we want persistent per-type breakdown in the UI.

Closes #92