### PR TITLE
feat(settings): add profile settings and platform integrations

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -9,6 +9,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'images.unsplash.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'images.igdb.com',
+      },
     ],
   },
 };

--- a/frontend/src/app/(app)/settings/integrations/page.tsx
+++ b/frontend/src/app/(app)/settings/integrations/page.tsx
@@ -1,0 +1,5 @@
+import { IntegrationsPageContent } from '@/components/settings/integrations-page-content';
+
+export default function SettingsIntegrationsPage() {
+  return <IntegrationsPageContent />;
+}

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -1,0 +1,5 @@
+import { ProfileSettingsPageContent } from '@/components/settings/profile-settings-page-content';
+
+export default function SettingsPage() {
+  return <ProfileSettingsPageContent />;
+}

--- a/frontend/src/components/settings/epic-integration-card.tsx
+++ b/frontend/src/components/settings/epic-integration-card.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  epicConnectRequestSchema,
+  type EpicConnectValues,
+} from '@/schemas/integrations';
+import { connectEpic, IntegrationsRequestError } from '@/services/integrations';
+
+type EpicIntegrationCardProps = {
+  isConnected: boolean;
+  importedPreviewCount: number;
+  onRefreshStatus: () => Promise<void>;
+};
+
+export function EpicIntegrationCard({
+  isConnected,
+  importedPreviewCount,
+  onRefreshStatus,
+}: EpicIntegrationCardProps) {
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<EpicConnectValues>({
+    resolver: zodResolver(epicConnectRequestSchema),
+    defaultValues: {
+      authToken: '',
+    },
+    mode: 'onChange',
+  });
+
+  const epicMutation = useMutation({
+    mutationFn: connectEpic,
+    onSuccess: async (response) => {
+      setErrorMessage(null);
+      setFeedback(response.message);
+      await onRefreshStatus();
+    },
+    onError: (error) => {
+      setFeedback(null);
+      setErrorMessage(
+        error instanceof IntegrationsRequestError
+          ? error.message
+          : 'Nao foi possivel conectar a Epic agora.',
+      );
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    await epicMutation.mutateAsync(values);
+  });
+
+  return (
+    <Card className="space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Epic</p>
+          <h2 className="font-display text-2xl font-semibold text-primary">
+            Biblioteca Epic Games
+          </h2>
+          <p className="text-sm leading-6 text-secondary">
+            Conecta pelo token de autenticacao real e importa a biblioteca disponivel.
+          </p>
+        </div>
+        <Badge tone={isConnected ? 'success' : 'neutral'}>
+          {isConnected ? 'Conectada' : 'Nao conectada'}
+        </Badge>
+      </div>
+
+      <p className="text-sm text-secondary">
+        {isConnected
+          ? `A profile API mostra ${importedPreviewCount} jogo(s) recentes dessa integracao.`
+          : 'Ainda nao ha integracao Epic ativa neste perfil.'}
+      </p>
+
+      {feedback ? (
+        <div className="rounded-control border border-status-online/40 bg-[rgba(16,185,129,0.12)] px-control-x py-control-y text-sm text-primary">
+          {feedback}
+        </div>
+      ) : null}
+
+      {errorMessage ? (
+        <div className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <form className="space-y-4" onSubmit={onSubmit} noValidate>
+        <label className="space-y-2">
+          <span className="text-sm font-medium text-primary">Token Epic</span>
+          <input
+            type="password"
+            className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+            placeholder="Cole o token de autenticacao"
+            aria-invalid={Boolean(errors.authToken)}
+            aria-describedby={errors.authToken ? 'epic-token-error' : undefined}
+            {...register('authToken')}
+          />
+          {errors.authToken ? (
+            <span id="epic-token-error" className="text-sm text-status-afk">
+              {errors.authToken.message}
+            </span>
+          ) : null}
+        </label>
+
+        <Button type="submit" disabled={isSubmitting || epicMutation.isPending}>
+          {isSubmitting || epicMutation.isPending ? 'Conectando...' : 'Conectar Epic'}
+        </Button>
+      </form>
+
+      <p className="text-xs leading-5 text-secondary">
+        O contrato atual nao expoe sync dedicado nem endpoint de desconexao para a Epic.
+      </p>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/igdb-search-card.tsx
+++ b/frontend/src/components/settings/igdb-search-card.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  igdbSearchRequestSchema,
+  type IgdbSearchResponse,
+  type IgdbSearchValues,
+} from '@/schemas/integrations';
+import { IntegrationsRequestError, searchIgdbGame } from '@/services/integrations';
+
+export function IgdbSearchCard() {
+  const [result, setResult] = useState<IgdbSearchResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<IgdbSearchValues>({
+    resolver: zodResolver(igdbSearchRequestSchema),
+    defaultValues: {
+      q: '',
+    },
+    mode: 'onChange',
+  });
+
+  const searchMutation = useMutation({
+    mutationFn: (values: IgdbSearchValues) => searchIgdbGame(values.q),
+    onSuccess: (response) => {
+      setErrorMessage(null);
+      setResult(response);
+    },
+    onError: (error) => {
+      setResult(null);
+      setErrorMessage(
+        error instanceof IntegrationsRequestError
+          ? error.message
+          : 'Nao foi possivel buscar no IGDB agora.',
+      );
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    await searchMutation.mutateAsync(values);
+  });
+
+  return (
+    <Card className="space-y-5">
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">IGDB</p>
+        <h2 className="font-display text-2xl font-semibold text-primary">
+          Busca de jogos
+        </h2>
+        <p className="text-sm leading-6 text-secondary">
+          O contrato atual retorna um jogo por consulta, com capa e plataformas quando disponiveis.
+        </p>
+      </div>
+
+      <form className="space-y-4" onSubmit={onSubmit} noValidate>
+        <label className="space-y-2">
+          <span className="text-sm font-medium text-primary">Nome do jogo</span>
+          <input
+            type="search"
+            className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+            placeholder="Ex.: Counter-Strike 2"
+            aria-invalid={Boolean(errors.q)}
+            aria-describedby={errors.q ? 'igdb-search-error' : undefined}
+            {...register('q')}
+          />
+          {errors.q ? (
+            <span id="igdb-search-error" className="text-sm text-status-afk">
+              {errors.q.message}
+            </span>
+          ) : null}
+        </label>
+
+        <Button type="submit" disabled={isSubmitting || searchMutation.isPending}>
+          {isSubmitting || searchMutation.isPending ? 'Buscando...' : 'Buscar no IGDB'}
+        </Button>
+      </form>
+
+      {errorMessage ? (
+        <div className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      {result ? (
+        <Card className="space-y-4" tone="neutral">
+          <div className="flex items-start gap-4">
+            <Avatar
+              src={result.coverUrl}
+              alt={result.name}
+              fallback={result.name.slice(0, 2).toUpperCase()}
+              size="lg"
+              className="rounded-control"
+            />
+            <div className="space-y-2">
+              <h3 className="font-display text-xl font-semibold text-primary">
+                {result.name}
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {result.platforms.map((platform) => (
+                  <Badge key={platform} tone="neutral">
+                    {platform}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <p className="text-sm leading-6 text-secondary">
+            {result.summary || 'O backend nao retornou resumo para esta busca.'}
+          </p>
+        </Card>
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/integrations-page-content.tsx
+++ b/frontend/src/components/settings/integrations-page-content.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { EpicIntegrationCard } from '@/components/settings/epic-integration-card';
+import { IgdbSearchCard } from '@/components/settings/igdb-search-card';
+import { SettingsNav } from '@/components/settings/settings-nav';
+import { SteamIntegrationCard } from '@/components/settings/steam-integration-card';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { useAuth } from '@/hooks/use-auth';
+import { fetchProfileByUsername, ProfileRequestError } from '@/services/profile';
+
+function IntegrationsLoadingState() {
+  return (
+    <div className="space-y-4" data-testid="settings-integrations-loading">
+      <Card>
+        <div className="h-8 w-56 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-4 h-20 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+      <Card>
+        <div className="h-32 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+    </div>
+  );
+}
+
+function IntegrationsErrorState({ message }: { message: string }) {
+  return (
+    <Card data-testid="settings-integrations-error">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Integrations</p>
+        <h2 className="font-display text-2xl font-semibold text-primary">
+          Nao foi possivel carregar as integracoes
+        </h2>
+        <p className="text-sm leading-6 text-secondary">{message}</p>
+      </div>
+    </Card>
+  );
+}
+
+export function IntegrationsPageContent() {
+  const { user, status } = useAuth();
+  const username = user?.username ?? null;
+
+  const profileQuery = useQuery({
+    queryKey: ['profile', username],
+    queryFn: () => fetchProfileByUsername(username as string),
+    enabled: status === 'authenticated' && typeof username === 'string',
+  });
+
+  if (status === 'loading' || profileQuery.isPending) {
+    return <IntegrationsLoadingState />;
+  }
+
+  if (status !== 'authenticated' || !username || profileQuery.isError || !profileQuery.data) {
+    const errorMessage =
+      profileQuery.error instanceof ProfileRequestError
+        ? profileQuery.error.message
+        : 'Tente novamente em alguns instantes.';
+
+    return <IntegrationsErrorState message={errorMessage} />;
+  }
+
+  const steamGames = profileQuery.data.gameLibrary.filter((game) => game.platform === 'STEAM');
+  const epicGames = profileQuery.data.gameLibrary.filter((game) => game.platform === 'EPIC');
+  const connectedPlatforms = new Set(
+    profileQuery.data.platformIntegrations.map((integration) => integration.platform),
+  );
+
+  return (
+    <div className="space-y-section" data-testid="settings-integrations-success">
+      <SectionHeading
+        eyebrow="Settings"
+        title="Integracoes de plataformas"
+        description="Cards conectados apenas aos contratos reais de Steam, Epic e busca IGDB."
+        level="h1"
+      />
+
+      <SettingsNav />
+
+      <div className="grid gap-section xl:grid-cols-2">
+        <SteamIntegrationCard
+          isConnected={connectedPlatforms.has('STEAM')}
+          importedPreviewCount={steamGames.length}
+          onRefreshStatus={async () => {
+            await profileQuery.refetch();
+          }}
+        />
+
+        <EpicIntegrationCard
+          isConnected={connectedPlatforms.has('EPIC')}
+          importedPreviewCount={epicGames.length}
+          onRefreshStatus={async () => {
+            await profileQuery.refetch();
+          }}
+        />
+      </div>
+
+      <IgdbSearchCard />
+
+      <Card className="space-y-4" tone="neutral">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">Discord</p>
+            <h2 className="font-display text-2xl font-semibold text-primary">
+              Ainda fora do contrato frontend atual
+            </h2>
+            <p className="text-sm leading-6 text-secondary">
+              A issue original menciona Discord, mas o backend atual nao expoe rota de connect para essa integracao.
+            </p>
+          </div>
+          <Badge tone="warning">Limitacao real</Badge>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/profile-settings-form.tsx
+++ b/frontend/src/components/settings/profile-settings-form.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { GamerCard } from '@/components/profile/gamer-card';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  profileUpdateRequestSchema,
+  type ProfileResponse,
+  type ProfileUpdateValues,
+} from '@/schemas/profile';
+import {
+  fetchProfileByUsername,
+  ProfileRequestError,
+  updateProfileByUsername,
+} from '@/services/profile';
+
+const fieldClassName = 'space-y-2';
+const textAreaClassName =
+  'min-h-[7rem] w-full rounded-control border border-border bg-background-secondary px-control-x py-control-y text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30';
+
+function isValidRemoteUrl(value: string | null | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(value);
+    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isValidAccentColor(value: string | null | undefined): value is string {
+  return typeof value === 'string' && /^#[0-9A-Fa-f]{6}$/.test(value);
+}
+
+function buildPreviewProfile(
+  profile: ProfileResponse,
+  values: ProfileUpdateValues,
+): ProfileResponse {
+  const displayName = values.displayName ?? profile.profile.displayName ?? '';
+  const bio = values.bio ?? profile.profile.bio ?? '';
+  const avatarUrl = values.avatarUrl ?? profile.profile.avatarUrl;
+  const bannerUrl = values.bannerUrl ?? profile.profile.bannerUrl;
+  const accentColor = values.accentColor ?? profile.profile.accentColor;
+
+  return {
+    ...profile,
+    profile: {
+      ...profile.profile,
+      displayName: displayName.trim(),
+      bio: bio.trim(),
+      avatarUrl: isValidRemoteUrl(avatarUrl)
+        ? avatarUrl
+        : profile.profile.avatarUrl,
+      bannerUrl: isValidRemoteUrl(bannerUrl)
+        ? bannerUrl
+        : profile.profile.bannerUrl,
+      accentColor: isValidAccentColor(accentColor)
+        ? accentColor
+        : profile.profile.accentColor,
+    },
+  };
+}
+
+function ProfileSettingsLoadingState() {
+  return (
+    <div className="space-y-4" data-testid="settings-profile-loading">
+      <Card>
+        <div className="h-8 w-56 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-4 h-32 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+      <Card>
+        <div className="h-48 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+    </div>
+  );
+}
+
+function ProfileSettingsErrorState({ message }: { message: string }) {
+  return (
+    <Card data-testid="settings-profile-error">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Settings</p>
+        <h2 className="font-display text-2xl font-semibold text-primary">
+          Nao foi possivel carregar seu perfil
+        </h2>
+        <p className="text-sm leading-6 text-secondary">{message}</p>
+      </div>
+    </Card>
+  );
+}
+
+export function ProfileSettingsForm() {
+  const queryClient = useQueryClient();
+  const { user, status } = useAuth();
+  const [serverFeedback, setServerFeedback] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const username = user?.username ?? null;
+
+  const profileQuery = useQuery({
+    queryKey: ['profile', username],
+    queryFn: () => fetchProfileByUsername(username as string),
+    enabled: status === 'authenticated' && typeof username === 'string',
+  });
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<ProfileUpdateValues>({
+    resolver: zodResolver(profileUpdateRequestSchema),
+    values: profileQuery.data
+      ? {
+          displayName: profileQuery.data.profile.displayName ?? '',
+          bio: profileQuery.data.profile.bio ?? '',
+          avatarUrl: profileQuery.data.profile.avatarUrl ?? '',
+          bannerUrl: profileQuery.data.profile.bannerUrl ?? '',
+          accentColor: profileQuery.data.profile.accentColor ?? '#7C3AED',
+        }
+      : undefined,
+    mode: 'onChange',
+  });
+
+  const watchedValues = watch();
+  const previewProfile = useMemo(() => {
+    if (!profileQuery.data) {
+      return null;
+    }
+
+    return buildPreviewProfile(profileQuery.data, watchedValues);
+  }, [profileQuery.data, watchedValues]);
+
+  const updateProfileMutation = useMutation({
+    mutationFn: (values: ProfileUpdateValues) =>
+      updateProfileByUsername(username as string, values),
+    onSuccess: async (_, values) => {
+      setServerError(null);
+      setServerFeedback('Perfil atualizado com sucesso.');
+
+      queryClient.setQueryData<ProfileResponse | undefined>(
+        ['profile', username],
+        (current) => {
+          if (!current) {
+            return current;
+          }
+
+          return buildPreviewProfile(current, values);
+        },
+      );
+
+      await queryClient.invalidateQueries({ queryKey: ['profile', username] });
+      reset(values);
+    },
+    onError: (error) => {
+      setServerFeedback(null);
+
+      if (error instanceof ProfileRequestError) {
+        setServerError(error.message);
+        return;
+      }
+
+      setServerError('Nao foi possivel salvar seu perfil agora.');
+    },
+  });
+
+  if (status === 'loading' || profileQuery.isPending) {
+    return <ProfileSettingsLoadingState />;
+  }
+
+  if (status !== 'authenticated' || !username || profileQuery.isError || !profileQuery.data) {
+    const errorMessage =
+      profileQuery.error instanceof ProfileRequestError
+        ? profileQuery.error.message
+        : 'Tente novamente em alguns instantes.';
+
+    return <ProfileSettingsErrorState message={errorMessage} />;
+  }
+
+  const onSubmit = handleSubmit(async (values) => {
+    setServerFeedback(null);
+    setServerError(null);
+    await updateProfileMutation.mutateAsync(values);
+  });
+
+  return (
+    <div className="space-y-section" data-testid="settings-profile-success">
+      <SectionHeading
+        eyebrow="Settings"
+        title="Seu perfil do CLUTCH"
+        description="Edite os campos suportados pelo backend e acompanhe o preview do seu GamerCard antes de salvar."
+        level="h1"
+      />
+
+      <div className="grid gap-section xl:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)]">
+        <Card className="space-y-6">
+          {serverFeedback ? (
+            <div
+              role="status"
+              className="rounded-control border border-status-online/40 bg-[rgba(16,185,129,0.12)] px-control-x py-control-y text-sm leading-6 text-primary"
+            >
+              {serverFeedback}
+            </div>
+          ) : null}
+
+          {serverError ? (
+            <div
+              role="alert"
+              className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm leading-6 text-primary"
+            >
+              {serverError}
+            </div>
+          ) : null}
+
+          <form className="space-y-5" onSubmit={onSubmit} noValidate>
+            <label className={fieldClassName}>
+              <span className="text-sm font-medium text-primary">Display name</span>
+              <input
+                type="text"
+                className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+                placeholder="Seu nome de exibicao"
+                aria-invalid={Boolean(errors.displayName)}
+                aria-describedby={errors.displayName ? 'settings-display-name-error' : undefined}
+                {...register('displayName')}
+              />
+              {errors.displayName ? (
+                <span id="settings-display-name-error" className="text-sm text-status-afk">
+                  {errors.displayName.message}
+                </span>
+              ) : null}
+            </label>
+
+            <label className={fieldClassName}>
+              <span className="text-sm font-medium text-primary">Bio</span>
+              <textarea
+                className={textAreaClassName}
+                placeholder="Conte um pouco sobre sua identidade gamer e geek."
+                aria-invalid={Boolean(errors.bio)}
+                aria-describedby={errors.bio ? 'settings-bio-error' : undefined}
+                {...register('bio')}
+              />
+              {errors.bio ? (
+                <span id="settings-bio-error" className="text-sm text-status-afk">
+                  {errors.bio.message}
+                </span>
+              ) : null}
+            </label>
+
+            <label className={fieldClassName}>
+              <span className="text-sm font-medium text-primary">Avatar URL</span>
+              <input
+                type="url"
+                className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+                placeholder="https://..."
+                aria-invalid={Boolean(errors.avatarUrl)}
+                aria-describedby={errors.avatarUrl ? 'settings-avatar-error' : undefined}
+                {...register('avatarUrl')}
+              />
+              {errors.avatarUrl ? (
+                <span id="settings-avatar-error" className="text-sm text-status-afk">
+                  {errors.avatarUrl.message}
+                </span>
+              ) : null}
+            </label>
+
+            <label className={fieldClassName}>
+              <span className="text-sm font-medium text-primary">Banner URL</span>
+              <input
+                type="url"
+                className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+                placeholder="https://..."
+                aria-invalid={Boolean(errors.bannerUrl)}
+                aria-describedby={errors.bannerUrl ? 'settings-banner-error' : undefined}
+                {...register('bannerUrl')}
+              />
+              {errors.bannerUrl ? (
+                <span id="settings-banner-error" className="text-sm text-status-afk">
+                  {errors.bannerUrl.message}
+                </span>
+              ) : null}
+            </label>
+
+            <label className={fieldClassName}>
+              <span className="text-sm font-medium text-primary">Accent color</span>
+              <div className="flex items-center gap-3">
+                <input
+                  type="text"
+                  className="h-11 flex-1 rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+                  placeholder="#7C3AED"
+                  aria-invalid={Boolean(errors.accentColor)}
+                  aria-describedby={errors.accentColor ? 'settings-accent-error' : undefined}
+                  {...register('accentColor')}
+                />
+                <span
+                  aria-hidden="true"
+                  className="h-11 w-11 rounded-control border border-border"
+                  style={{
+                    backgroundColor: isValidAccentColor(watchedValues.accentColor)
+                      ? watchedValues.accentColor
+                      : profileQuery.data.profile.accentColor ?? '#7C3AED',
+                  }}
+                />
+              </div>
+              {errors.accentColor ? (
+                <span id="settings-accent-error" className="text-sm text-status-afk">
+                  {errors.accentColor.message}
+                </span>
+              ) : null}
+            </label>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button type="submit" disabled={isSubmitting || updateProfileMutation.isPending}>
+                {isSubmitting || updateProfileMutation.isPending ? 'Salvando...' : 'Salvar perfil'}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  reset({
+                    displayName: profileQuery.data.profile.displayName ?? '',
+                    bio: profileQuery.data.profile.bio ?? '',
+                    avatarUrl: profileQuery.data.profile.avatarUrl ?? '',
+                    bannerUrl: profileQuery.data.profile.bannerUrl ?? '',
+                    accentColor: profileQuery.data.profile.accentColor ?? '#7C3AED',
+                  });
+                  setServerFeedback(null);
+                  setServerError(null);
+                }}
+              >
+                Reverter
+              </Button>
+            </div>
+          </form>
+        </Card>
+
+        <div className="space-y-4">
+          <SectionHeading
+            eyebrow="Preview"
+            title="GamerCard em tempo real"
+            description="O preview aplica apenas valores validos para nao mascarar erros de formulario."
+          />
+          {previewProfile ? <GamerCard profile={previewProfile} /> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/profile-settings-page-content.tsx
+++ b/frontend/src/components/settings/profile-settings-page-content.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { ProfileSettingsForm } from '@/components/settings/profile-settings-form';
+import { SettingsNav } from '@/components/settings/settings-nav';
+
+export function ProfileSettingsPageContent() {
+  return (
+    <div className="space-y-section">
+      <SettingsNav />
+      <ProfileSettingsForm />
+    </div>
+  );
+}

--- a/frontend/src/components/settings/settings-nav.tsx
+++ b/frontend/src/components/settings/settings-nav.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils/cn';
+
+const navItems = [
+  {
+    href: '/settings',
+    label: 'Perfil',
+    description: 'Edicao visual do seu GamerCard.',
+  },
+  {
+    href: '/settings/integrations',
+    label: 'Integracoes',
+    description: 'Steam, Epic e busca IGDB.',
+  },
+] as const;
+
+export function SettingsNav() {
+  const pathname = usePathname();
+
+  return (
+    <Card className="p-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-start justify-between gap-4 rounded-control border px-control-x py-control-y transition',
+                isActive
+                  ? 'border-accent-cyan/40 bg-[rgba(6,182,212,0.1)] text-primary'
+                  : 'border-border bg-background-secondary text-secondary hover:text-primary',
+              )}
+            >
+              <span className="space-y-1">
+                <span className="block font-medium">{item.label}</span>
+                <span className="block text-xs leading-5 text-secondary">
+                  {item.description}
+                </span>
+              </span>
+              {isActive ? <Badge tone="accent">Ativa</Badge> : null}
+            </Link>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/steam-integration-card.tsx
+++ b/frontend/src/components/settings/steam-integration-card.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  steamConnectRequestSchema,
+  type SteamConnectValues,
+} from '@/schemas/integrations';
+import {
+  connectSteam,
+  IntegrationsRequestError,
+  syncSteamLibrary,
+} from '@/services/integrations';
+
+type SteamIntegrationCardProps = {
+  isConnected: boolean;
+  importedPreviewCount: number;
+  onRefreshStatus: () => Promise<void>;
+};
+
+export function SteamIntegrationCard({
+  isConnected,
+  importedPreviewCount,
+  onRefreshStatus,
+}: SteamIntegrationCardProps) {
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SteamConnectValues>({
+    resolver: zodResolver(steamConnectRequestSchema),
+    defaultValues: {
+      steamId: '',
+    },
+    mode: 'onChange',
+  });
+
+  const connectMutation = useMutation({
+    mutationFn: connectSteam,
+    onSuccess: async (response) => {
+      setErrorMessage(null);
+      setFeedback(response.message);
+      await onRefreshStatus();
+    },
+    onError: (error) => {
+      setFeedback(null);
+      setErrorMessage(
+        error instanceof IntegrationsRequestError
+          ? error.message
+          : 'Nao foi possivel conectar a Steam agora.',
+      );
+    },
+  });
+
+  const syncMutation = useMutation({
+    mutationFn: syncSteamLibrary,
+    onSuccess: async (response) => {
+      setErrorMessage(null);
+      setFeedback(response.message);
+      await onRefreshStatus();
+    },
+    onError: (error) => {
+      setFeedback(null);
+      setErrorMessage(
+        error instanceof IntegrationsRequestError
+          ? error.message
+          : 'Nao foi possivel sincronizar a Steam agora.',
+      );
+    },
+  });
+
+  const onSubmit = handleSubmit(async (values) => {
+    await connectMutation.mutateAsync(values);
+  });
+
+  return (
+    <Card className="space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Steam</p>
+          <h2 className="font-display text-2xl font-semibold text-primary">
+            Biblioteca Steam
+          </h2>
+          <p className="text-sm leading-6 text-secondary">
+            Conecta sua conta pela SteamID publica e permite sincronizar a biblioteca real.
+          </p>
+        </div>
+        <Badge tone={isConnected ? 'success' : 'neutral'}>
+          {isConnected ? 'Conectada' : 'Nao conectada'}
+        </Badge>
+      </div>
+
+      <p className="text-sm text-secondary">
+        {isConnected
+          ? `A profile API mostra ${importedPreviewCount} jogo(s) recentes dessa integracao.`
+          : 'Ainda nao ha integracao Steam ativa neste perfil.'}
+      </p>
+
+      {feedback ? (
+        <div className="rounded-control border border-status-online/40 bg-[rgba(16,185,129,0.12)] px-control-x py-control-y text-sm text-primary">
+          {feedback}
+        </div>
+      ) : null}
+
+      {errorMessage ? (
+        <div className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <form className="space-y-4" onSubmit={onSubmit} noValidate>
+        <label className="space-y-2">
+          <span className="text-sm font-medium text-primary">SteamID</span>
+          <input
+            type="text"
+            className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+            placeholder="76561198000000000"
+            aria-invalid={Boolean(errors.steamId)}
+            aria-describedby={errors.steamId ? 'steam-id-error' : undefined}
+            {...register('steamId')}
+          />
+          {errors.steamId ? (
+            <span id="steam-id-error" className="text-sm text-status-afk">
+              {errors.steamId.message}
+            </span>
+          ) : null}
+        </label>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button type="submit" disabled={isSubmitting || connectMutation.isPending}>
+            {isSubmitting || connectMutation.isPending ? 'Conectando...' : 'Conectar Steam'}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!isConnected || syncMutation.isPending}
+            onClick={() => {
+              syncMutation.mutate();
+            }}
+          >
+            {syncMutation.isPending ? 'Sincronizando...' : 'Sincronizar biblioteca'}
+          </Button>
+        </div>
+      </form>
+
+      <p className="text-xs leading-5 text-secondary">
+        O contrato atual nao expoe progresso assincrono nem endpoint de desconexao.
+      </p>
+    </Card>
+  );
+}

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -40,4 +40,17 @@ export {
   postCommentNotificationPayloadSchema,
   postLikeNotificationPayloadSchema,
 } from './notifications';
-export { profileResponseSchema } from './profile';
+export {
+  epicConnectRequestSchema,
+  epicConnectResponseSchema,
+  igdbSearchRequestSchema,
+  igdbSearchResponseSchema,
+  steamConnectRequestSchema,
+  steamConnectResponseSchema,
+  steamSyncResponseSchema,
+} from './integrations';
+export {
+  profileResponseSchema,
+  profileUpdateRequestSchema,
+  profileUpdateResponseSchema,
+} from './profile';

--- a/frontend/src/schemas/integrations.ts
+++ b/frontend/src/schemas/integrations.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+export const steamConnectRequestSchema = z.object({
+  steamId: z.string().trim().min(1, 'SteamID e obrigatorio.'),
+});
+
+export const steamConnectResponseSchema = z.object({
+  message: z.string().min(1),
+  imported: z.number().int().min(0),
+});
+
+export const steamSyncResponseSchema = z.object({
+  message: z.string().min(1),
+  synced: z.number().int().min(0),
+});
+
+export const epicConnectRequestSchema = z.object({
+  authToken: z.string().trim().min(1, 'Token Epic e obrigatorio.'),
+});
+
+export const epicConnectResponseSchema = z.object({
+  message: z.string().min(1),
+  imported: z.number().int().min(0),
+});
+
+export const igdbSearchRequestSchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .min(2, 'Digite pelo menos 2 caracteres para buscar no IGDB.'),
+});
+
+export const igdbSearchResponseSchema = z.object({
+  id: z.number().int(),
+  name: z.string().min(1),
+  coverUrl: z.string().nullable(),
+  platforms: z.array(z.string()),
+  summary: z.string().nullable(),
+});
+
+export type SteamConnectValues = z.infer<typeof steamConnectRequestSchema>;
+export type SteamConnectResponse = z.infer<typeof steamConnectResponseSchema>;
+export type SteamSyncResponse = z.infer<typeof steamSyncResponseSchema>;
+export type EpicConnectValues = z.infer<typeof epicConnectRequestSchema>;
+export type EpicConnectResponse = z.infer<typeof epicConnectResponseSchema>;
+export type IgdbSearchValues = z.infer<typeof igdbSearchRequestSchema>;
+export type IgdbSearchResponse = z.infer<typeof igdbSearchResponseSchema>;

--- a/frontend/src/schemas/profile.ts
+++ b/frontend/src/schemas/profile.ts
@@ -61,5 +61,46 @@ export const profileResponseSchema = z.object({
   ),
 });
 
+export const profileUpdateRequestSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, 'O display name precisa ter pelo menos 1 caractere.')
+    .max(50, 'O display name aceita no maximo 50 caracteres.'),
+  bio: z
+    .string()
+    .trim()
+    .max(300, 'A bio aceita no maximo 300 caracteres.'),
+  avatarUrl: z
+    .string()
+    .trim()
+    .url('Digite uma URL de avatar valida.')
+    .or(z.literal('')),
+  bannerUrl: z
+    .string()
+    .trim()
+    .url('Digite uma URL de banner valida.')
+    .or(z.literal('')),
+  accentColor: z
+    .string()
+    .trim()
+    .regex(/^#[0-9A-Fa-f]{6}$/, 'Use uma cor hex valida, como #7C3AED.'),
+});
+
+export const profileUpdateResponseSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  displayName: z.string().nullable(),
+  bio: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  bannerUrl: z.string().nullable(),
+  accentColor: z.string().nullable(),
+  badges: z.array(z.string()),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+});
+
 export type ProfileResponse = z.infer<typeof profileResponseSchema>;
 export type ProfilePresenceStatus = z.infer<typeof profilePresenceStatusSchema>;
+export type ProfileUpdateValues = z.infer<typeof profileUpdateRequestSchema>;
+export type ProfileUpdateResponse = z.infer<typeof profileUpdateResponseSchema>;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -24,4 +24,15 @@ export {
   markNotificationAsRead,
   NotificationsRequestError,
 } from './notifications';
-export { fetchProfileByUsername, ProfileRequestError } from './profile';
+export {
+  connectEpic,
+  connectSteam,
+  IntegrationsRequestError,
+  searchIgdbGame,
+  syncSteamLibrary,
+} from './integrations';
+export {
+  fetchProfileByUsername,
+  ProfileRequestError,
+  updateProfileByUsername,
+} from './profile';

--- a/frontend/src/services/integrations.ts
+++ b/frontend/src/services/integrations.ts
@@ -1,0 +1,132 @@
+import { apiRequest } from '@/lib/api';
+import {
+  epicConnectRequestSchema,
+  epicConnectResponseSchema,
+  igdbSearchRequestSchema,
+  igdbSearchResponseSchema,
+  steamConnectRequestSchema,
+  steamConnectResponseSchema,
+  steamSyncResponseSchema,
+  type EpicConnectResponse,
+  type EpicConnectValues,
+  type IgdbSearchResponse,
+  type SteamConnectResponse,
+  type SteamConnectValues,
+  type SteamSyncResponse,
+} from '@/schemas/integrations';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+export class IntegrationsRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'IntegrationsRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function connectSteam(
+  input: SteamConnectValues,
+): Promise<SteamConnectResponse> {
+  const payload = steamConnectRequestSchema.parse(input);
+  const response = await apiRequest('/integrations/steam/connect', {
+    method: 'POST',
+    body: payload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel conectar a Steam agora.'),
+    );
+  }
+
+  return steamConnectResponseSchema.parse(responsePayload);
+}
+
+export async function syncSteamLibrary(): Promise<SteamSyncResponse> {
+  const response = await apiRequest('/integrations/steam/sync', {
+    method: 'POST',
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel sincronizar a Steam agora.'),
+    );
+  }
+
+  return steamSyncResponseSchema.parse(responsePayload);
+}
+
+export async function connectEpic(
+  input: EpicConnectValues,
+): Promise<EpicConnectResponse> {
+  const payload = epicConnectRequestSchema.parse(input);
+  const response = await apiRequest('/integrations/epic/connect', {
+    method: 'POST',
+    body: payload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel conectar a Epic agora.'),
+    );
+  }
+
+  return epicConnectResponseSchema.parse(responsePayload);
+}
+
+export async function searchIgdbGame(query: string): Promise<IgdbSearchResponse> {
+  const payload = igdbSearchRequestSchema.parse({ q: query });
+  const response = await apiRequest(
+    `/integrations/igdb/search?q=${encodeURIComponent(payload.q)}`,
+    {
+      method: 'GET',
+    },
+  );
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel buscar no IGDB agora.'),
+    );
+  }
+
+  return igdbSearchResponseSchema.parse(responsePayload);
+}

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -1,5 +1,12 @@
 import { apiRequest } from '@/lib/api';
-import { profileResponseSchema, type ProfileResponse } from '@/schemas/profile';
+import {
+  profileResponseSchema,
+  profileUpdateRequestSchema,
+  profileUpdateResponseSchema,
+  type ProfileResponse,
+  type ProfileUpdateResponse,
+  type ProfileUpdateValues,
+} from '@/schemas/profile';
 
 type ErrorResponse = {
   message?: string;
@@ -63,4 +70,34 @@ export async function fetchProfileByUsername(
   }
 
   return profileResponseSchema.parse(payload);
+}
+
+export async function updateProfileByUsername(
+  username: string,
+  input: ProfileUpdateValues,
+): Promise<ProfileUpdateResponse> {
+  const payload = profileUpdateRequestSchema.parse(input);
+  const normalizedPayload = {
+    displayName: payload.displayName.trim(),
+    bio: payload.bio.trim(),
+    avatarUrl: payload.avatarUrl.trim() || undefined,
+    bannerUrl: payload.bannerUrl.trim() || undefined,
+    accentColor: payload.accentColor.trim(),
+  };
+
+  const response = await apiRequest(`/profiles/${encodeURIComponent(username)}`, {
+    method: 'PATCH',
+    body: normalizedPayload,
+  });
+
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new ProfileRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel atualizar o perfil agora.'),
+    );
+  }
+
+  return profileUpdateResponseSchema.parse(responsePayload);
 }

--- a/frontend/tests/unit/components/igdb-search-card.test.tsx
+++ b/frontend/tests/unit/components/igdb-search-card.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IgdbSearchCard } from '@/components/settings/igdb-search-card';
+import { searchIgdbGame } from '@/services/integrations';
+
+vi.mock('@/services/integrations', () => ({
+  searchIgdbGame: vi.fn(),
+  IntegrationsRequestError: class IntegrationsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'IntegrationsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedSearchIgdbGame = vi.mocked(searchIgdbGame);
+
+function renderIgdbSearchCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <IgdbSearchCard />
+    </QueryClientProvider>,
+  );
+}
+
+describe('IgdbSearchCard', () => {
+  beforeEach(() => {
+    mockedSearchIgdbGame.mockReset();
+  });
+
+  it('searches igdb and renders the returned game', async () => {
+    mockedSearchIgdbGame.mockResolvedValue({
+      id: 730,
+      name: 'Counter-Strike 2',
+      coverUrl: 'https://images.ct2.jpg',
+      platforms: ['PC'],
+      summary: 'Competitive FPS',
+    });
+
+    renderIgdbSearchCard();
+
+    fireEvent.change(screen.getByLabelText(/nome do jogo/i), {
+      target: { value: 'Counter-Strike 2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /buscar no igdb/i }));
+
+    await waitFor(() => {
+      expect(mockedSearchIgdbGame).toHaveBeenCalledWith('Counter-Strike 2');
+    });
+
+    expect(await screen.findByText(/counter-strike 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/competitive fps/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -1,0 +1,114 @@
+import React, { type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IntegrationsPageContent } from '@/components/settings/integrations-page-content';
+import { useAuth } from '@/hooks/use-auth';
+import { fetchProfileByUsername } from '@/services/profile';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/settings/integrations',
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/profile', () => ({
+  fetchProfileByUsername: vi.fn(),
+  ProfileRequestError: class ProfileRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'ProfileRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchProfileByUsername = vi.mocked(fetchProfileByUsername);
+
+function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('IntegrationsPageContent', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchProfileByUsername.mockReset();
+  });
+
+  it('renders integrations status and contract limitation', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchProfileByUsername.mockResolvedValue({
+      id: 'user-1',
+      username: 'clutchplayer',
+      createdAt: '2026-03-29T22:15:00.000Z',
+      profile: {
+        displayName: 'CLUTCH Player',
+        bio: 'Bio',
+        avatarUrl: null,
+        bannerUrl: null,
+        accentColor: '#7C3AED',
+        badges: ['Founder'],
+      },
+      stats: {
+        level: 18,
+        xp: 4820,
+        reputation: 215,
+        friendCount: 2,
+        postCount: 2,
+      },
+      presence: {
+        status: 'ONLINE',
+        currentGame: null,
+        gameDetails: null,
+        platform: 'PC',
+        updatedAt: '2026-03-29T22:15:00.000Z',
+      },
+      platformIntegrations: [
+        { platform: 'STEAM', metadata: null },
+        { platform: 'EPIC', metadata: null },
+      ],
+      gameLibrary: [
+        {
+          gameName: 'Counter-Strike 2',
+          coverUrl: null,
+          platform: 'STEAM',
+          hoursPlayed: 100,
+          lastPlayedAt: '2026-03-29T22:15:00.000Z',
+        },
+      ],
+    });
+
+    renderWithQuery(<IntegrationsPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('settings-integrations-success')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/biblioteca steam/i)).toBeInTheDocument();
+    expect(screen.getByText(/biblioteca epic games/i)).toBeInTheDocument();
+    expect(screen.getByText(/^discord$/i)).toBeInTheDocument();
+    expect(screen.getByText(/ainda fora do contrato frontend atual/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/profile-settings-form.test.tsx
+++ b/frontend/tests/unit/components/profile-settings-form.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProfileSettingsForm } from '@/components/settings/profile-settings-form';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchProfileByUsername,
+  updateProfileByUsername,
+} from '@/services/profile';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/profile', () => ({
+  fetchProfileByUsername: vi.fn(),
+  updateProfileByUsername: vi.fn(),
+  ProfileRequestError: class ProfileRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'ProfileRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock('@/components/profile/gamer-card', () => ({
+  GamerCard: ({ profile }: { profile: { profile: { displayName: string | null; bio: string | null } } }) => (
+    <div data-testid="profile-preview">
+      {profile.profile.displayName ?? 'sem-nome'}::{profile.profile.bio ?? 'sem-bio'}
+    </div>
+  ),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchProfileByUsername = vi.mocked(fetchProfileByUsername);
+const mockedUpdateProfileByUsername = vi.mocked(updateProfileByUsername);
+
+function renderProfileSettingsForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProfileSettingsForm />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ProfileSettingsForm', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchProfileByUsername.mockReset();
+    mockedUpdateProfileByUsername.mockReset();
+
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchProfileByUsername.mockResolvedValue({
+      id: 'user-1',
+      username: 'clutchplayer',
+      createdAt: '2026-03-29T22:15:00.000Z',
+      profile: {
+        displayName: 'CLUTCH Player',
+        bio: 'Bio antiga',
+        avatarUrl: null,
+        bannerUrl: null,
+        accentColor: '#7C3AED',
+        badges: ['Founder'],
+      },
+      stats: {
+        level: 18,
+        xp: 4820,
+        reputation: 215,
+        friendCount: 2,
+        postCount: 2,
+      },
+      presence: {
+        status: 'ONLINE',
+        currentGame: null,
+        gameDetails: null,
+        platform: 'PC',
+        updatedAt: '2026-03-29T22:15:00.000Z',
+      },
+      platformIntegrations: [],
+      gameLibrary: [],
+    });
+  });
+
+  it('renders profile preview and updates it locally', async () => {
+    renderProfileSettingsForm();
+
+    expect(await screen.findByTestId('settings-profile-success')).toBeInTheDocument();
+    expect(screen.getByTestId('profile-preview')).toHaveTextContent(
+      'CLUTCH Player::Bio antiga',
+    );
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'Novo nome' },
+    });
+    fireEvent.change(screen.getByLabelText(/bio/i), {
+      target: { value: 'Bio atualizada' },
+    });
+
+    expect(screen.getByTestId('profile-preview')).toHaveTextContent(
+      'Novo nome::Bio atualizada',
+    );
+  });
+
+  it('submits the real profile patch payload', async () => {
+    mockedUpdateProfileByUsername.mockResolvedValue({
+      id: 'profile-1',
+      userId: 'user-1',
+      displayName: 'Novo nome',
+      bio: 'Bio atualizada',
+      avatarUrl: null,
+      bannerUrl: null,
+      accentColor: '#7C3AED',
+      badges: ['Founder'],
+      createdAt: '2026-03-29T22:15:00.000Z',
+      updatedAt: '2026-03-31T22:15:00.000Z',
+    });
+
+    renderProfileSettingsForm();
+
+    await screen.findByTestId('settings-profile-success');
+
+    fireEvent.change(screen.getByLabelText(/display name/i), {
+      target: { value: 'Novo nome' },
+    });
+    fireEvent.change(screen.getByLabelText(/bio/i), {
+      target: { value: 'Bio atualizada' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /salvar perfil/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateProfileByUsername).toHaveBeenCalled();
+    });
+
+    expect(mockedUpdateProfileByUsername.mock.calls[0]?.[0]).toBe('clutchplayer');
+    expect(mockedUpdateProfileByUsername.mock.calls[0]?.[1]).toMatchObject({
+      displayName: 'Novo nome',
+      bio: 'Bio atualizada',
+      accentColor: '#7C3AED',
+    });
+  });
+});

--- a/frontend/tests/unit/components/steam-integration-card.test.tsx
+++ b/frontend/tests/unit/components/steam-integration-card.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SteamIntegrationCard } from '@/components/settings/steam-integration-card';
+import { connectSteam, syncSteamLibrary } from '@/services/integrations';
+
+vi.mock('@/services/integrations', () => ({
+  connectSteam: vi.fn(),
+  syncSteamLibrary: vi.fn(),
+  IntegrationsRequestError: class IntegrationsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'IntegrationsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedConnectSteam = vi.mocked(connectSteam);
+const mockedSyncSteamLibrary = vi.mocked(syncSteamLibrary);
+
+function renderSteamIntegrationCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SteamIntegrationCard
+        isConnected
+        importedPreviewCount={3}
+        onRefreshStatus={vi.fn().mockResolvedValue(undefined)}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('SteamIntegrationCard', () => {
+  beforeEach(() => {
+    mockedConnectSteam.mockReset();
+    mockedSyncSteamLibrary.mockReset();
+  });
+
+  it('connects steam with the form payload', async () => {
+    mockedConnectSteam.mockResolvedValue({
+      message: 'Steam conectado. 2 jogos importados.',
+      imported: 2,
+    });
+
+    renderSteamIntegrationCard();
+
+    fireEvent.change(screen.getByLabelText(/steamid/i), {
+      target: { value: '76561198000000000' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /conectar steam/i }));
+
+    await waitFor(() => {
+      expect(mockedConnectSteam).toHaveBeenCalled();
+    });
+
+    expect(mockedConnectSteam.mock.calls[0]?.[0]).toEqual({
+      steamId: '76561198000000000',
+    });
+  });
+
+  it('syncs the steam library when requested', async () => {
+    mockedSyncSteamLibrary.mockResolvedValue({
+      message: '1 jogos sincronizados.',
+      synced: 1,
+    });
+
+    renderSteamIntegrationCard();
+
+    fireEvent.click(screen.getByRole('button', { name: /sincronizar biblioteca/i }));
+
+    await waitFor(() => {
+      expect(mockedSyncSteamLibrary).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/tests/unit/services/integrations.test.ts
+++ b/frontend/tests/unit/services/integrations.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import {
+  connectEpic,
+  connectSteam,
+  searchIgdbGame,
+  syncSteamLibrary,
+} from '@/services/integrations';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+describe('integrations service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('connects steam with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: 'Steam conectado. 2 jogos importados.',
+          imported: 2,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await connectSteam({ steamId: '76561198000000000' });
+
+    expect(response.imported).toBe(2);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/integrations/steam/connect', {
+      method: 'POST',
+      body: { steamId: '76561198000000000' },
+    });
+  });
+
+  it('syncs steam library with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: '1 jogos sincronizados.',
+          synced: 1,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await syncSteamLibrary();
+
+    expect(response.synced).toBe(1);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/integrations/steam/sync', {
+      method: 'POST',
+    });
+  });
+
+  it('connects epic with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: 'Epic conectado. 2 jogos importados.',
+          imported: 2,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await connectEpic({ authToken: 'valid-token' });
+
+    expect(response.imported).toBe(2);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/integrations/epic/connect', {
+      method: 'POST',
+      body: { authToken: 'valid-token' },
+    });
+  });
+
+  it('searches the igdb endpoint with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 730,
+          name: 'Counter-Strike 2',
+          coverUrl: 'https://images.ct2.jpg',
+          platforms: ['PC'],
+          summary: 'Competitive FPS',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await searchIgdbGame('Counter-Strike 2');
+
+    expect(response.name).toBe('Counter-Strike 2');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/integrations/igdb/search?q=Counter-Strike%202',
+      { method: 'GET' },
+    );
+  });
+});

--- a/frontend/tests/unit/services/profile.test.ts
+++ b/frontend/tests/unit/services/profile.test.ts
@@ -3,6 +3,7 @@ import { apiRequest } from '@/lib/api';
 import {
   fetchProfileByUsername,
   ProfileRequestError,
+  updateProfileByUsername,
 } from '@/services/profile';
 
 vi.mock('@/lib/api', () => ({
@@ -97,5 +98,50 @@ describe('profile service', () => {
       status: 500,
       message: 'Erro interno.',
     } satisfies Partial<ProfileRequestError>);
+  });
+
+  it('updates the profile with the real patch contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'profile-1',
+          userId: 'user-1',
+          displayName: 'CLUTCH Player',
+          bio: 'Bio',
+          avatarUrl: 'https://cdn.clutch.gg/avatar.jpg',
+          bannerUrl: 'https://cdn.clutch.gg/banner.jpg',
+          accentColor: '#7C3AED',
+          badges: ['Founder'],
+          createdAt: '2026-03-29T22:15:00.000Z',
+          updatedAt: '2026-03-31T22:15:00.000Z',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+
+    const response = await updateProfileByUsername('clutchplayer', {
+      displayName: 'CLUTCH Player',
+      bio: 'Bio',
+      avatarUrl: 'https://cdn.clutch.gg/avatar.jpg',
+      bannerUrl: 'https://cdn.clutch.gg/banner.jpg',
+      accentColor: '#7C3AED',
+    });
+
+    expect(response.userId).toBe('user-1');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/profiles/clutchplayer', {
+      method: 'PATCH',
+      body: {
+        displayName: 'CLUTCH Player',
+        bio: 'Bio',
+        avatarUrl: 'https://cdn.clutch.gg/avatar.jpg',
+        bannerUrl: 'https://cdn.clutch.gg/banner.jpg',
+        accentColor: '#7C3AED',
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add `/settings` with a typed profile form backed by the real `PATCH /profiles/:username` contract
- add `/settings/integrations` with Steam connect/sync, Epic connect and IGDB search using only supported backend routes
- cover the new flows with contract and component tests, plus honest UI limits for unsupported integration capabilities

## What This PR Adds
- profile settings form with React Hook Form + Zod validation
- real-time local preview for display name, bio, avatar URL, banner URL and accent color
- Steam integration card with connect and sync actions
- Epic integration card with connect action
- IGDB search card rendering the single game result returned by the backend contract
- settings navigation and authenticated pages for `/settings` and `/settings/integrations`

## Contract Notes
- Integration status is rehydrated from the profile payload (`platformIntegrations` and `gameLibrary`) because the backend does not expose a dedicated status endpoint.
- Steam sync is supported as an action, but the backend does not expose import progress, so the UI does not invent it.
- IGDB search currently returns a single game result for a query, not a paginated list.
- Discord is intentionally shown as unsupported because the backend does not expose a frontend-usable connect route.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## Risks
- Imported game counts shown in settings are preview counts derived from the currently loaded profile library slice, not authoritative totals.
- If the backend expands integration status/progress contracts later, the cards should be extended rather than overloaded with client-side assumptions.

Closes #96
