### PR TITLE
feat(notifications): add notifications list flow

### DIFF
--- a/frontend/src/app/(app)/notifications/page.tsx
+++ b/frontend/src/app/(app)/notifications/page.tsx
@@ -1,0 +1,5 @@
+import { NotificationsPageContent } from '@/components/notifications/notifications-page-content';
+
+export default function NotificationsPage() {
+  return <NotificationsPageContent />;
+}

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { NotificationsBell } from '@/components/notifications/notifications-bell';
 import { useAuth } from '@/hooks/use-auth';
 import { cn } from '@/lib/utils/cn';
 import { fetchPendingFriendRequests } from '@/services/friends';
@@ -108,70 +109,73 @@ export function Navbar({
 
         <div className="flex items-center gap-2">
           {variant === 'app' ? (
-            <div className="relative">
-              <ActionButton
-                type="button"
-                aria-label="Open friend requests preview"
-                onClick={() => {
-                  setIsRequestsOpen((current) => !current);
-                }}
-              >
-                Requests
-                <FriendRequestsBadge
-                  count={pendingRequests.length}
-                  isLoading={pendingRequestsQuery.isPending}
-                />
-              </ActionButton>
+            <>
+              <NotificationsBell />
+              <div className="relative">
+                <ActionButton
+                  type="button"
+                  aria-label="Open friend requests preview"
+                  onClick={() => {
+                    setIsRequestsOpen((current) => !current);
+                  }}
+                >
+                  Requests
+                  <FriendRequestsBadge
+                    count={pendingRequests.length}
+                    isLoading={pendingRequestsQuery.isPending}
+                  />
+                </ActionButton>
 
-              {isRequestsOpen && status === 'authenticated' ? (
-                <div className="absolute right-0 top-[calc(100%+0.75rem)] z-40 w-[22rem] max-w-[calc(100vw-2rem)]">
-                  <Card>
-                    <div className="space-y-4">
-                      <div className="space-y-2">
-                        <p className="text-xs uppercase tracking-[0.35em] text-secondary">
-                          Pedidos
-                        </p>
-                        <h2 className="font-display text-xl font-semibold text-primary">
-                          Friend requests
-                        </h2>
-                      </div>
-
-                      {pendingRequestsQuery.isPending ? (
-                        <p className="text-sm text-secondary">
-                          Carregando pedidos pendentes...
-                        </p>
-                      ) : null}
-
-                      {pendingRequestsQuery.isError ? (
-                        <p className="text-sm text-status-afk">
-                          Nao foi possivel carregar os pedidos pendentes.
-                        </p>
-                      ) : null}
-
-                      {!pendingRequestsQuery.isPending &&
-                      !pendingRequestsQuery.isError &&
-                      pendingRequests.length === 0 ? (
-                        <p className="text-sm text-secondary">
-                          Nenhum pedido pendente no momento.
-                        </p>
-                      ) : null}
-
-                      {pendingRequests.length > 0 ? (
-                        <div className="space-y-3">
-                          {pendingRequests.map((request) => (
-                            <FriendRequestCard
-                              key={request.id}
-                              request={request}
-                              receiverUserId={user?.id ?? ''}
-                            />
-                          ))}
+                {isRequestsOpen && status === 'authenticated' ? (
+                  <div className="absolute right-0 top-[calc(100%+0.75rem)] z-40 w-[22rem] max-w-[calc(100vw-2rem)]">
+                    <Card>
+                      <div className="space-y-4">
+                        <div className="space-y-2">
+                          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+                            Pedidos
+                          </p>
+                          <h2 className="font-display text-xl font-semibold text-primary">
+                            Friend requests
+                          </h2>
                         </div>
-                      ) : null}
-                    </div>
-                  </Card>
-                </div>
-              ) : null}
-            </div>
+
+                        {pendingRequestsQuery.isPending ? (
+                          <p className="text-sm text-secondary">
+                            Carregando pedidos pendentes...
+                          </p>
+                        ) : null}
+
+                        {pendingRequestsQuery.isError ? (
+                          <p className="text-sm text-status-afk">
+                            Nao foi possivel carregar os pedidos pendentes.
+                          </p>
+                        ) : null}
+
+                        {!pendingRequestsQuery.isPending &&
+                        !pendingRequestsQuery.isError &&
+                        pendingRequests.length === 0 ? (
+                          <p className="text-sm text-secondary">
+                            Nenhum pedido pendente no momento.
+                          </p>
+                        ) : null}
+
+                        {pendingRequests.length > 0 ? (
+                          <div className="space-y-3">
+                            {pendingRequests.map((request) => (
+                              <FriendRequestCard
+                                key={request.id}
+                                request={request}
+                                receiverUserId={user?.id ?? ''}
+                              />
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                    </Card>
+                  </div>
+                ) : null}
+              </div>
+            </>
           ) : (
             <Badge tone="accent">No sidebar</Badge>
           )}

--- a/frontend/src/components/notifications/notification-dropdown.tsx
+++ b/frontend/src/components/notifications/notification-dropdown.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import Link from 'next/link';
+import { NotificationItem } from '@/components/notifications/notification-item';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import type { NotificationRecord } from '@/schemas/notifications';
+
+type NotificationDropdownProps = {
+  notifications: NotificationRecord[];
+  unreadCount: number;
+  isLoading: boolean;
+  isError: boolean;
+  isMarkingAllRead?: boolean;
+  activeNotificationId?: string | null;
+  onMarkAsRead: (notificationId: string) => void;
+  onMarkAllAsRead: () => void;
+};
+
+export function NotificationDropdown({
+  notifications,
+  unreadCount,
+  isLoading,
+  isError,
+  isMarkingAllRead = false,
+  activeNotificationId = null,
+  onMarkAsRead,
+  onMarkAllAsRead,
+}: NotificationDropdownProps) {
+  const previewItems = notifications.slice(0, 5);
+
+  return (
+    <Card>
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+              Notifications
+            </p>
+            <h2 className="font-display text-xl font-semibold text-primary">
+              Activity inbox
+            </h2>
+            <p className="text-sm leading-6 text-secondary">
+              {unreadCount > 0
+                ? `${unreadCount} notificacao${unreadCount > 1 ? 'es' : ''} nao lida${unreadCount > 1 ? 's' : ''}.`
+                : 'Nenhuma notificacao pendente agora.'}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Link
+              href="/notifications"
+              className="text-sm font-medium text-accent-cyan transition hover:text-primary"
+            >
+              Ver todas
+            </Link>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={unreadCount === 0 || isMarkingAllRead}
+              onClick={onMarkAllAsRead}
+            >
+              {isMarkingAllRead ? 'Marcando...' : 'Marcar todas'}
+            </Button>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-secondary">Carregando notificacoes...</p>
+        ) : null}
+
+        {isError ? (
+          <p className="text-sm text-status-afk">
+            Nao foi possivel carregar as notificacoes agora.
+          </p>
+        ) : null}
+
+        {!isLoading && !isError && previewItems.length === 0 ? (
+          <p className="text-sm text-secondary">
+            Seu inbox esta limpo no momento.
+          </p>
+        ) : null}
+
+        {previewItems.length > 0 ? (
+          <div className="space-y-3">
+            {previewItems.map((notification) => (
+              <NotificationItem
+                key={notification.id}
+                compact
+                notification={notification}
+                onMarkAsRead={onMarkAsRead}
+                isMarkingRead={activeNotificationId === notification.id}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/notifications/notification-item.tsx
+++ b/frontend/src/components/notifications/notification-item.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  friendAcceptedNotificationPayloadSchema,
+  friendRequestNotificationPayloadSchema,
+  postCommentNotificationPayloadSchema,
+  postLikeNotificationPayloadSchema,
+  type NotificationRecord,
+} from '@/schemas/notifications';
+import { cn } from '@/lib/utils/cn';
+
+type NotificationItemProps = {
+  notification: NotificationRecord;
+  onMarkAsRead?: (notificationId: string) => void;
+  isMarkingRead?: boolean;
+  compact?: boolean;
+};
+
+type NotificationPresentation = {
+  label: string;
+  title: string;
+  description: string;
+  badgeTone: 'accent' | 'neutral' | 'success' | 'warning';
+  ctaHref?: string;
+  ctaLabel?: string;
+};
+
+function formatNotificationDate(createdAt: string): string {
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(createdAt));
+}
+
+function getNotificationPresentation(
+  notification: NotificationRecord,
+): NotificationPresentation {
+  switch (notification.type) {
+    case 'FRIEND_REQUEST': {
+      const payload = friendRequestNotificationPayloadSchema.safeParse(notification.payload);
+
+      return {
+        label: 'Friends',
+        title: 'Pedido de amizade recebido',
+        description: payload.success
+          ? 'Um jogador enviou um novo pedido de amizade para voce.'
+          : 'Existe um novo pedido de amizade aguardando resposta.',
+        badgeTone: notification.isRead ? 'neutral' : 'accent',
+      };
+    }
+    case 'FRIEND_ACCEPTED': {
+      const payload = friendAcceptedNotificationPayloadSchema.safeParse(notification.payload);
+
+      return {
+        label: 'Friends',
+        title: 'Pedido de amizade aceito',
+        description: payload.success
+          ? 'Seu pedido de amizade foi aceito.'
+          : 'Uma amizade foi confirmada recentemente.',
+        badgeTone: notification.isRead ? 'neutral' : 'success',
+      };
+    }
+    case 'POST_LIKE': {
+      const payload = postLikeNotificationPayloadSchema.safeParse(notification.payload);
+
+      return {
+        label: 'Feed',
+        title: 'Nova reaction no seu post',
+        description: payload.success
+          ? `Um jogador reagiu ao seu post com ${payload.data.interactionType}.`
+          : 'Seu post recebeu uma nova reaction.',
+        badgeTone: notification.isRead ? 'neutral' : 'accent',
+        ctaHref: '/feed',
+        ctaLabel: 'Ver feed',
+      };
+    }
+    case 'POST_COMMENT': {
+      const payload = postCommentNotificationPayloadSchema.safeParse(notification.payload);
+      const isReply = payload.success && payload.data.parentId !== null;
+
+      return {
+        label: 'Feed',
+        title: isReply ? 'Nova resposta no feed' : 'Novo comentario no seu post',
+        description: isReply
+          ? 'Um jogador respondeu a um comentario ligado ao seu post.'
+          : 'Seu post recebeu um novo comentario.',
+        badgeTone: notification.isRead ? 'neutral' : 'accent',
+        ctaHref: '/feed',
+        ctaLabel: 'Ver feed',
+      };
+    }
+    case 'GAME_INVITE':
+      return {
+        label: 'Social',
+        title: 'Convite de jogo',
+        description: 'Existe um convite de jogo aguardando sua atencao.',
+        badgeTone: notification.isRead ? 'neutral' : 'warning',
+      };
+    case 'FRIEND_NOW_PLAYING':
+      return {
+        label: 'Presence',
+        title: 'Amigo jogando agora',
+        description: 'Um amigo acabou de iniciar uma nova sessao de jogo.',
+        badgeTone: notification.isRead ? 'neutral' : 'success',
+      };
+    case 'SYSTEM':
+    default:
+      return {
+        label: 'System',
+        title: 'Atualizacao do CLUTCH',
+        description: 'Existe uma nova atualizacao operacional para voce revisar.',
+        badgeTone: notification.isRead ? 'neutral' : 'warning',
+      };
+  }
+}
+
+export function NotificationItem({
+  notification,
+  onMarkAsRead,
+  isMarkingRead = false,
+  compact = false,
+}: NotificationItemProps) {
+  const presentation = getNotificationPresentation(notification);
+  const showMarkAsRead = !notification.isRead && typeof onMarkAsRead === 'function';
+
+  return (
+    <Card
+      data-testid="notification-item"
+      className={cn(
+        'space-y-4',
+        !notification.isRead && 'border-accent-cyan/50 bg-[rgba(6,182,212,0.06)]',
+        compact && 'p-4',
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <Badge tone={presentation.badgeTone}>{presentation.label}</Badge>
+          <div className="space-y-1">
+            <h3 className="font-medium text-primary">{presentation.title}</h3>
+            <p className="text-sm leading-6 text-secondary">{presentation.description}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-end gap-2">
+          <span className="text-xs uppercase tracking-[0.24em] text-secondary">
+            {formatNotificationDate(notification.createdAt)}
+          </span>
+          <Badge tone={notification.isRead ? 'neutral' : 'accent'}>
+            {notification.isRead ? 'Lida' : 'Nao lida'}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        {presentation.ctaHref && presentation.ctaLabel ? (
+          <Link
+            href={presentation.ctaHref}
+            className="text-sm font-medium text-accent-cyan transition hover:text-primary"
+          >
+            {presentation.ctaLabel}
+          </Link>
+        ) : null}
+
+        {showMarkAsRead ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={isMarkingRead}
+            onClick={() => {
+              onMarkAsRead(notification.id);
+            }}
+          >
+            {isMarkingRead ? 'Marcando...' : 'Marcar como lida'}
+          </Button>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/notifications/notifications-bell.tsx
+++ b/frontend/src/components/notifications/notifications-bell.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { NotificationDropdown } from '@/components/notifications/notification-dropdown';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchNotifications,
+  markAllNotificationsAsRead,
+  markNotificationAsRead,
+} from '@/services/notifications';
+
+export function NotificationsBell() {
+  const queryClient = useQueryClient();
+  const { user, status } = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeNotificationId, setActiveNotificationId] = useState<string | null>(null);
+  const userId = user?.id;
+
+  const notificationsQuery = useQuery({
+    queryKey: ['notifications', userId, 'all'],
+    queryFn: () => fetchNotifications({ userId: userId as string }),
+    enabled: status === 'authenticated' && typeof userId === 'string',
+    refetchInterval: 30_000,
+  });
+
+  const invalidateNotifications = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'all'] }),
+      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'unread'] }),
+    ]);
+  };
+
+  const markOneMutation = useMutation({
+    mutationFn: markNotificationAsRead,
+    onMutate: (notificationId) => {
+      setActiveNotificationId(notificationId);
+    },
+    onSuccess: async () => {
+      await invalidateNotifications();
+    },
+    onSettled: () => {
+      setActiveNotificationId(null);
+    },
+  });
+
+  const markAllMutation = useMutation({
+    mutationFn: markAllNotificationsAsRead,
+    onSuccess: async () => {
+      await invalidateNotifications();
+    },
+  });
+
+  if (status !== 'authenticated' || !userId) {
+    return null;
+  }
+
+  const data = notificationsQuery.data;
+
+  return (
+    <div className="relative">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label="Open notifications preview"
+        onClick={() => {
+          setIsOpen((current) => !current);
+        }}
+      >
+        Notifications
+        <Badge tone={data?.unreadCount ? 'accent' : 'neutral'}>
+          {notificationsQuery.isPending ? '...' : String(data?.unreadCount ?? 0)}
+        </Badge>
+      </Button>
+
+      {isOpen ? (
+        <div className="absolute right-0 top-[calc(100%+0.75rem)] z-40 w-[24rem] max-w-[calc(100vw-2rem)]">
+          <NotificationDropdown
+            notifications={data?.notifications ?? []}
+            unreadCount={data?.unreadCount ?? 0}
+            isLoading={notificationsQuery.isPending}
+            isError={notificationsQuery.isError}
+            activeNotificationId={activeNotificationId}
+            isMarkingAllRead={markAllMutation.isPending}
+            onMarkAsRead={(notificationId) => {
+              markOneMutation.mutate(notificationId);
+            }}
+            onMarkAllAsRead={() => {
+              markAllMutation.mutate();
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/notifications/notifications-page-content.tsx
+++ b/frontend/src/components/notifications/notifications-page-content.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { NotificationItem } from '@/components/notifications/notification-item';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchNotifications,
+  markAllNotificationsAsRead,
+  markNotificationAsRead,
+} from '@/services/notifications';
+
+function NotificationsLoadingState() {
+  return (
+    <div className="space-y-4" data-testid="notifications-loading">
+      <Card>
+        <div className="h-8 w-56 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-4 h-5 w-full animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+      <Card>
+        <div className="h-6 w-44 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-4 h-5 w-2/3 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+    </div>
+  );
+}
+
+function NotificationsErrorState() {
+  return (
+    <Card data-testid="notifications-error">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Notifications</p>
+        <h2 className="font-display text-2xl font-semibold text-primary">
+          Nao foi possivel carregar as notificacoes
+        </h2>
+        <p className="text-sm leading-6 text-secondary">
+          Tente novamente em alguns instantes.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function NotificationsEmptyState() {
+  return (
+    <Card data-testid="notifications-empty">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Notifications</p>
+        <h2 className="font-display text-2xl font-semibold text-primary">
+          Inbox limpo
+        </h2>
+        <p className="text-sm leading-6 text-secondary">
+          Novas interacoes do CLUTCH aparecem aqui assim que chegarem.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+export function NotificationsPageContent() {
+  const queryClient = useQueryClient();
+  const { status, user } = useAuth();
+  const userId = user?.id;
+
+  const notificationsQuery = useQuery({
+    queryKey: ['notifications', userId, 'all'],
+    queryFn: () => fetchNotifications({ userId: userId as string }),
+    enabled: status === 'authenticated' && typeof userId === 'string',
+    refetchInterval: 30_000,
+  });
+
+  const invalidateNotifications = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'all'] }),
+      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'unread'] }),
+    ]);
+  };
+
+  const markOneMutation = useMutation({
+    mutationFn: markNotificationAsRead,
+    onSuccess: async () => {
+      await invalidateNotifications();
+    },
+  });
+
+  const markAllMutation = useMutation({
+    mutationFn: markAllNotificationsAsRead,
+    onSuccess: async () => {
+      await invalidateNotifications();
+    },
+  });
+
+  if (status === 'loading') {
+    return <NotificationsLoadingState />;
+  }
+
+  if (status !== 'authenticated' || !userId) {
+    return <NotificationsErrorState />;
+  }
+
+  if (notificationsQuery.isPending) {
+    return <NotificationsLoadingState />;
+  }
+
+  if (notificationsQuery.isError) {
+    return <NotificationsErrorState />;
+  }
+
+  const data = notificationsQuery.data;
+
+  return (
+    <section className="space-y-section" data-testid="notifications-success">
+      <SectionHeading
+        eyebrow="Notifications"
+        title="Seu inbox social"
+        description="Acompanhe amizade, reactions e comentarios usando apenas o contrato real do backend."
+        level="h1"
+        actions={(
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={data.unreadCount === 0 || markAllMutation.isPending}
+            onClick={() => {
+              markAllMutation.mutate();
+            }}
+          >
+            {markAllMutation.isPending ? 'Marcando...' : 'Marcar todas como lidas'}
+          </Button>
+        )}
+      />
+
+      {data.notifications.length === 0 ? <NotificationsEmptyState /> : null}
+
+      {data.notifications.length > 0 ? (
+        <div className="space-y-4">
+          {data.notifications.map((notification) => (
+            <NotificationItem
+              key={notification.id}
+              notification={notification}
+              onMarkAsRead={(notificationId) => {
+                markOneMutation.mutate(notificationId);
+              }}
+              isMarkingRead={
+                markOneMutation.isPending && markOneMutation.variables === notification.id
+              }
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -30,4 +30,14 @@ export {
   pendingFriendRequestSchema,
   pendingFriendRequestsResponseSchema,
 } from './friends';
+export {
+  friendAcceptedNotificationPayloadSchema,
+  friendRequestNotificationPayloadSchema,
+  markAllNotificationsReadResponseSchema,
+  notificationRecordSchema,
+  notificationsResponseSchema,
+  notificationTypeSchema,
+  postCommentNotificationPayloadSchema,
+  postLikeNotificationPayloadSchema,
+} from './notifications';
 export { profileResponseSchema } from './profile';

--- a/frontend/src/schemas/notifications.ts
+++ b/frontend/src/schemas/notifications.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+export const notificationTypeSchema = z.enum([
+  'FRIEND_REQUEST',
+  'FRIEND_ACCEPTED',
+  'POST_LIKE',
+  'POST_COMMENT',
+  'GAME_INVITE',
+  'FRIEND_NOW_PLAYING',
+  'SYSTEM',
+]);
+
+export const friendRequestNotificationPayloadSchema = z.object({
+  requestId: z.string().min(1),
+  senderId: z.string().min(1),
+});
+
+export const friendAcceptedNotificationPayloadSchema = z.object({
+  requestId: z.string().min(1),
+  friendId: z.string().min(1),
+});
+
+export const postLikeNotificationPayloadSchema = z.object({
+  postId: z.string().min(1),
+  interactionType: z.enum(['LIKE', 'GG', 'F', 'CLAP', 'HYPE']),
+});
+
+export const postCommentNotificationPayloadSchema = z.object({
+  postId: z.string().min(1),
+  commentId: z.string().min(1),
+  parentId: z.string().nullable(),
+});
+
+export const notificationRecordSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  actorId: z.string().nullable(),
+  type: notificationTypeSchema,
+  payload: z.record(z.unknown()),
+  isRead: z.boolean(),
+  createdAt: z.string().min(1),
+});
+
+export const notificationsResponseSchema = z.object({
+  notifications: z.array(notificationRecordSchema),
+  unreadCount: z.number().int().min(0),
+});
+
+export const markAllNotificationsReadResponseSchema = z.object({
+  message: z.string().min(1),
+});
+
+export type NotificationType = z.infer<typeof notificationTypeSchema>;
+export type NotificationRecord = z.infer<typeof notificationRecordSchema>;
+export type NotificationsResponse = z.infer<typeof notificationsResponseSchema>;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -18,4 +18,10 @@ export {
   FeedRequestError,
   togglePostInteraction,
 } from './feed';
+export {
+  fetchNotifications,
+  markAllNotificationsAsRead,
+  markNotificationAsRead,
+  NotificationsRequestError,
+} from './notifications';
 export { fetchProfileByUsername, ProfileRequestError } from './profile';

--- a/frontend/src/services/notifications.ts
+++ b/frontend/src/services/notifications.ts
@@ -1,0 +1,116 @@
+import { apiRequest } from '@/lib/api';
+import {
+  markAllNotificationsReadResponseSchema,
+  notificationRecordSchema,
+  notificationsResponseSchema,
+  type NotificationRecord,
+  type NotificationsResponse,
+} from '@/schemas/notifications';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+type FetchNotificationsInput = {
+  userId: string;
+  unreadOnly?: boolean;
+};
+
+export class NotificationsRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'NotificationsRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchNotifications(
+  input: FetchNotificationsInput,
+): Promise<NotificationsResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (input.unreadOnly) {
+    searchParams.set('unreadOnly', 'true');
+  }
+
+  const path = `/notifications/${encodeURIComponent(input.userId)}${
+    searchParams.size > 0 ? `?${searchParams.toString()}` : ''
+  }`;
+
+  const response = await apiRequest(path, { method: 'GET' });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new NotificationsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar as notificacoes agora.'),
+    );
+  }
+
+  return notificationsResponseSchema.parse(payload);
+}
+
+export async function markNotificationAsRead(
+  notificationId: string,
+): Promise<NotificationRecord> {
+  const response = await apiRequest(
+    `/notifications/${encodeURIComponent(notificationId)}/read`,
+    {
+      method: 'PATCH',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new NotificationsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel marcar a notificacao como lida.'),
+    );
+  }
+
+  return notificationRecordSchema.parse(payload);
+}
+
+export async function markAllNotificationsAsRead(): Promise<void> {
+  const response = await apiRequest('/notifications/read-all', {
+    method: 'PATCH',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new NotificationsRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel marcar todas as notificacoes como lidas.'),
+    );
+  }
+
+  markAllNotificationsReadResponseSchema.parse(payload);
+}

--- a/frontend/tests/unit/components/navbar.test.tsx
+++ b/frontend/tests/unit/components/navbar.test.tsx
@@ -20,6 +20,10 @@ vi.mock('@/components/friends/friend-request-card', () => ({
   ),
 }));
 
+vi.mock('@/components/notifications/notifications-bell', () => ({
+  NotificationsBell: () => <div data-testid="notifications-bell">notifications-bell</div>,
+}));
+
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedFetchPendingFriendRequests = vi.mocked(fetchPendingFriendRequests);
 
@@ -71,6 +75,7 @@ describe('Navbar', () => {
 
     renderNavbar();
 
+    expect(screen.getByTestId('notifications-bell')).toBeInTheDocument();
     expect(await screen.findByText('1')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /open friend requests preview/i }));

--- a/frontend/tests/unit/components/notification-item.test.tsx
+++ b/frontend/tests/unit/components/notification-item.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NotificationItem } from '@/components/notifications/notification-item';
+
+describe('NotificationItem', () => {
+  it('renders a post comment notification with feed CTA and mark-as-read action', () => {
+    const onMarkAsRead = vi.fn();
+
+    render(
+      <NotificationItem
+        notification={{
+          id: 'notification-1',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'POST_COMMENT',
+          payload: {
+            postId: 'post-1',
+            commentId: 'comment-1',
+            parentId: null,
+          },
+          isRead: false,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        }}
+        onMarkAsRead={onMarkAsRead}
+      />,
+    );
+
+    expect(screen.getByText(/novo comentario no seu post/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /ver feed/i })).toHaveAttribute('href', '/feed');
+
+    fireEvent.click(screen.getByRole('button', { name: /marcar como lida/i }));
+
+    expect(onMarkAsRead).toHaveBeenCalledWith('notification-1');
+  });
+
+  it('renders a read friend accepted notification without mark-as-read action', () => {
+    render(
+      <NotificationItem
+        notification={{
+          id: 'notification-2',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'FRIEND_ACCEPTED',
+          payload: {
+            requestId: 'request-1',
+            friendId: 'user-2',
+          },
+          isRead: true,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/pedido de amizade aceito/i)).toBeInTheDocument();
+    expect(screen.getByText(/^lida$/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /marcar como lida/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/notifications-bell.test.tsx
+++ b/frontend/tests/unit/components/notifications-bell.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationsBell } from '@/components/notifications/notifications-bell';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchNotifications,
+} from '@/services/notifications';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/notifications', () => ({
+  fetchNotifications: vi.fn(),
+  markAllNotificationsAsRead: vi.fn(),
+  markNotificationAsRead: vi.fn(),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchNotifications = vi.mocked(fetchNotifications);
+
+function renderNotificationsBell() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <NotificationsBell />
+    </QueryClientProvider>,
+  );
+}
+
+describe('NotificationsBell', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchNotifications.mockReset();
+
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+  });
+
+  it('renders the unread notifications count and opens the dropdown', async () => {
+    mockedFetchNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'notification-1',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'FRIEND_REQUEST',
+          payload: {
+            requestId: 'request-1',
+            senderId: 'user-2',
+          },
+          isRead: false,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        },
+      ],
+      unreadCount: 1,
+    });
+
+    renderNotificationsBell();
+
+    expect(await screen.findByText('1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /open notifications preview/i }));
+
+    expect(await screen.findByText(/activity inbox/i)).toBeInTheDocument();
+    expect(screen.getByText(/pedido de amizade recebido/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/notifications-page-content.test.tsx
+++ b/frontend/tests/unit/components/notifications-page-content.test.tsx
@@ -1,0 +1,188 @@
+import React, { type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationsPageContent } from '@/components/notifications/notifications-page-content';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchNotifications,
+  markAllNotificationsAsRead,
+  markNotificationAsRead,
+} from '@/services/notifications';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/notifications', () => ({
+  fetchNotifications: vi.fn(),
+  markNotificationAsRead: vi.fn(),
+  markAllNotificationsAsRead: vi.fn(),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchNotifications = vi.mocked(fetchNotifications);
+const mockedMarkNotificationAsRead = vi.mocked(markNotificationAsRead);
+const mockedMarkAllNotificationsAsRead = vi.mocked(markAllNotificationsAsRead);
+
+function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('NotificationsPageContent', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchNotifications.mockReset();
+    mockedMarkNotificationAsRead.mockReset();
+    mockedMarkAllNotificationsAsRead.mockReset();
+  });
+
+  it('renders loading state while auth is loading', () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'loading',
+      user: null,
+      logout: vi.fn(),
+    });
+
+    renderWithQuery(<NotificationsPageContent />);
+
+    expect(screen.getByTestId('notifications-loading')).toBeInTheDocument();
+  });
+
+  it('renders notifications on success and marks all as read', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'notification-1',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'POST_LIKE',
+          payload: {
+            postId: 'post-1',
+            interactionType: 'GG',
+          },
+          isRead: false,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        },
+      ],
+      unreadCount: 1,
+    });
+    mockedMarkAllNotificationsAsRead.mockResolvedValue(undefined);
+
+    renderWithQuery(<NotificationsPageContent />);
+
+    expect(await screen.findByText(/nova reaction no seu post/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /marcar todas como lidas/i }));
+
+    await waitFor(() => {
+      expect(mockedMarkAllNotificationsAsRead).toHaveBeenCalled();
+    });
+  });
+
+  it('marks a single notification as read from the list', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'notification-1',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'FRIEND_REQUEST',
+          payload: {
+            requestId: 'request-1',
+            senderId: 'user-2',
+          },
+          isRead: false,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        },
+      ],
+      unreadCount: 1,
+    });
+    mockedMarkNotificationAsRead.mockResolvedValue({
+      id: 'notification-1',
+      userId: 'user-1',
+      actorId: 'user-2',
+      type: 'FRIEND_REQUEST',
+      payload: {
+        requestId: 'request-1',
+        senderId: 'user-2',
+      },
+      isRead: true,
+      createdAt: '2026-03-31T10:00:00.000Z',
+    });
+
+    renderWithQuery(<NotificationsPageContent />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /marcar como lida/i }));
+
+    await waitFor(() => {
+      expect(mockedMarkNotificationAsRead).toHaveBeenCalled();
+    });
+
+    expect(mockedMarkNotificationAsRead.mock.calls[0]?.[0]).toBe('notification-1');
+  });
+
+  it('renders empty state when there are no notifications', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchNotifications.mockResolvedValue({
+      notifications: [],
+      unreadCount: 0,
+    });
+
+    renderWithQuery(<NotificationsPageContent />);
+
+    expect(await screen.findByTestId('notifications-empty')).toBeInTheDocument();
+  });
+
+  it('renders generic error state when notifications request fails', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchNotifications.mockRejectedValue(new Error('network'));
+
+    renderWithQuery(<NotificationsPageContent />);
+
+    expect(await screen.findByTestId('notifications-error')).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/services/notifications.test.ts
+++ b/frontend/tests/unit/services/notifications.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import {
+  fetchNotifications,
+  markAllNotificationsAsRead,
+  markNotificationAsRead,
+} from '@/services/notifications';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+describe('notifications service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('returns parsed notifications list', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          notifications: [
+            {
+              id: 'notification-1',
+              userId: 'user-1',
+              actorId: 'user-2',
+              type: 'FRIEND_REQUEST',
+              payload: {
+                requestId: 'request-1',
+                senderId: 'user-2',
+              },
+              isRead: false,
+              createdAt: '2026-03-31T10:00:00.000Z',
+            },
+          ],
+          unreadCount: 1,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await fetchNotifications({ userId: 'user-1' });
+
+    expect(response.unreadCount).toBe(1);
+    expect(response.notifications).toHaveLength(1);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/notifications/user-1', {
+      method: 'GET',
+    });
+  });
+
+  it('supports unread-only notifications query', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({ notifications: [], unreadCount: 0 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await fetchNotifications({ userId: 'user-1', unreadOnly: true });
+
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/notifications/user-1?unreadOnly=true',
+      { method: 'GET' },
+    );
+  });
+
+  it('marks a single notification as read', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'notification-1',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'POST_COMMENT',
+          payload: {
+            postId: 'post-1',
+            commentId: 'comment-1',
+            parentId: null,
+          },
+          isRead: true,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await markNotificationAsRead('notification-1');
+
+    expect(response.isRead).toBe(true);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/notifications/notification-1/read', {
+      method: 'PATCH',
+    });
+  });
+
+  it('marks all notifications as read', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({ message: 'Todas as notificacoes marcadas como lidas.' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    await markAllNotificationsAsRead();
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('/notifications/read-all', {
+      method: 'PATCH',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the authenticated `/notifications` page with explicit loading, error and empty states
- implement typed notifications services and reusable UI for item rendering, dropdown preview and unread badge
- integrate the navbar with the real notifications contract using polling, mark-as-read and mark-all actions

## What changed
- add `GET /notifications/:userId` integration with support for `unreadOnly` and `unreadCount`
- add mutations for `PATCH /notifications/:id/read` and `PATCH /notifications/read-all`
- add `NotificationItem`, `NotificationDropdown`, `NotificationsBell` and `NotificationsPageContent`
- wire the navbar to show unread notifications without redesigning the shell
- add unit coverage for notifications services, item rendering, bell/dropdown behavior and page states

## Contract notes
- the current backend response exposes `actorId`, `type`, `payload`, `isRead` and `createdAt`, but it does not include actor usernames or direct profile slugs
- because of that, the UI renders conservative copy per notification type and only links to `/feed` when the real payload contains a post-related target
- polling is implemented via React Query every 30 seconds, which matches the issue expectation without inventing a new realtime transport

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build

## Risks
- richer actor display and deeper CTA navigation will require backend contract expansion if we want profile-aware notification copy or direct post anchors

Closes #95