### PR TITLE
feat(presence): add authenticated realtime rich presence

### DIFF
--- a/frontend/src/app/api/auth/presence-token/route.ts
+++ b/frontend/src/app/api/auth/presence-token/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import {
+  AUTH_SESSION_COOKIE_NAME,
+  getClearedAuthSessionCookieOptions,
+} from '@/lib/auth/session';
+import { buildApiUrl } from '@/services/http/client';
+
+export async function GET(request: NextRequest) {
+  const token = request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value;
+
+  if (!token) {
+    return NextResponse.json({ message: 'Sessao inexistente.' }, { status: 401 });
+  }
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(buildApiUrl('/auth/me'), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    });
+  } catch {
+    return NextResponse.json(
+      { message: 'Nao foi possivel validar a sessao de realtime.' },
+      { status: 502 },
+    );
+  }
+
+  if (!backendResponse.ok) {
+    const response = NextResponse.json(
+      {
+        message:
+          backendResponse.status === 401
+            ? 'Token invalido ou expirado.'
+            : 'Nao foi possivel validar a sessao de realtime.',
+      },
+      { status: backendResponse.status },
+    );
+
+    if (backendResponse.status === 401) {
+      response.cookies.set(
+        AUTH_SESSION_COOKIE_NAME,
+        '',
+        getClearedAuthSessionCookieOptions(),
+      );
+    }
+
+    return response;
+  }
+
+  const response = NextResponse.json({ token }, { status: 200 });
+  response.headers.set('Cache-Control', 'no-store');
+
+  return response;
+}

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useState, type ReactNode } from 'react';
 import { AuthProvider } from '@/components/auth/auth-provider';
