### PR TITLE
fix(backend): support configurable server port

### DIFF
--- a/backend/src/config/server-config.ts
+++ b/backend/src/config/server-config.ts
@@ -1,0 +1,17 @@
+const DEFAULT_PORT = 3333;
+
+export function resolveServerPort(rawPort: string | undefined): number {
+  if (!rawPort) {
+    return DEFAULT_PORT;
+  }
+
+  const parsedPort = Number.parseInt(rawPort, 10);
+
+  if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
+    return DEFAULT_PORT;
+  }
+
+  return parsedPort;
+}
+
+export { DEFAULT_PORT };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,12 +8,14 @@ import { integrationRoutes } from './api/routes/integrations.routes';
 import { postRoutes } from './api/routes/posts.routes';
 import { notificationRoutes } from './api/routes/notifications.routes';
 import { authenticate } from './api/middlewares/authenticate';
+import { resolveServerPort } from './config/server-config';
 
 // ─────────────────────────────────────────────────────────────
 // CLUTCH ⚡ — Entry point
 // ─────────────────────────────────────────────────────────────
 
 const app = Fastify({ logger: true });
+const port = resolveServerPort(process.env['PORT']);
 
 // ── JWT Plugin ────────────────────────────────────────────────
 await app.register(fastifyJwt, {
@@ -42,8 +44,12 @@ await app.register(notificationRoutes, { prefix: '/notifications' });
 // ── Start ─────────────────────────────────────────────────────
 const start = async (): Promise<void> => {
   try {
-    await app.listen({ port: 3333, host: '0.0.0.0' });
+    await app.listen({ port, host: '0.0.0.0' });
   } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'EADDRINUSE') {
+      app.log.error(`Port ${port} is already in use. Stop the running API instance or set PORT to a different value.`);
+    }
+
     app.log.error(err);
     process.exit(1);
   }

--- a/backend/tests/unit/config/server-config.test.ts
+++ b/backend/tests/unit/config/server-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PORT, resolveServerPort } from '../../../src/config/server-config';
+
+describe('server-config', () => {
+  it('retorna a porta padrão quando PORT não está definida', () => {
+    expect(resolveServerPort(undefined)).toBe(DEFAULT_PORT);
+  });
+
+  it('retorna a porta configurada quando PORT é válida', () => {
+    expect(resolveServerPort('4444')).toBe(4444);
+  });
+
+  it('retorna a porta padrão quando PORT é inválida', () => {
+    expect(resolveServerPort('abc')).toBe(DEFAULT_PORT);
+    expect(resolveServerPort('0')).toBe(DEFAULT_PORT);
+    expect(resolveServerPort('-1')).toBe(DEFAULT_PORT);
+    expect(resolveServerPort('70000')).toBe(DEFAULT_PORT);
+  });
+});


### PR DESCRIPTION
## Summary
- make the backend honor the documented PORT env var with a safe fallback to 3333
- improve the startup error for EADDRINUSE so local conflicts are explicit and actionable
- add unit coverage for server port resolution without changing the HTTP contract

## What Changed
- added a small server-config helper to resolve and validate PORT
- updated the backend bootstrap to use the configured port instead of hardcoding 3333
- logged a clearer message when the selected port is already in use
- added unit tests covering default, valid and invalid port values

## Validation
- 
pm run test
- 
pm run lint
- 
pm run typecheck
- 
pm run build
- PORT=3334 node dist/src/server.js
- PORT=3334 npm run dev

## Scope Notes
- this is a focused follow-up to the startup fixes already merged in #132
- no route, auth, persistence or websocket contract was changed

Closes #133