### PR TITLE
feat(friends): add friendship flows and request badge

### DIFF
--- a/frontend/src/components/friends/friend-button.tsx
+++ b/frontend/src/components/friends/friend-button.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  acceptFriendRequest,
+  fetchFriends,
+  fetchPendingFriendRequests,
+  FriendsRequestError,
+  removeFriend,
+  sendFriendRequest,
+} from '@/services/friends';
+
+type FriendButtonProps = {
+  targetUserId: string;
+};
+
+export function FriendButton({ targetUserId }: FriendButtonProps) {
+  const queryClient = useQueryClient();
+  const { user, status } = useAuth();
+  const currentUserId = user?.id ?? null;
+  const [localPending, setLocalPending] = useState(false);
+
+  const friendsQuery = useQuery({
+    queryKey: ['friends', currentUserId],
+    queryFn: () => fetchFriends(currentUserId as string),
+    enabled: status === 'authenticated' && typeof currentUserId === 'string',
+  });
+
+  const pendingRequestsQuery = useQuery({
+    queryKey: ['friend-requests', currentUserId],
+    queryFn: () => fetchPendingFriendRequests(currentUserId as string),
+    enabled: status === 'authenticated' && typeof currentUserId === 'string',
+  });
+
+  const incomingRequest = useMemo(
+    () =>
+      pendingRequestsQuery.data?.find(
+        (request) => request.sender.id === targetUserId,
+      ) ?? null,
+    [pendingRequestsQuery.data, targetUserId],
+  );
+
+  const isFriend = useMemo(
+    () => friendsQuery.data?.some((friend) => friend.id === targetUserId) ?? false,
+    [friendsQuery.data, targetUserId],
+  );
+
+  useEffect(() => {
+    if (isFriend || incomingRequest) {
+      setLocalPending(false);
+    }
+  }, [incomingRequest, isFriend]);
+
+  const commonSuccessHandler = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ['friends', currentUserId],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['friend-requests', currentUserId],
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['profile'],
+      }),
+    ]);
+  };
+
+  const sendRequestMutation = useMutation({
+    mutationFn: sendFriendRequest,
+    onSuccess: async () => {
+      setLocalPending(true);
+      await commonSuccessHandler();
+    },
+    onError: (error) => {
+      if (error instanceof FriendsRequestError && error.status === 409) {
+        setLocalPending(true);
+      }
+    },
+  });
+
+  const acceptRequestMutation = useMutation({
+    mutationFn: acceptFriendRequest,
+    onSuccess: async () => {
+      setLocalPending(false);
+      await commonSuccessHandler();
+    },
+  });
+
+  const removeFriendMutation = useMutation({
+    mutationFn: removeFriend,
+    onSuccess: async () => {
+      setLocalPending(false);
+      await commonSuccessHandler();
+    },
+  });
+
+  const activeError =
+    sendRequestMutation.error ??
+    acceptRequestMutation.error ??
+    removeFriendMutation.error;
+  const serverError = activeError instanceof FriendsRequestError
+    ? activeError.message
+    : activeError
+      ? 'Nao foi possivel atualizar a amizade agora.'
+      : null;
+
+  const isBusy =
+    sendRequestMutation.isPending ||
+    acceptRequestMutation.isPending ||
+    removeFriendMutation.isPending;
+
+  if (status !== 'authenticated' || !currentUserId) {
+    return null;
+  }
+
+  if (currentUserId === targetUserId) {
+    return (
+      <Button disabled>
+        Seu perfil
+      </Button>
+    );
+  }
+
+  if (friendsQuery.isPending || pendingRequestsQuery.isPending) {
+    return (
+      <Button disabled>
+        Carregando amizade...
+      </Button>
+    );
+  }
+
+  if (friendsQuery.isError || pendingRequestsQuery.isError) {
+    return (
+      <div className="space-y-2">
+        <Button variant="secondary" disabled>
+          Amizade indisponivel
+        </Button>
+        <p role="alert" className="text-sm text-status-afk">
+          Nao foi possivel resolver o estado de amizade agora.
+        </p>
+      </div>
+    );
+  }
+
+  if (incomingRequest) {
+    return (
+      <div className="space-y-2">
+        <Button
+          disabled={isBusy}
+          onClick={() => {
+            acceptRequestMutation.mutate(incomingRequest.id);
+          }}
+        >
+          {acceptRequestMutation.isPending ? 'Aceitando...' : 'Aceitar pedido'}
+        </Button>
+        {serverError ? (
+          <p role="alert" className="text-sm text-status-afk">
+            {serverError}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (isFriend) {
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="secondary" disabled>
+          Amigos
+        </Button>
+        <Button
+          variant="ghost"
+          disabled={isBusy}
+          onClick={() => {
+            removeFriendMutation.mutate(targetUserId);
+          }}
+        >
+          {removeFriendMutation.isPending ? 'Removendo...' : 'Remover'}
+        </Button>
+        {serverError ? (
+          <p role="alert" className="w-full text-sm text-status-afk">
+            {serverError}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (localPending) {
+    return (
+      <Button variant="secondary" disabled>
+        Pedido enviado
+      </Button>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        disabled={isBusy}
+        onClick={() => {
+          sendRequestMutation.mutate(targetUserId);
+        }}
+      >
+        {sendRequestMutation.isPending ? 'Enviando...' : 'Adicionar amigo'}
+      </Button>
+      {serverError ? (
+        <p role="alert" className="text-sm text-status-afk">
+          {serverError}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/friends/friend-request-card.tsx
+++ b/frontend/src/components/friends/friend-request-card.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Avatar } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { type PendingFriendRequest } from '@/schemas/friends';
+import {
+  acceptFriendRequest,
+  FriendsRequestError,
+} from '@/services/friends';
+
+type FriendRequestCardProps = {
+  request: PendingFriendRequest;
+  receiverUserId: string;
+};
+
+function formatCreatedAt(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+export function FriendRequestCard({
+  request,
+  receiverUserId,
+}: FriendRequestCardProps) {
+  const queryClient = useQueryClient();
+  const senderName =
+    request.sender.profile?.displayName && request.sender.profile.displayName.length > 0
+      ? request.sender.profile.displayName
+      : request.sender.username;
+  const avatarFallback = request.sender.username.slice(0, 2).toUpperCase();
+
+  const acceptMutation = useMutation({
+    mutationFn: acceptFriendRequest,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['friend-requests', receiverUserId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['friends', receiverUserId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['profile'],
+        }),
+      ]);
+    },
+  });
+
+  const serverError = acceptMutation.error instanceof FriendsRequestError
+    ? acceptMutation.error.message
+    : acceptMutation.isError
+      ? 'Nao foi possivel aceitar o pedido agora.'
+      : null;
+
+  return (
+    <Card data-testid="friend-request-card">
+      <div className="space-y-4">
+        <div className="flex items-start gap-3">
+          <Avatar
+            src={request.sender.profile?.avatarUrl}
+            alt={request.sender.username}
+            fallback={avatarFallback}
+          />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold text-primary">{senderName}</p>
+            <p className="truncate text-xs text-secondary">@{request.sender.username}</p>
+            <p className="mt-2 text-xs text-secondary">
+              Pedido enviado em {formatCreatedAt(request.createdAt)}
+            </p>
+          </div>
+        </div>
+
+        <Button
+          size="sm"
+          disabled={acceptMutation.isPending}
+          onClick={() => {
+            acceptMutation.mutate(request.id);
+          }}
+        >
+          {acceptMutation.isPending ? 'Aceitando...' : 'Aceitar pedido'}
+        </Button>
+
+        {serverError ? (
+          <p role="alert" className="text-sm text-status-afk">
+            {serverError}
+          </p>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/friends/friend-requests-badge.tsx
+++ b/frontend/src/components/friends/friend-requests-badge.tsx
@@ -1,0 +1,21 @@
+import { Badge } from '@/components/ui/badge';
+
+type FriendRequestsBadgeProps = {
+  count: number;
+  isLoading?: boolean;
+};
+
+export function FriendRequestsBadge({
+  count,
+  isLoading = false,
+}: FriendRequestsBadgeProps) {
+  if (isLoading) {
+    return <Badge tone="neutral">...</Badge>;
+  }
+
+  return (
+    <Badge tone={count > 0 ? 'accent' : 'neutral'}>
+      {count}
+    </Badge>
+  );
+}

--- a/frontend/src/components/friends/friends-list.tsx
+++ b/frontend/src/components/friends/friends-list.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Avatar } from '@/components/ui/avatar';
+import { Card } from '@/components/ui/card';
+import { PresenceBadge } from '@/components/profile/presence-badge';
+import { type FriendSummary, type FriendPresenceStatus } from '@/schemas/friends';
+import { fetchFriends } from '@/services/friends';
+
+type FriendsListProps = {
+  userId: string;
+  title?: string;
+};
+
+const presenceOrder: Record<FriendPresenceStatus, number> = {
+  IN_GAME: 0,
+  ONLINE: 1,
+  AFK: 2,
+  OFFLINE: 3,
+};
+
+export function sortFriendsByPresence(friends: FriendSummary[]): FriendSummary[] {
+  return [...friends].sort((left, right) => {
+    const leftStatus = left.presence?.status ?? 'OFFLINE';
+    const rightStatus = right.presence?.status ?? 'OFFLINE';
+
+    return presenceOrder[leftStatus] - presenceOrder[rightStatus];
+  });
+}
+
+function FriendsListLoadingState() {
+  return (
+    <Card data-testid="friends-list-loading">
+      <div className="space-y-4">
+        <div className="h-6 w-44 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="h-16 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="h-16 animate-pulse rounded-control bg-background-tertiary" />
+      </div>
+    </Card>
+  );
+}
+
+export function FriendsList({
+  userId,
+  title = 'Amigos',
+}: FriendsListProps) {
+  const friendsQuery = useQuery({
+    queryKey: ['friends', userId],
+    queryFn: () => fetchFriends(userId),
+  });
+
+  if (friendsQuery.isPending) {
+    return <FriendsListLoadingState />;
+  }
+
+  if (friendsQuery.isError) {
+    return (
+      <Card data-testid="friends-list-error">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Amizades
+          </p>
+          <h2 className="font-display text-2xl font-semibold text-primary">
+            Nao foi possivel carregar a lista de amigos
+          </h2>
+        </div>
+      </Card>
+    );
+  }
+
+  const friends = sortFriendsByPresence(friendsQuery.data);
+
+  if (friends.length === 0) {
+    return (
+      <Card data-testid="friends-list-empty">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Amizades
+          </p>
+          <h2 className="font-display text-2xl font-semibold text-primary">
+            Nenhum amigo encontrado
+          </h2>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="friends-list-success">
+      <div className="space-y-5">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Amizades
+          </p>
+          <h2 className="font-display text-2xl font-semibold text-primary">{title}</h2>
+        </div>
+
+        <div className="space-y-3">
+          {friends.map((friend) => {
+            const displayName =
+              friend.profile?.displayName && friend.profile.displayName.length > 0
+                ? friend.profile.displayName
+                : friend.username;
+            const avatarFallback = friend.username.slice(0, 2).toUpperCase();
+
+            return (
+              <div
+                key={friend.id}
+                data-testid="friend-list-item"
+                className="flex items-center justify-between gap-4 rounded-control border border-border bg-background-secondary/60 px-control-x py-control-y"
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <Avatar
+                    src={friend.profile?.avatarUrl}
+                    alt={friend.username}
+                    fallback={avatarFallback}
+                  />
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-primary">
+                      {displayName}
+                    </p>
+                    <p className="truncate text-xs text-secondary">@{friend.username}</p>
+                  </div>
+                </div>
+
+                <PresenceBadge
+                  status={friend.presence?.status ?? 'OFFLINE'}
+                  currentGame={friend.presence?.currentGame ?? null}
+                  platform={friend.presence?.platform ?? null}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -1,11 +1,17 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
-import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { useState, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { FriendRequestCard } from '@/components/friends/friend-request-card';
+import { FriendRequestsBadge } from '@/components/friends/friend-requests-badge';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/use-auth';
 import { cn } from '@/lib/utils/cn';
+import { fetchPendingFriendRequests } from '@/services/friends';
 
 type NavbarVariant = 'auth' | 'app';
 
@@ -47,6 +53,15 @@ export function Navbar({
   menuOpen = false,
   onMenuToggle,
 }: NavbarProps) {
+  const { user, status } = useAuth();
+  const [isRequestsOpen, setIsRequestsOpen] = useState(false);
+  const pendingRequestsQuery = useQuery({
+    queryKey: ['friend-requests', user?.id],
+    queryFn: () => fetchPendingFriendRequests(user?.id as string),
+    enabled: variant === 'app' && status === 'authenticated' && typeof user?.id === 'string',
+  });
+  const pendingRequests = pendingRequestsQuery.data ?? [];
+
   return (
     <header className="sticky top-0 z-30 border-b border-border bg-[rgba(10,10,15,0.88)] backdrop-blur">
       <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-page-x py-4">
@@ -93,14 +108,70 @@ export function Navbar({
 
         <div className="flex items-center gap-2">
           {variant === 'app' ? (
-            <>
-              <ActionButton type="button" aria-label="Open notifications preview">
-                Notifications
+            <div className="relative">
+              <ActionButton
+                type="button"
+                aria-label="Open friend requests preview"
+                onClick={() => {
+                  setIsRequestsOpen((current) => !current);
+                }}
+              >
+                Requests
+                <FriendRequestsBadge
+                  count={pendingRequests.length}
+                  isLoading={pendingRequestsQuery.isPending}
+                />
               </ActionButton>
-              <Badge tone="neutral" className="hidden sm:inline-flex">
-                Preview
-              </Badge>
-            </>
+
+              {isRequestsOpen && status === 'authenticated' ? (
+                <div className="absolute right-0 top-[calc(100%+0.75rem)] z-40 w-[22rem] max-w-[calc(100vw-2rem)]">
+                  <Card>
+                    <div className="space-y-4">
+                      <div className="space-y-2">
+                        <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+                          Pedidos
+                        </p>
+                        <h2 className="font-display text-xl font-semibold text-primary">
+                          Friend requests
+                        </h2>
+                      </div>
+
+                      {pendingRequestsQuery.isPending ? (
+                        <p className="text-sm text-secondary">
+                          Carregando pedidos pendentes...
+                        </p>
+                      ) : null}
+
+                      {pendingRequestsQuery.isError ? (
+                        <p className="text-sm text-status-afk">
+                          Nao foi possivel carregar os pedidos pendentes.
+                        </p>
+                      ) : null}
+
+                      {!pendingRequestsQuery.isPending &&
+                      !pendingRequestsQuery.isError &&
+                      pendingRequests.length === 0 ? (
+                        <p className="text-sm text-secondary">
+                          Nenhum pedido pendente no momento.
+                        </p>
+                      ) : null}
+
+                      {pendingRequests.length > 0 ? (
+                        <div className="space-y-3">
+                          {pendingRequests.map((request) => (
+                            <FriendRequestCard
+                              key={request.id}
+                              request={request}
+                              receiverUserId={user?.id ?? ''}
+                            />
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  </Card>
+                </div>
+              ) : null}
+            </div>
           ) : (
             <Badge tone="accent">No sidebar</Badge>
           )}

--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
@@ -7,9 +8,10 @@ import { type ProfileResponse } from '@/schemas/profile';
 
 type GamerCardProps = {
   profile: ProfileResponse;
+  actions?: ReactNode;
 };
 
-export function GamerCard({ profile }: GamerCardProps) {
+export function GamerCard({ profile, actions }: GamerCardProps) {
   const displayName = profile.profile.displayName || profile.username;
   const badgeList = profile.profile.badges.slice(0, 4);
   const initials = profile.username.slice(0, 2).toUpperCase();
@@ -52,7 +54,10 @@ export function GamerCard({ profile }: GamerCardProps) {
             </div>
           </div>
 
-          <Badge tone="accent">Nv. {profile.stats.level}</Badge>
+          <div className="flex flex-col items-end gap-3">
+            <Badge tone="accent">Nv. {profile.stats.level}</Badge>
+            {actions}
+          </div>
         </div>
 
         <p className="text-sm leading-6 text-secondary">

--- a/frontend/src/components/profile/profile-page-content.tsx
+++ b/frontend/src/components/profile/profile-page-content.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { FriendButton } from '@/components/friends/friend-button';
+import { FriendsList } from '@/components/friends/friends-list';
 import { Card } from '@/components/ui/card';
 import { GamerCard } from '@/components/profile/gamer-card';
 import { GameLibraryPreview } from '@/components/profile/game-library-preview';
@@ -91,8 +93,15 @@ export function ProfilePageContent({ username }: ProfilePageContentProps) {
 
   return (
     <div className="space-y-section" data-testid="profile-success">
-      <GamerCard profile={profileQuery.data} />
+      <GamerCard
+        profile={profileQuery.data}
+        actions={<FriendButton targetUserId={profileQuery.data.id} />}
+      />
       <ProfileStats stats={profileQuery.data.stats} />
+      <FriendsList
+        userId={profileQuery.data.id}
+        title={`Amigos de @${profileQuery.data.username}`}
+      />
       <GameLibraryPreview games={profileQuery.data.gameLibrary} />
     </div>
   );

--- a/frontend/src/schemas/friends.ts
+++ b/frontend/src/schemas/friends.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+export const friendPresenceStatusSchema = z.enum([
+  'IN_GAME',
+  'ONLINE',
+  'AFK',
+  'OFFLINE',
+]);
+
+export const friendSummarySchema = z.object({
+  id: z.string().min(1),
+  username: z.string().min(1),
+  profile: z
+    .object({
+      displayName: z.string().nullable(),
+      avatarUrl: z.string().nullable(),
+      accentColor: z.string().nullable(),
+    })
+    .nullable(),
+  presence: z
+    .object({
+      status: friendPresenceStatusSchema,
+      currentGame: z.string().nullable(),
+      platform: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+export const friendsResponseSchema = z.array(friendSummarySchema);
+
+export const pendingFriendRequestSchema = z.object({
+  id: z.string().min(1),
+  createdAt: z.string().min(1),
+  sender: z.object({
+    id: z.string().min(1),
+    username: z.string().min(1),
+    profile: z
+      .object({
+        displayName: z.string().nullable(),
+        avatarUrl: z.string().nullable(),
+      })
+      .nullable(),
+  }),
+});
+
+export const pendingFriendRequestsResponseSchema = z.array(
+  pendingFriendRequestSchema,
+);
+
+export const createFriendRequestResponseSchema = z.object({
+  id: z.string().min(1),
+  status: z.literal('PENDING'),
+});
+
+export const friendActionResponseSchema = z.object({
+  message: z.string().min(1),
+});
+
+export type FriendSummary = z.infer<typeof friendSummarySchema>;
+export type PendingFriendRequest = z.infer<typeof pendingFriendRequestSchema>;
+export type FriendPresenceStatus = z.infer<typeof friendPresenceStatusSchema>;
+export type CreateFriendRequestResponse = z.infer<
+  typeof createFriendRequestResponseSchema
+>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -22,4 +22,12 @@ export {
   toggleInteractionRequestSchema,
   toggleInteractionResponseSchema,
 } from './feed';
+export {
+  createFriendRequestResponseSchema,
+  friendActionResponseSchema,
+  friendPresenceStatusSchema,
+  friendsResponseSchema,
+  pendingFriendRequestSchema,
+  pendingFriendRequestsResponseSchema,
+} from './friends';
 export { profileResponseSchema } from './profile';

--- a/frontend/src/services/friends.ts
+++ b/frontend/src/services/friends.ts
@@ -1,0 +1,143 @@
+import { apiRequest } from '@/lib/api';
+import {
+  createFriendRequestResponseSchema,
+  friendActionResponseSchema,
+  friendsResponseSchema,
+  pendingFriendRequestsResponseSchema,
+  type CreateFriendRequestResponse,
+  type FriendSummary,
+  type PendingFriendRequest,
+} from '@/schemas/friends';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+export class FriendsRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'FriendsRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchFriends(userId: string): Promise<FriendSummary[]> {
+  const response = await apiRequest(`/friends/${encodeURIComponent(userId)}`, {
+    method: 'GET',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FriendsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar a lista de amigos.'),
+    );
+  }
+
+  return friendsResponseSchema.parse(payload);
+}
+
+export async function fetchPendingFriendRequests(
+  userId: string,
+): Promise<PendingFriendRequest[]> {
+  const response = await apiRequest(
+    `/friends/requests/${encodeURIComponent(userId)}`,
+    {
+      method: 'GET',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FriendsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar os pedidos pendentes.'),
+    );
+  }
+
+  return pendingFriendRequestsResponseSchema.parse(payload);
+}
+
+export async function sendFriendRequest(
+  targetId: string,
+): Promise<CreateFriendRequestResponse> {
+  const response = await apiRequest(
+    `/friends/request/${encodeURIComponent(targetId)}`,
+    {
+      method: 'POST',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FriendsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel enviar o pedido agora.'),
+    );
+  }
+
+  return createFriendRequestResponseSchema.parse(payload);
+}
+
+export async function acceptFriendRequest(requestId: string): Promise<void> {
+  const response = await apiRequest(
+    `/friends/accept/${encodeURIComponent(requestId)}`,
+    {
+      method: 'POST',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FriendsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel aceitar o pedido agora.'),
+    );
+  }
+
+  friendActionResponseSchema.parse(payload);
+}
+
+export async function removeFriend(friendId: string): Promise<void> {
+  const response = await apiRequest(`/friends/${encodeURIComponent(friendId)}`, {
+    method: 'DELETE',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new FriendsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel remover a amizade agora.'),
+    );
+  }
+
+  friendActionResponseSchema.parse(payload);
+}

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,5 +1,13 @@
 export { buildApiUrl } from './http/client';
 export { login, register, AuthRequestError } from './auth';
+export {
+  acceptFriendRequest,
+  fetchFriends,
+  fetchPendingFriendRequests,
+  FriendsRequestError,
+  removeFriend,
+  sendFriendRequest,
+} from './friends';
 export { fetchAuthSession, logoutAuthSession } from './session';
 export {
   createPost,

--- a/frontend/tests/smoke/app-shell.test.tsx
+++ b/frontend/tests/smoke/app-shell.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { AppShell } from '@/components/layout/app-shell';
@@ -12,10 +13,20 @@ vi.mock('next/navigation', () => ({
 
 describe('AppShell', () => {
   it('renders the authenticated shell and toggles the mobile sidebar', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
     render(
-      <AppShell>
-        <div>Authenticated content</div>
-      </AppShell>,
+      <QueryClientProvider client={queryClient}>
+        <AppShell>
+          <div>Authenticated content</div>
+        </AppShell>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText('Authenticated content')).toBeInTheDocument();

--- a/frontend/tests/unit/components/friend-button.test.tsx
+++ b/frontend/tests/unit/components/friend-button.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FriendButton } from '@/components/friends/friend-button';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  acceptFriendRequest,
+  fetchFriends,
+  fetchPendingFriendRequests,
+  removeFriend,
+  sendFriendRequest,
+} from '@/services/friends';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/friends', () => ({
+  fetchFriends: vi.fn(),
+  fetchPendingFriendRequests: vi.fn(),
+  sendFriendRequest: vi.fn(),
+  acceptFriendRequest: vi.fn(),
+  removeFriend: vi.fn(),
+  FriendsRequestError: class FriendsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'FriendsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchFriends = vi.mocked(fetchFriends);
+const mockedFetchPendingFriendRequests = vi.mocked(fetchPendingFriendRequests);
+const mockedSendFriendRequest = vi.mocked(sendFriendRequest);
+const mockedAcceptFriendRequest = vi.mocked(acceptFriendRequest);
+const mockedRemoveFriend = vi.mocked(removeFriend);
+
+function renderFriendButton(targetUserId = 'user-2') {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <FriendButton targetUserId={targetUserId} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('FriendButton', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchFriends.mockReset();
+    mockedFetchPendingFriendRequests.mockReset();
+    mockedSendFriendRequest.mockReset();
+    mockedAcceptFriendRequest.mockReset();
+    mockedRemoveFriend.mockReset();
+
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchFriends.mockResolvedValue([]);
+    mockedFetchPendingFriendRequests.mockResolvedValue([]);
+  });
+
+  it('renders the own-profile state', async () => {
+    renderFriendButton('user-1');
+
+    expect(await screen.findByRole('button', { name: /seu perfil/i })).toBeDisabled();
+  });
+
+  it('sends a friend request from the default state', async () => {
+    mockedSendFriendRequest.mockResolvedValue({
+      id: 'request-1',
+      status: 'PENDING',
+    });
+
+    renderFriendButton();
+
+    fireEvent.click(await screen.findByRole('button', { name: /adicionar amigo/i }));
+
+    await waitFor(() => {
+      expect(mockedSendFriendRequest).toHaveBeenCalled();
+    });
+    expect(mockedSendFriendRequest.mock.calls[0]?.[0]).toBe('user-2');
+
+    expect(await screen.findByRole('button', { name: /pedido enviado/i })).toBeDisabled();
+  });
+
+  it('accepts an incoming request state', async () => {
+    mockedFetchPendingFriendRequests.mockResolvedValue([
+      {
+        id: 'request-1',
+        createdAt: '2026-03-31T10:00:00.000Z',
+        sender: {
+          id: 'user-2',
+          username: 'pixelsamurai',
+          profile: {
+            displayName: 'Pixel Samurai',
+            avatarUrl: null,
+          },
+        },
+      },
+    ]);
+    mockedAcceptFriendRequest.mockResolvedValue(undefined);
+
+    renderFriendButton();
+
+    fireEvent.click(await screen.findByRole('button', { name: /aceitar pedido/i }));
+
+    await waitFor(() => {
+      expect(mockedAcceptFriendRequest).toHaveBeenCalled();
+    });
+    expect(mockedAcceptFriendRequest.mock.calls[0]?.[0]).toBe('request-1');
+  });
+
+  it('renders the friend state and removes friendship', async () => {
+    mockedFetchFriends.mockResolvedValue([
+      {
+        id: 'user-2',
+        username: 'pixelsamurai',
+        profile: {
+          displayName: 'Pixel Samurai',
+          avatarUrl: null,
+          accentColor: '#06B6D4',
+        },
+        presence: {
+          status: 'ONLINE',
+          currentGame: null,
+          platform: 'PC',
+        },
+      },
+    ]);
+    mockedRemoveFriend.mockResolvedValue(undefined);
+
+    renderFriendButton();
+
+    expect(await screen.findByRole('button', { name: /^amigos$/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /remover/i }));
+
+    await waitFor(() => {
+      expect(mockedRemoveFriend).toHaveBeenCalled();
+    });
+    expect(mockedRemoveFriend.mock.calls[0]?.[0]).toBe('user-2');
+  });
+});

--- a/frontend/tests/unit/components/friend-request-card.test.tsx
+++ b/frontend/tests/unit/components/friend-request-card.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FriendRequestCard } from '@/components/friends/friend-request-card';
+import { acceptFriendRequest } from '@/services/friends';
+
+vi.mock('@/services/friends', () => ({
+  acceptFriendRequest: vi.fn(),
+  FriendsRequestError: class FriendsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'FriendsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedAcceptFriendRequest = vi.mocked(acceptFriendRequest);
+
+function renderFriendRequestCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <FriendRequestCard
+        receiverUserId="user-1"
+        request={{
+          id: 'request-1',
+          createdAt: '2026-03-31T10:00:00.000Z',
+          sender: {
+            id: 'user-2',
+            username: 'pixelsamurai',
+            profile: {
+              displayName: 'Pixel Samurai',
+              avatarUrl: null,
+            },
+          },
+        }}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('FriendRequestCard', () => {
+  beforeEach(() => {
+    mockedAcceptFriendRequest.mockReset();
+  });
+
+  it('accepts a pending request', async () => {
+    mockedAcceptFriendRequest.mockResolvedValue(undefined);
+
+    renderFriendRequestCard();
+
+    fireEvent.click(screen.getByRole('button', { name: /aceitar pedido/i }));
+
+    await waitFor(() => {
+      expect(mockedAcceptFriendRequest).toHaveBeenCalled();
+    });
+    expect(mockedAcceptFriendRequest.mock.calls[0]?.[0]).toBe('request-1');
+  });
+});

--- a/frontend/tests/unit/components/friend-requests-badge.test.tsx
+++ b/frontend/tests/unit/components/friend-requests-badge.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FriendRequestsBadge } from '@/components/friends/friend-requests-badge';
+
+describe('FriendRequestsBadge', () => {
+  it('renders the pending request count', () => {
+    render(<FriendRequestsBadge count={3} />);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/friends-list.test.tsx
+++ b/frontend/tests/unit/components/friends-list.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FriendsList } from '@/components/friends/friends-list';
+import { fetchFriends } from '@/services/friends';
+
+vi.mock('@/services/friends', () => ({
+  fetchFriends: vi.fn(),
+}));
+
+const mockedFetchFriends = vi.mocked(fetchFriends);
+
+function renderFriendsList() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <FriendsList userId="user-1" />
+    </QueryClientProvider>,
+  );
+}
+
+describe('FriendsList', () => {
+  beforeEach(() => {
+    mockedFetchFriends.mockReset();
+  });
+
+  it('orders friends by presence priority', async () => {
+    mockedFetchFriends.mockResolvedValue([
+      {
+        id: 'friend-3',
+        username: 'offline',
+        profile: { displayName: 'Offline', avatarUrl: null, accentColor: null },
+        presence: { status: 'OFFLINE', currentGame: null, platform: null },
+      },
+      {
+        id: 'friend-2',
+        username: 'online',
+        profile: { displayName: 'Online', avatarUrl: null, accentColor: null },
+        presence: { status: 'ONLINE', currentGame: null, platform: null },
+      },
+      {
+        id: 'friend-1',
+        username: 'ingame',
+        profile: { displayName: 'In Game', avatarUrl: null, accentColor: null },
+        presence: { status: 'IN_GAME', currentGame: 'Valorant', platform: 'PC' },
+      },
+    ]);
+
+    renderFriendsList();
+
+    const items = await screen.findAllByTestId('friend-list-item');
+    expect(items[0]).toHaveTextContent(/in game/i);
+    expect(items[1]).toHaveTextContent(/online/i);
+    expect(items[2]).toHaveTextContent(/offline/i);
+  });
+});

--- a/frontend/tests/unit/components/navbar.test.tsx
+++ b/frontend/tests/unit/components/navbar.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Navbar } from '@/components/layout/navbar';
+import { useAuth } from '@/hooks/use-auth';
+import { fetchPendingFriendRequests } from '@/services/friends';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/friends', () => ({
+  fetchPendingFriendRequests: vi.fn(),
+}));
+
+vi.mock('@/components/friends/friend-request-card', () => ({
+  FriendRequestCard: ({ request }: { request: { sender: { username: string } } }) => (
+    <div data-testid="friend-request-card">{request.sender.username}</div>
+  ),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchPendingFriendRequests = vi.mocked(fetchPendingFriendRequests);
+
+function renderNavbar() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Navbar variant="app" />
+    </QueryClientProvider>,
+  );
+}
+
+describe('Navbar', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchPendingFriendRequests.mockReset();
+
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+  });
+
+  it('renders the pending requests count in the navbar', async () => {
+    mockedFetchPendingFriendRequests.mockResolvedValue([
+      {
+        id: 'request-1',
+        createdAt: '2026-03-31T10:00:00.000Z',
+        sender: {
+          id: 'user-2',
+          username: 'pixelsamurai',
+          profile: {
+            displayName: 'Pixel Samurai',
+            avatarUrl: null,
+          },
+        },
+      },
+    ]);
+
+    renderNavbar();
+
+    expect(await screen.findByText('1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /open friend requests preview/i }));
+
+    expect(await screen.findByTestId('friend-request-card')).toHaveTextContent(
+      /pixelsamurai/i,
+    );
+  });
+});

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -22,6 +22,18 @@ vi.mock('@/services/profile', () => ({
   },
 }));
 
+vi.mock('@/components/friends/friend-button', () => ({
+  FriendButton: ({ targetUserId }: { targetUserId: string }) => (
+    <div data-testid="friend-button">friend-button:{targetUserId}</div>
+  ),
+}));
+
+vi.mock('@/components/friends/friends-list', () => ({
+  FriendsList: ({ userId }: { userId: string }) => (
+    <div data-testid="friends-list">friends-list:{userId}</div>
+  ),
+}));
+
 const mockedFetchProfile = vi.mocked(fetchProfileByUsername);
 
 const profileFixture: ProfileResponse = {
@@ -112,6 +124,8 @@ describe('ProfilePageContent', () => {
       screen.getByRole('heading', { name: /clutch player/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
+    expect(screen.getByTestId('friend-button')).toHaveTextContent('friend-button:user-1');
+    expect(screen.getByTestId('friends-list')).toHaveTextContent('friends-list:user-1');
   });
 
   it('renders not found state', async () => {

--- a/frontend/tests/unit/services/friends.test.ts
+++ b/frontend/tests/unit/services/friends.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import {
+  acceptFriendRequest,
+  fetchFriends,
+  fetchPendingFriendRequests,
+  removeFriend,
+  sendFriendRequest,
+} from '@/services/friends';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+describe('friends service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('returns parsed friends list', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: 'friend-1',
+            username: 'pixelsamurai',
+            profile: {
+              displayName: 'Pixel Samurai',
+              avatarUrl: null,
+              accentColor: '#06B6D4',
+            },
+            presence: {
+              status: 'ONLINE',
+              currentGame: null,
+              platform: 'PC',
+            },
+          },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await fetchFriends('user-1');
+
+    expect(response).toHaveLength(1);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/friends/user-1', {
+      method: 'GET',
+    });
+  });
+
+  it('returns parsed pending requests', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            id: 'request-1',
+            createdAt: '2026-03-31T10:00:00.000Z',
+            sender: {
+              id: 'user-2',
+              username: 'pixelsamurai',
+              profile: {
+                displayName: 'Pixel Samurai',
+                avatarUrl: null,
+              },
+            },
+          },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await fetchPendingFriendRequests('user-1');
+
+    expect(response).toHaveLength(1);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/friends/requests/user-1', {
+      method: 'GET',
+    });
+  });
+
+  it('sends a friend request with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ id: 'request-1', status: 'PENDING' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await sendFriendRequest('user-2');
+
+    expect(response.status).toBe('PENDING');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/friends/request/user-2', {
+      method: 'POST',
+    });
+  });
+
+  it('accepts a friend request with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Amizade confirmada.' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await acceptFriendRequest('request-1');
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('/friends/accept/request-1', {
+      method: 'POST',
+    });
+  });
+
+  it('removes a friend with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Amizade removida.' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await removeFriend('friend-1');
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('/friends/friend-1', {
+      method: 'DELETE',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the frontend friendship flow with reusable button, friends list, pending request cards and navbar badge
- integrate the real backend friends endpoints for request, accept, remove, list and pending requests
- surface friendship state directly on the profile page and extend test coverage for the critical UI and service contracts

## Operational cleanup
- verified that `feat/frontend-feed-create-post` was fully superseded by the merge of #126 using patch-equivalence against `develop`
- removed the obsolete remote and local branch to eliminate GitHub compare noise

## What changed
- add `FriendButton` with the supported states from the real contract: own profile, none, incoming request, friend and session-local sent request
- add `FriendsList` ordered by presence using the backend payload and a defensive client-side sort
- add `FriendRequestCard` and pending requests preview in the navbar with badge count
- wire profile page actions and friends list into the authenticated profile experience
- add typed schemas/services plus unit and smoke coverage for the new flows

## Contract notes
- the backend does not expose a dedicated endpoint for outgoing pending requests, so the `Pedido enviado` state is persisted only locally after a successful request (or a 409 indicating an existing pending request)
- friend ordering by presence is supported by the backend response and preserved defensively in the frontend

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build

## Risks
- a persisted outgoing pending state after page reload still depends on backend contract expansion if we want it to be fully reconstructible from the API alone

Closes #94