+import { PresenceProvider } from '@/components/auth/presence-provider';
 import { makeQueryClient } from '@/lib/query/make-query-client';
 
 type ProvidersProps = {
@@ -14,7 +15,9 @@ export function Providers({ children }: ProvidersProps) {
 
   return (
     <AuthProvider>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <PresenceProvider>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </PresenceProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/components/auth/presence-provider.tsx
+++ b/frontend/src/components/auth/presence-provider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import { usePresence } from '@/hooks/use-presence';
+
+type PresenceProviderProps = {
+  children: ReactNode;
+};
+
+export function PresenceProvider({ children }: PresenceProviderProps) {
+  usePresence();
+  return children;
+}

--- a/frontend/src/components/friends/friends-list.tsx
+++ b/frontend/src/components/friends/friends-list.tsx
@@ -6,6 +6,7 @@ import { Card } from '@/components/ui/card';
 import { PresenceBadge } from '@/components/profile/presence-badge';
 import { type FriendSummary, type FriendPresenceStatus } from '@/schemas/friends';
 import { fetchFriends } from '@/services/friends';
+import { usePresenceStore, type PresenceEntry } from '@/store/presence-store';
 
 type FriendsListProps = {
   userId: string;
@@ -28,6 +29,29 @@ export function sortFriendsByPresence(friends: FriendSummary[]): FriendSummary[]
   });
 }
 
+function resolvePresence(
+  friend: FriendSummary,
+  realtimePresence: PresenceEntry | undefined,
+) {
+  return {
+    status: realtimePresence?.status ?? friend.presence?.status ?? 'OFFLINE',
+    currentGame: realtimePresence?.currentGame ?? friend.presence?.currentGame ?? null,
+    platform: realtimePresence?.platform ?? friend.presence?.platform ?? null,
+  } as const;
+}
+
+export function sortFriendsByEffectivePresence(
+  friends: FriendSummary[],
+  entries: Record<string, PresenceEntry>,
+): FriendSummary[] {
+  return [...friends].sort((left, right) => {
+    const leftStatus = resolvePresence(left, entries[left.id]).status;
+    const rightStatus = resolvePresence(right, entries[right.id]).status;
+
+    return presenceOrder[leftStatus] - presenceOrder[rightStatus];
+  });
+}
+
 function FriendsListLoadingState() {
   return (
     <Card data-testid="friends-list-loading">
@@ -44,6 +68,7 @@ export function FriendsList({
   userId,
   title = 'Amigos',
 }: FriendsListProps) {
+  const presenceEntries = usePresenceStore((state) => state.entries);
   const friendsQuery = useQuery({
     queryKey: ['friends', userId],
     queryFn: () => fetchFriends(userId),
@@ -68,7 +93,7 @@ export function FriendsList({
     );
   }
 
-  const friends = sortFriendsByPresence(friendsQuery.data);
+  const friends = sortFriendsByEffectivePresence(friendsQuery.data, presenceEntries);
 
   if (friends.length === 0) {
     return (
@@ -102,6 +127,7 @@ export function FriendsList({
                 ? friend.profile.displayName
                 : friend.username;
             const avatarFallback = friend.username.slice(0, 2).toUpperCase();
+            const effectivePresence = resolvePresence(friend, presenceEntries[friend.id]);
 
             return (
               <div
@@ -124,9 +150,9 @@ export function FriendsList({
                 </div>
 
                 <PresenceBadge
-                  status={friend.presence?.status ?? 'OFFLINE'}
-                  currentGame={friend.presence?.currentGame ?? null}
-                  platform={friend.presence?.platform ?? null}
+                  status={effectivePresence.status}
+                  currentGame={effectivePresence.currentGame}
+                  platform={effectivePresence.platform}
                 />
               </div>
             );

--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { ReactNode } from 'react';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -5,6 +7,7 @@ import { Card } from '@/components/ui/card';
 import { PresenceBadge } from '@/components/profile/presence-badge';
 import { PlatformBadges } from '@/components/profile/platform-badges';
 import { type ProfileResponse } from '@/schemas/profile';
+import { usePresenceStore } from '@/store/presence-store';
 
 type GamerCardProps = {
   profile: ProfileResponse;
@@ -15,6 +18,12 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
   const displayName = profile.profile.displayName || profile.username;
   const badgeList = profile.profile.badges.slice(0, 4);
   const initials = profile.username.slice(0, 2).toUpperCase();
+  const realtimePresence = usePresenceStore((state) => state.entries[profile.id]);
+  const effectivePresence = {
+    status: realtimePresence?.status ?? profile.presence.status,
+    currentGame: realtimePresence?.currentGame ?? profile.presence.currentGame,
+    platform: realtimePresence?.platform ?? profile.presence.platform,
+  };
 
   return (
     <Card className="overflow-hidden p-0">
@@ -47,9 +56,9 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
               </h1>
               <p className="truncate text-sm text-secondary">@{profile.username}</p>
               <PresenceBadge
-                status={profile.presence.status}
-                currentGame={profile.presence.currentGame}
-                platform={profile.presence.platform}
+                status={effectivePresence.status}
+                currentGame={effectivePresence.currentGame}
+                platform={effectivePresence.platform}
               />
             </div>
           </div>

--- a/frontend/src/hooks/use-presence.ts
+++ b/frontend/src/hooks/use-presence.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { fetchPresenceCredential, PresenceConnection } from '@/services/presence';
+import { usePresenceStore } from '@/store/presence-store';
+import { useAuthStore } from '@/store/auth-store';
+
+export function usePresence(): void {
+  const status = useAuthStore((state) => state.status);
+  const clearSession = useAuthStore((state) => state.clearSession);
+  const setConnectionStatus = usePresenceStore((state) => state.setConnectionStatus);
+  const upsertPresence = usePresenceStore((state) => state.upsertPresence);
+  const clearAll = usePresenceStore((state) => state.clearAll);
+  const connectionRef = useRef<PresenceConnection | null>(null);
+
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      connectionRef.current?.disconnect();
+      connectionRef.current = null;
+      clearAll();
+      return;
+    }
+
+    if (!connectionRef.current) {
+      connectionRef.current = new PresenceConnection({
+        getCredential: fetchPresenceCredential,
+        onPresence: (payload, receivedAt) => {
+          upsertPresence(payload, receivedAt);
+        },
+        onConnectionStatusChange: (nextStatus, errorMessage) => {
+          setConnectionStatus(nextStatus, errorMessage ?? null);
+        },
+        onAuthFailure: () => {
+          clearAll();
+          clearSession();
+        },
+      });
+    }
+
+    connectionRef.current.connect();
+
+    return () => {
+      connectionRef.current?.disconnect();
+      connectionRef.current = null;
+    };
+  }, [clearAll, clearSession, setConnectionStatus, status, upsertPresence]);
+}

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -50,6 +50,14 @@ export {
   steamSyncResponseSchema,
 } from './integrations';
 export {
+  friendPresenceEventPayloadSchema,
+  friendPresenceSocketEventSchema,
+  presenceCredentialResponseSchema,
+  presencePongSocketEventSchema,
+  presenceSocketEventSchema,
+  presenceStatusSchema,
+} from './presence';
+export {
   profileResponseSchema,
   profileUpdateRequestSchema,
   profileUpdateResponseSchema,

--- a/frontend/src/schemas/presence.ts
+++ b/frontend/src/schemas/presence.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const presenceStatusSchema = z.enum([
+  'ONLINE',
+  'IN_GAME',
+  'AFK',
+  'OFFLINE',
+]);
+
+export const presenceCredentialResponseSchema = z.object({
+  token: z.string().min(1),
+});
+
+export const friendPresenceEventPayloadSchema = z.object({
+  userId: z.string().min(1),
+  status: presenceStatusSchema,
+  currentGame: z.string().nullable(),
+  platform: z.string().nullable(),
+});
+
+export const friendPresenceSocketEventSchema = z.object({
+  event: z.literal('FRIEND_PRESENCE'),
+  payload: friendPresenceEventPayloadSchema,
+  ts: z.number(),
+});
+
+export const presencePongSocketEventSchema = z.object({
+  event: z.literal('PONG'),
+  payload: z.nullable(z.unknown()),
+  ts: z.number(),
+});
+
+export const presenceSocketEventSchema = z.union([
+  friendPresenceSocketEventSchema,
+  presencePongSocketEventSchema,
+]);
+
+export type PresenceStatus = z.infer<typeof presenceStatusSchema>;
+export type PresenceCredentialResponse = z.infer<
+  typeof presenceCredentialResponseSchema
+>;
+export type FriendPresenceEventPayload = z.infer<
+  typeof friendPresenceEventPayloadSchema
+>;
+export type FriendPresenceSocketEvent = z.infer<
+  typeof friendPresenceSocketEventSchema
+>;
+export type PresencePongSocketEvent = z.infer<
+  typeof presencePongSocketEventSchema
+>;
+export type PresenceSocketEvent = z.infer<typeof presenceSocketEventSchema>;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -32,6 +32,11 @@ export {
   syncSteamLibrary,
 } from './integrations';
 export {
+  fetchPresenceCredential,
+  PresenceConnection,
+  PresenceRequestError,
+} from './presence';
+export {
   fetchProfileByUsername,
   ProfileRequestError,
   updateProfileByUsername,

--- a/frontend/src/services/presence.ts
+++ b/frontend/src/services/presence.ts
@@ -1,0 +1,298 @@
+'use client';
+
+import {
+  friendPresenceSocketEventSchema,
+  presenceCredentialResponseSchema,
+  presenceSocketEventSchema,
+  type FriendPresenceEventPayload,
+} from '@/schemas/presence';
+import { getClientEnv } from '@/lib/config/env';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+type PresenceWebSocket = Pick<
+  WebSocket,
+  'addEventListener' | 'removeEventListener' | 'close' | 'send' | 'readyState'
+>;
+
+type PresenceSocketFactory = (url: string) => PresenceWebSocket;
+type PresenceConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'auth_error'
+  | 'error';
+
+type PresenceConnectionOptions = {
+  getCredential: () => Promise<string>;
+  socketFactory?: PresenceSocketFactory;
+  onPresence: (payload: FriendPresenceEventPayload, receivedAt: number) => void;
+  onConnectionStatusChange?: (
+    status: PresenceConnectionStatus,
+    errorMessage?: string | null,
+  ) => void;
+  onAuthFailure?: () => void;
+};
+
+export class PresenceRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'PresenceRequestError';
+    this.status = status;
+  }
+}
+
+const initialReconnectDelayMs = 1_000;
+const maxReconnectDelayMs = 30_000;
+const appPingIntervalMs = 25_000;
+
+function readJson(response: Response): Promise<unknown> {
+  return response.text().then((text) => {
+    if (text.length === 0) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return null;
+    }
+  });
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchPresenceCredential(): Promise<string> {
+  const response = await fetch('/api/auth/presence-token', {
+    method: 'GET',
+    credentials: 'include',
+    cache: 'no-store',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new PresenceRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel autenticar o realtime agora.'),
+    );
+  }
+
+  return presenceCredentialResponseSchema.parse(payload).token;
+}
+
+function buildPresenceSocketUrl(token: string): string {
+  const { wsUrl } = getClientEnv();
+  if (wsUrl.trim().length === 0) {
+    throw new PresenceRequestError(
+      500,
+      'NEXT_PUBLIC_WS_URL nao esta configurada para o realtime.',
+    );
+  }
+
+  const baseUrl = wsUrl.replace(/\/$/, '');
+  const url = new URL(`${baseUrl}/ws/presence`);
+  url.searchParams.set('token', token);
+  return url.toString();
+}
+
+export class PresenceConnection {
+  private readonly getCredential: PresenceConnectionOptions['getCredential'];
+  private readonly socketFactory: PresenceSocketFactory;
+  private readonly onPresence: PresenceConnectionOptions['onPresence'];
+  private readonly onConnectionStatusChange?: PresenceConnectionOptions['onConnectionStatusChange'];
+  private readonly onAuthFailure?: PresenceConnectionOptions['onAuthFailure'];
+  private socket: PresenceWebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectDelayMs = initialReconnectDelayMs;
+  private shouldReconnect = true;
+  private isConnecting = false;
+
+  constructor(options: PresenceConnectionOptions) {
+    this.getCredential = options.getCredential;
+    this.socketFactory =
+      options.socketFactory ??
+      ((url) => new WebSocket(url));
+    this.onPresence = options.onPresence;
+    this.onConnectionStatusChange = options.onConnectionStatusChange;
+    this.onAuthFailure = options.onAuthFailure;
+  }
+
+  connect(): void {
+    if (this.isConnecting || this.socket) {
+      return;
+    }
+
+    this.shouldReconnect = true;
+    void this.openSocket();
+  }
+
+  disconnect(): void {
+    this.shouldReconnect = false;
+    this.clearReconnectTimer();
+    this.clearPingTimer();
+
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+
+    this.isConnecting = false;
+    this.setStatus('idle');
+  }
+
+  private async openSocket(): Promise<void> {
+    this.isConnecting = true;
+    this.setStatus(this.reconnectDelayMs > initialReconnectDelayMs ? 'reconnecting' : 'connecting');
+
+    let token: string;
+
+    try {
+      token = await this.getCredential();
+    } catch (error) {
+      this.isConnecting = false;
+
+      if (error instanceof PresenceRequestError && error.status === 401) {
+        this.setStatus('auth_error', error.message);
+        this.onAuthFailure?.();
+        return;
+      }
+
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Nao foi possivel autenticar o realtime agora.';
+
+      this.setStatus('error', message);
+      this.scheduleReconnect();
+      return;
+    }
+
+    const socket = this.socketFactory(buildPresenceSocketUrl(token));
+    this.socket = socket;
+
+    const handleOpen = () => {
+      this.isConnecting = false;
+      this.reconnectDelayMs = initialReconnectDelayMs;
+      this.setStatus('connected');
+      this.startPingLoop();
+    };
+
+    const handleMessage = (event: Event) => {
+      const messageEvent = event as MessageEvent<string>;
+
+      try {
+        const parsed = presenceSocketEventSchema.parse(JSON.parse(messageEvent.data));
+
+        if (parsed.event === 'FRIEND_PRESENCE') {
+          const update = friendPresenceSocketEventSchema.parse(parsed);
+          this.onPresence(update.payload, update.ts);
+        }
+      } catch {
+        return;
+      }
+    };
+
+    const handleClose = () => {
+      this.cleanupSocketListeners(socket, handleOpen, handleMessage, handleClose, handleError);
+      this.clearPingTimer();
+      this.socket = null;
+      this.isConnecting = false;
+
+      if (!this.shouldReconnect) {
+        this.setStatus('idle');
+        return;
+      }
+
+      this.setStatus('error', 'Conexao realtime encerrada.');
+      this.scheduleReconnect();
+    };
+
+    const handleError = () => {
+      this.setStatus('error', 'Falha ao conectar no realtime.');
+    };
+
+    socket.addEventListener('open', handleOpen as EventListener);
+    socket.addEventListener('message', handleMessage as EventListener);
+    socket.addEventListener('close', handleClose as EventListener);
+    socket.addEventListener('error', handleError as EventListener);
+  }
+
+  private cleanupSocketListeners(
+    socket: PresenceWebSocket,
+    handleOpen: () => void,
+    handleMessage: (event: Event) => void,
+    handleClose: () => void,
+    handleError: () => void,
+  ): void {
+    socket.removeEventListener('open', handleOpen as EventListener);
+    socket.removeEventListener('message', handleMessage as EventListener);
+    socket.removeEventListener('close', handleClose as EventListener);
+    socket.removeEventListener('error', handleError as EventListener);
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.shouldReconnect || this.reconnectTimer) {
+      return;
+    }
+
+    const delay = this.reconnectDelayMs;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.reconnectDelayMs = Math.min(delay * 2, maxReconnectDelayMs);
+      this.connect();
+    }, delay);
+  }
+
+  private startPingLoop(): void {
+    this.clearPingTimer();
+
+    this.pingTimer = setInterval(() => {
+      if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      this.socket.send(JSON.stringify({ event: 'PING' }));
+    }, appPingIntervalMs);
+  }
+
+  private clearReconnectTimer(): void {
+    if (!this.reconnectTimer) {
+      return;
+    }
+
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+  }
+
+  private clearPingTimer(): void {
+    if (!this.pingTimer) {
+      return;
+    }
+
+    clearInterval(this.pingTimer);
+    this.pingTimer = null;
+  }
+
+  private setStatus(
+    status: PresenceConnectionStatus,
+    errorMessage: string | null = null,
+  ): void {
+    this.onConnectionStatusChange?.(status, errorMessage);
+  }
+}

--- a/frontend/src/store/presence-store.ts
+++ b/frontend/src/store/presence-store.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand';
+import { type FriendPresenceEventPayload } from '@/schemas/presence';
+
+export type PresenceConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'auth_error'
+  | 'error';
+
+export type PresenceEntry = FriendPresenceEventPayload & {
+  receivedAt: number;
+};
+
+type PresenceState = {
+  connectionStatus: PresenceConnectionStatus;
+  errorMessage: string | null;
+  entries: Record<string, PresenceEntry>;
+  setConnectionStatus: (
+    status: PresenceConnectionStatus,
+    errorMessage?: string | null,
+  ) => void;
+  upsertPresence: (update: FriendPresenceEventPayload, receivedAt: number) => void;
+  clearPresence: (userId: string) => void;
+  clearAll: () => void;
+};
+
+const initialState = {
+  connectionStatus: 'idle' as PresenceConnectionStatus,
+  errorMessage: null as string | null,
+  entries: {} as Record<string, PresenceEntry>,
+};
+
+export const usePresenceStore = create<PresenceState>((set) => ({
+  ...initialState,
+  setConnectionStatus: (status, errorMessage = null) =>
+    set({ connectionStatus: status, errorMessage }),
+  upsertPresence: (update, receivedAt) =>
+    set((state) => ({
+      entries: {
+        ...state.entries,
+        [update.userId]: {
+          ...update,
+          receivedAt,
+        },
+      },
+    })),
+  clearPresence: (userId) =>
+    set((state) => {
+      const nextEntries = { ...state.entries };
+      delete nextEntries[userId];
+
+      return { entries: nextEntries };
+    }),
+  clearAll: () =>
+    set({
+      ...initialState,
+      connectionStatus: 'idle',
+    }),
+}));
+
+export function resetPresenceStore(): void {
+  usePresenceStore.setState(initialState);
+}

--- a/frontend/tests/unit/components/friends-list.test.tsx
+++ b/frontend/tests/unit/components/friends-list.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FriendsList } from '@/components/friends/friends-list';
 import { fetchFriends } from '@/services/friends';
+import { resetPresenceStore, usePresenceStore } from '@/store/presence-store';
 
 vi.mock('@/services/friends', () => ({
   fetchFriends: vi.fn(),
@@ -28,6 +29,7 @@ function renderFriendsList() {
 describe('FriendsList', () => {
   beforeEach(() => {
     mockedFetchFriends.mockReset();
+    resetPresenceStore();
   });
 
   it('orders friends by presence priority', async () => {
@@ -58,5 +60,39 @@ describe('FriendsList', () => {
     expect(items[0]).toHaveTextContent(/in game/i);
     expect(items[1]).toHaveTextContent(/online/i);
     expect(items[2]).toHaveTextContent(/offline/i);
+  });
+
+  it('reorders the list when realtime presence overrides the fetched snapshot', async () => {
+    mockedFetchFriends.mockResolvedValue([
+      {
+        id: 'friend-1',
+        username: 'offline',
+        profile: { displayName: 'Offline', avatarUrl: null, accentColor: null },
+        presence: { status: 'OFFLINE', currentGame: null, platform: null },
+      },
+      {
+        id: 'friend-2',
+        username: 'online',
+        profile: { displayName: 'Online', avatarUrl: null, accentColor: null },
+        presence: { status: 'ONLINE', currentGame: null, platform: null },
+      },
+    ]);
+
+    usePresenceStore.getState().upsertPresence(
+      {
+        userId: 'friend-1',
+        status: 'IN_GAME',
+        currentGame: 'Marvel Rivals',
+        platform: 'PC',
+      },
+      123,
+    );
+
+    renderFriendsList();
+
+    const items = await screen.findAllByTestId('friend-list-item');
+    expect(items[0]).toHaveTextContent(/offline/i);
+    expect(items[0]).toHaveTextContent(/jogando marvel rivals/i);
+    expect(items[1]).toHaveTextContent(/online/i);
   });
 });

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GamerCard } from '@/components/profile/gamer-card';
+import { type ProfileResponse } from '@/schemas/profile';
+import { resetPresenceStore, usePresenceStore } from '@/store/presence-store';
+
+const profileFixture: ProfileResponse = {
+  id: 'user-1',
+  username: 'clutchplayer',
+  createdAt: '2026-03-29T22:15:00.000Z',
+  profile: {
+    displayName: 'CLUTCH Player',
+    bio: 'Bio de teste',
+    avatarUrl: null,
+    bannerUrl: null,
+    accentColor: '#7C3AED',
+    badges: ['Founder'],
+  },
+  stats: {
+    level: 18,
+    xp: 4820,
+    reputation: 215,
+    friendCount: 2,
+    postCount: 2,
+  },
+  presence: {
+    status: 'OFFLINE',
+    currentGame: null,
+    gameDetails: null,
+    platform: null,
+    updatedAt: '2026-03-29T22:15:00.000Z',
+  },
+  platformIntegrations: [],
+  gameLibrary: [],
+};
+
+describe('GamerCard', () => {
+  beforeEach(() => {
+    resetPresenceStore();
+  });
+
+  it('overrides static profile presence with realtime store data', () => {
+    usePresenceStore.getState().upsertPresence(
+      {
+        userId: 'user-1',
+        status: 'IN_GAME',
+        currentGame: 'Valorant',
+        platform: 'PC',
+      },
+      123,
+    );
+
+    render(<GamerCard profile={profileFixture} />);
+
+    expect(screen.getByText(/in game/i)).toBeInTheDocument();
+    expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/routes/auth-presence-token-route.test.ts
+++ b/frontend/tests/unit/routes/auth-presence-token-route.test.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '@/app/api/auth/presence-token/route';
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+describe('auth presence token route', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    vi.restoreAllMocks();
+  });
+
+  it('returns the websocket credential when the session cookie is valid', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            id: 'user-1',
+            username: 'clutchplayer',
+            email: 'clutchplayer@clutch.gg',
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        );
+      }) as typeof fetch,
+    );
+
+    const request = new NextRequest('http://localhost/api/auth/presence-token', {
+      headers: {
+        cookie: 'clutch_session=jwt-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ token: 'jwt-token' });
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('clears the cookie when the backend rejects the session token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      }) as typeof fetch,
+    );
+
+    const request = new NextRequest('http://localhost/api/auth/presence-token', {
+      headers: {
+        cookie: 'clutch_session=expired-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+  });
+});
+
+afterAll(() => {
+  if (typeof originalApiUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+});

--- a/frontend/tests/unit/services/presence.test.ts
+++ b/frontend/tests/unit/services/presence.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchPresenceCredential,
+  PresenceConnection,
+  PresenceRequestError,
+} from '@/services/presence';
+
+type Listener = (event: Event) => void;
+
+class FakeWebSocket {
+  public static readonly OPEN = 1;
+
+  public readyState = 0;
+  public readonly sent: string[] = [];
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(type: string, listener: Listener) {
+    const current = this.listeners.get(type) ?? new Set<Listener>();
+    current.add(listener);
+    this.listeners.set(type, current);
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  close() {
+    this.readyState = 3;
+    this.emit('close', new Event('close'));
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  emitOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit('open', new Event('open'));
+  }
+
+  emitMessage(data: string) {
+    this.emit('message', { data } as MessageEvent<string>);
+  }
+
+  emitClose() {
+    this.readyState = 3;
+    this.emit('close', new Event('close'));
+  }
+
+  private emit(type: string, event: Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+describe('presence service', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8080';
+    vi.restoreAllMocks();
+    vi.stubGlobal('WebSocket', { OPEN: FakeWebSocket.OPEN });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('hydrates the presence credential from the local auth route', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ token: 'jwt-token' }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+      }) as typeof fetch,
+    );
+
+    await expect(fetchPresenceCredential()).resolves.toBe('jwt-token');
+  });
+
+  it('opens the websocket with the authenticated token and parses presence events', async () => {
+    const createdUrls: string[] = [];
+    const socket = new FakeWebSocket();
+    const onPresence = vi.fn();
+    const onStatus = vi.fn();
+
+    const connection = new PresenceConnection({
+      getCredential: vi.fn(async () => 'jwt-token'),
+      socketFactory: (url) => {
+        createdUrls.push(url);
+        return socket;
+      },
+      onPresence,
+      onConnectionStatusChange: onStatus,
+    });
+
+    connection.connect();
+    await vi.waitFor(() => {
+      expect(createdUrls).toHaveLength(1);
+    });
+
+    expect(createdUrls[0]).toContain('/ws/presence?token=jwt-token');
+    expect(createdUrls[0]).not.toContain('userId=');
+
+    socket.emitOpen();
+    socket.emitMessage(
+      JSON.stringify({
+        event: 'FRIEND_PRESENCE',
+        payload: {
+          userId: 'friend-1',
+          status: 'IN_GAME',
+          currentGame: 'Valorant',
+          platform: 'PC',
+        },
+        ts: 321,
+      }),
+    );
+
+    expect(onStatus).toHaveBeenCalledWith('connected', null);
+    expect(onPresence).toHaveBeenCalledWith(
+      {
+        userId: 'friend-1',
+        status: 'IN_GAME',
+        currentGame: 'Valorant',
+        platform: 'PC',
+      },
+      321,
+    );
+  });
+
+  it('stops the flow and reports auth error when the credential route rejects the session', async () => {
+    const onAuthFailure = vi.fn();
+    const onStatus = vi.fn();
+    const connection = new PresenceConnection({
+      getCredential: vi.fn(async () => {
+        throw new PresenceRequestError(401, 'Token invalido ou expirado.');
+      }),
+      onPresence: vi.fn(),
+      onConnectionStatusChange: onStatus,
+      onAuthFailure,
+    });
+
+    connection.connect();
+
+    await vi.waitFor(() => {
+      expect(onAuthFailure).toHaveBeenCalled();
+    });
+
+    expect(onStatus).toHaveBeenCalledWith('auth_error', 'Token invalido ou expirado.');
+  });
+
+  it('reconnects with backoff after an unexpected socket close', async () => {
+    vi.useFakeTimers();
+
+    const sockets = [new FakeWebSocket(), new FakeWebSocket()];
+    const getCredential = vi.fn(async () => 'jwt-token');
+    const connection = new PresenceConnection({
+      getCredential,
+      socketFactory: vi
+        .fn()
+        .mockImplementationOnce(() => sockets[0])
+        .mockImplementationOnce(() => sockets[1]),
+      onPresence: vi.fn(),
+      onConnectionStatusChange: vi.fn(),
+    });
+
+    connection.connect();
+    await vi.runAllTimersAsync();
+    sockets[0]!.emitOpen();
+    sockets[0]!.emitClose();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(getCredential).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/tests/unit/store/presence-store.test.ts
+++ b/frontend/tests/unit/store/presence-store.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resetPresenceStore, usePresenceStore } from '@/store/presence-store';
+
+describe('presence store', () => {
+  beforeEach(() => {
+    resetPresenceStore();
+  });
+
+  it('starts idle with no presence entries', () => {
+    const state = usePresenceStore.getState();
+
+    expect(state.connectionStatus).toBe('idle');
+    expect(state.entries).toEqual({});
+    expect(state.errorMessage).toBeNull();
+  });
+
+  it('stores realtime updates and can clear all state', () => {
+    usePresenceStore.getState().setConnectionStatus('connected');
+    usePresenceStore.getState().upsertPresence(
+      {
+        userId: 'friend-1',
+        status: 'IN_GAME',
+        currentGame: 'Valorant',
+        platform: 'PC',
+      },
+      123,
+    );
+
+    expect(usePresenceStore.getState().entries['friend-1']).toEqual({
+      userId: 'friend-1',
+      status: 'IN_GAME',
+      currentGame: 'Valorant',
+      platform: 'PC',
+      receivedAt: 123,
+    });
+
+    usePresenceStore.getState().clearAll();
+
+    expect(usePresenceStore.getState().connectionStatus).toBe('idle');
+    expect(usePresenceStore.getState().entries).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add authenticated Rich Presence wiring on the frontend using the hardened backend websocket contract
- introduce a presence store, realtime hook and same-origin presence credential route without relying on `userId` as handshake identity
- overlay realtime presence updates on profile and friends list with contract-level tests for auth, reconnection and parsing

## What This PR Adds
- `PresenceProvider` bootstrapped from the authenticated app shell lifecycle
- `presenceStore` for authorized presence snapshots and connection state
- `PresenceConnection` client with exponential backoff reconnection and cleanup on logout/auth failure
- `/api/auth/presence-token` route that validates the current httpOnly session before exposing an in-memory websocket credential
- realtime presence overrides in `GamerCard` and `FriendsList`

## Contract Notes
- The real backend contract no longer trusts `userId` from query string; the websocket is authenticated by JWT and fan-out is scoped server-side.
- Browser-native WebSocket clients cannot set `Authorization` headers, so the frontend uses the backend-supported `?token=` handshake with a token obtained at runtime from a same-origin route and never persisted in localStorage/sessionStorage.
- Only `FRIEND_PRESENCE` and `PONG` are handled; other realtime channels remain intentionally out of scope for issue #93.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## Risks
- If the backend later replaces query-token handshake with a dedicated short-lived presence ticket, the local credential route should be migrated to that contract.
- The project docs still mention `?userId=` for websocket presence; this PR follows the real backend code instead of the stale documentation.

Closes #93
