### PR TITLE
feat(infra): migre o ambiente local para proxy reverso container-first

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+POSTGRES_PASSWORD=clutch_dev_pass
+JWT_SECRET=clutch-dev-secret-change-in-production

--- a/README.md
+++ b/README.md
@@ -28,14 +28,17 @@ CLUTCH é uma rede social para gamers, otakus e geeks. Perfil unificado, Rich Pr
 
 ## 📋 Pré-requisitos
 
-- [Node.js 20+](https://nodejs.org)
 - [Docker + Docker Compose](https://www.docker.com)
-- [Go 1.22+](https://golang.org) *(para o presence-service)*
 - [Git](https://git-scm.com)
+- Node.js 20+ apenas se você quiser rodar serviços fora dos containers
+- Go 1.24+ apenas se você quiser rodar o `presence-service` fora dos containers
 
 ---
 
 ## 🚀 Como rodar localmente
+
+O ambiente local agora é **container-first** e sobe por **porta única externa** via proxy reverso.  
+Você não precisa mais expor `3000`, `3344`, `5432`, `6379` ou `8080` no host.
 
 ### 1. Clonar o repositório
 ```bash
@@ -43,101 +46,78 @@ git clone https://github.com/alessandrolsdev/clutch.git
 cd clutch
 ```
 
-### 2. Subir Postgres e Redis
+### 2. Configurar variáveis do compose
 ```bash
-docker-compose up -d
-```
-
-### 3. Configurar variáveis de ambiente
-```bash
-cd backend
 cp .env.example .env
-# Edite o .env com seus valores
 ```
 
-### 4. Instalar dependências
+### 3. Subir todo o ambiente
 ```bash
-npm install
+docker compose up --build
 ```
 
-### 5. Rodar as migrations
-```bash
-npx prisma migrate dev
-```
+Se esta for a primeira subida depois de trocar a imagem do backend, o boot pode demorar mais enquanto o container recompõe `node_modules` e regenera o Prisma client no volume de desenvolvimento.
 
-### 6. Popular o banco com dados demo
-```bash
-npm run db:seed
-```
+O compose sobe:
+- `traefik` na porta `80`
+- `frontend` internamente na `3000`
+- `backend` internamente na `3344`
+- `presence` internamente na `8080`
+- `postgres` internamente na `5432`
+- `redis` internamente na `6379`
 
-O seed é determinístico, pode ser reexecutado e não depende de Steam, IGDB, Epic ou Discord para concluir.
+Todos os serviços se comunicam por nome Docker (`frontend`, `backend`, `presence`, `postgres`, `redis`).
 
-**Conta demo após o seed:**
+### 4. Acessar o app
+
+- Frontend: `http://localhost`
+- Login: `http://localhost/login`
+- Backend health via frontend proxy: `http://localhost/api/health`
+- Presence health via proxy: `http://localhost/presence/health`
+
+### 5. Conta demo
+
+O backend aplica migrations e roda o seed no boot do container.  
+O seed é determinístico e pode ser reexecutado sem depender de Steam, IGDB, Epic ou Discord.
+
 ```txt
 Email: clutchplayer@clutch.gg
 Senha: clutch123
-```
-
-### 7. Iniciar o servidor
-```bash
-npm run dev
-```
-
-O backend estará disponível em `http://localhost:3333`.
-
-**Health check:**
-```bash
-curl http://localhost:3333/health
-# { "status": "ok", "service": "clutch-backend" }
 ```
 
 ---
 
-## Frontend foundation
+## Validação rápida do ambiente
 
-Com a issue `#83`, o frontend agora vive de fato em [frontend/](/C:/Github/clutch/frontend).
-
-### 1. Configurar variaveis do frontend
+### Health do backend
 ```bash
-cd frontend
-cp .env.example .env.local
+curl http://localhost/api/health
 ```
 
-### 2. Instalar dependencias
+### Health do presence
 ```bash
-npm install
+curl http://localhost/presence/health
 ```
 
-### 3. Subir o app
+### Login via frontend proxy
 ```bash
-npm run dev
+curl -X POST http://localhost/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"clutchplayer@clutch.gg","password":"clutch123"}'
 ```
 
-O frontend ficara disponivel em `http://localhost:3000`.
-
-### 4. Validar a foundation
-```bash
-npm run typecheck
-npm run lint
-npm run test
-npm run build
-```
-
-Esta etapa entrega apenas a base do app: Next.js 15, TypeScript strict, Tailwind v3, aliases, shell inicial e setup de testes.
-
-### Login local
-Depois da foundation e da issue `#87`, o login do frontend fica em:
+### Presença em tempo real
+O browser conecta o WebSocket pelo mesmo host público:
 
 ```txt
-http://localhost:3000/login
+ws://localhost/ws/presence?token=<jwt>
 ```
 
-Use a conta demo seeded no backend:
+O token continua vindo da rota local autenticada do frontend.
 
-```txt
-Email: clutchplayer@clutch.gg
-Senha: clutch123
-```
+### Desenvolvimento manual fora de containers
+Ainda é possível rodar serviços manualmente, mas esse fluxo deixou de ser o padrão.  
+O caminho recomendado para DX local agora é sempre `docker compose up --build`.
 
 ---
 
@@ -192,7 +172,7 @@ clutch/
 │       ├── core/services/        ← Regras de negócio
 │       └── infra/                ← Database, Redis, integrações
 ├── frontend/                     ← Next.js 15
-└── docker-compose.yml            ← Postgres + Redis
+└── docker-compose.yml            ← Traefik + frontend + backend + presence + postgres + redis
 ```
 
 ---

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+coverage
+*.log
+prisma/dev.db

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,7 +11,7 @@ PORT=3344
 # ── Banco de dados ───────────────────────────────────────────
 # Formato: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
 # Obrigatório
-DATABASE_URL="postgresql://clutch_admin:clutch_dev_pass@localhost:5432/clutch_main_db"
+DATABASE_URL="postgresql://clutch_admin:clutch_dev_pass@postgres:5432/clutch_main_db"
 
 # Senha do Postgres (usada pelo docker-compose)
 # Obrigatório
@@ -20,7 +20,7 @@ POSTGRES_PASSWORD=clutch_dev_pass
 # ── Redis ────────────────────────────────────────────────────
 # Formato: redis://HOST:PORT
 # Obrigatório
-REDIS_URL="redis://localhost:6379"
+REDIS_URL="redis://redis:6379"
 
 # ── Steam ────────────────────────────────────────────────────
 # Obter em: https://steamcommunity.com/dev/apikey
@@ -43,7 +43,7 @@ IGDB_CLIENT_SECRET=
 # ── Epic Games (Python Service) ──────────────────────────────
 # URL do serviço Python rodando localmente
 # Opcional em desenvolvimento
-EPIC_SERVICE_URL="http://localhost:8000"
+EPIC_SERVICE_URL="http://python-service:8000"
 
 # ── JWT (preencher antes do deploy) ──────────────────────────
 # Gerar com: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npx prisma generate
+
+EXPOSE 3344
+
+CMD ["npm", "run", "dev"]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3993,6 +3993,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,14 +1,27 @@
 import bcrypt from 'bcrypt';
-import {
+import * as prismaClientPackage from '@prisma/client';
+import type {
+  Prisma,
+  PrismaClient as PrismaClientType,
+} from '@prisma/client';
+import { fileURLToPath } from 'node:url';
+
+const {
   InteractionType,
   NotificationType,
   Platform,
   PostType,
   PresenceStatus,
-  Prisma,
+  Prisma: PrismaRuntime,
   PrismaClient,
-} from '@prisma/client';
-import { fileURLToPath } from 'node:url';
+} = prismaClientPackage;
+
+type InteractionType = (typeof InteractionType)[keyof typeof InteractionType];
+type NotificationType = (typeof NotificationType)[keyof typeof NotificationType];
+type Platform = (typeof Platform)[keyof typeof Platform];
+type PostType = (typeof PostType)[keyof typeof PostType];
+type PresenceStatus = (typeof PresenceStatus)[keyof typeof PresenceStatus];
+type PrismaClient = PrismaClientType;
 
 const prisma = new PrismaClient();
 
@@ -155,7 +168,7 @@ type SeedIntegrationConfig = {
 };
 
 function toNullableJsonInput(value: Prisma.JsonObject | null): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
-  return value ?? Prisma.JsonNull;
+  return value ?? PrismaRuntime.JsonNull;
 }
 
 const seedUsers: SeedUserRecord[] = [

--- a/backend/scripts/container-dev-start.sh
+++ b/backend/scripts/container-dev-start.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+# The backend source is bind-mounted in development and node_modules lives in a
+# persistent Docker volume. Reinstalling + regenerating Prisma on boot keeps the
+# volume aligned with the current image/runtime after base-image or lockfile changes.
+npm install
+npx prisma generate
+npm run db:migrate:prod
+npm run db:seed
+npm run dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,90 @@
 services:
-  postgres:
-    image: postgres:15-alpine
-    container_name: clutch_postgres
+  traefik:
+    image: traefik:v3.3
+    container_name: clutch_traefik
     restart: unless-stopped
-    environment:
-      POSTGRES_DB:       clutch_main_db
-      POSTGRES_USER:     clutch_admin
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-clutch_dev_pass}
+    command:
+      - --api.dashboard=false
+      - --providers.file.filename=/etc/traefik/dynamic.yml
+      - --entrypoints.web.address=:80
+      - --log.level=INFO
+      - --accesslog=true
     ports:
-      - "5432:5432"
+      - "80:80"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U clutch_admin -d clutch_main_db"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
+      - ./infra/traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+    depends_on:
+      frontend:
+        condition: service_started
+      presence:
+        condition: service_healthy
+    networks:
+      - clutch
 
-  redis:
-    image: redis:7-alpine
-    container_name: clutch_redis
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: clutch_frontend
     restart: unless-stopped
-    command: redis-server --appendonly yes
-    ports:
-      - "6379:6379"
+    working_dir: /app
+    command: npm run dev -- --hostname 0.0.0.0 --port 3000
+    environment:
+      NODE_ENV: development
+      WATCHPACK_POLLING: "true"
+      INTERNAL_API_URL: http://backend:3344
+      NEXT_PUBLIC_API_URL: http://localhost/api
+      NEXT_PUBLIC_WS_URL: ws://localhost
     volumes:
-      - redis_data:/data
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    depends_on:
+      backend:
+        condition: service_healthy
+    expose:
+      - "3000"
+    networks:
+      - clutch
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: clutch_backend
+    restart: unless-stopped
+    working_dir: /app
+    command: sh ./scripts/container-dev-start.sh
+    environment:
+      NODE_ENV: development
+      PORT: "3344"
+      DATABASE_URL: postgresql://clutch_admin:${POSTGRES_PASSWORD:-clutch_dev_pass}@postgres:5432/clutch_main_db
+      REDIS_URL: redis://redis:6379
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-clutch_dev_pass}
+      JWT_SECRET: ${JWT_SECRET:-clutch-dev-secret-change-in-production}
+    volumes:
+      - ./backend:/app
+      - backend_node_modules:/app/node_modules
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    expose:
+      - "3344"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3344/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 5s
+      retries: 15
+      start_period: 90s
+    networks:
+      - clutch
 
   presence:
     build:
@@ -40,15 +92,70 @@ services:
       dockerfile: Dockerfile
     container_name: clutch_presence
     restart: unless-stopped
-    ports:
-      - "8080:8080"
     environment:
-      REDIS_URL:     redis://redis:6379
+      REDIS_URL: redis://redis:6379
       PRESENCE_PORT: "8080"
+      JWT_SECRET: ${JWT_SECRET:-clutch-dev-secret-change-in-production}
+      PRESENCE_ALLOWED_ORIGINS: http://localhost,http://127.0.0.1
     depends_on:
       redis:
         condition: service_healthy
+    expose:
+      - "8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/health >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    networks:
+      - clutch
+
+  postgres:
+    image: postgres:15-alpine
+    container_name: clutch_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: clutch_main_db
+      POSTGRES_USER: clutch_admin
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-clutch_dev_pass}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U clutch_admin -d clutch_main_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - clutch
+
+  redis:
+    image: redis:7-alpine
+    container_name: clutch_redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    expose:
+      - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - clutch
+
+networks:
+  clutch:
+    driver: bridge
 
 volumes:
+  backend_node_modules:
+  frontend_node_modules:
   postgres_data:
   redis_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env
+coverage
+*.log

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,3 @@
-NEXT_PUBLIC_API_URL=http://localhost:3333
-NEXT_PUBLIC_WS_URL=ws://localhost:8080
+INTERNAL_API_URL=http://backend:3344
+NEXT_PUBLIC_API_URL=http://localhost/api
+NEXT_PUBLIC_WS_URL=ws://localhost

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/frontend/src/services/http/client.ts
+++ b/frontend/src/services/http/client.ts
@@ -1,11 +1,30 @@
-import { getClientEnv } from '@/lib/config/env';
+function resolveApiBaseUrl(): string {
+  const internalApiUrl = process.env.INTERNAL_API_URL?.trim();
 
-export function buildApiUrl(pathname: string): string {
-  const { apiUrl } = getClientEnv();
-
-  if (!apiUrl) {
-    throw new Error('NEXT_PUBLIC_API_URL is not configured.');
+  if (internalApiUrl) {
+    return internalApiUrl;
   }
 
-  return new URL(pathname, apiUrl).toString();
+  const publicApiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+  if (publicApiUrl) {
+    return publicApiUrl;
+  }
+
+  throw new Error('API URL is not configured.');
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+}
+
+function normalizePathname(pathname: string): string {
+  return pathname.replace(/^\/+/, '');
+}
+
+export function buildApiUrl(pathname: string): string {
+  const baseUrl = normalizeBaseUrl(resolveApiBaseUrl());
+  const normalizedPath = normalizePathname(pathname);
+
+  return new URL(normalizedPath, baseUrl).toString();
 }

--- a/frontend/tests/unit/routes/api-proxy-route.test.ts
+++ b/frontend/tests/unit/routes/api-proxy-route.test.ts
@@ -3,10 +3,12 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from '@/app/api/[...path]/route';
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
 describe('api proxy route', () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
     vi.restoreAllMocks();
   });
 
@@ -76,6 +78,12 @@ describe('api proxy route', () => {
 });
 
 afterAll(() => {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
   if (typeof originalApiUrl === 'undefined') {
     delete process.env.NEXT_PUBLIC_API_URL;
     return;

--- a/frontend/tests/unit/routes/auth-login-route.test.ts
+++ b/frontend/tests/unit/routes/auth-login-route.test.ts
@@ -2,11 +2,13 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 import { POST } from '@/app/api/auth/login/route';
 import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
 
-const originalEnv = process.env.NEXT_PUBLIC_API_URL;
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
 describe('auth login route', () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
     vi.restoreAllMocks();
   });
 
@@ -89,10 +91,16 @@ describe('auth login route', () => {
 });
 
 afterAll(() => {
-  if (typeof originalEnv === 'undefined') {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
+  if (typeof originalApiUrl === 'undefined') {
     delete process.env.NEXT_PUBLIC_API_URL;
     return;
   }
 
-  process.env.NEXT_PUBLIC_API_URL = originalEnv;
+  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
 });

--- a/frontend/tests/unit/routes/auth-me-route.test.ts
+++ b/frontend/tests/unit/routes/auth-me-route.test.ts
@@ -3,10 +3,12 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from '@/app/api/auth/me/route';
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
 describe('auth me route', () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
     vi.restoreAllMocks();
   });
 
@@ -73,6 +75,12 @@ describe('auth me route', () => {
 });
 
 afterAll(() => {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
   if (typeof originalApiUrl === 'undefined') {
     delete process.env.NEXT_PUBLIC_API_URL;
     return;

--- a/frontend/tests/unit/routes/auth-presence-token-route.test.ts
+++ b/frontend/tests/unit/routes/auth-presence-token-route.test.ts
@@ -3,10 +3,12 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from '@/app/api/auth/presence-token/route';
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
 describe('auth presence token route', () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
     vi.restoreAllMocks();
   });
 
@@ -70,6 +72,12 @@ describe('auth presence token route', () => {
 });
 
 afterAll(() => {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
   if (typeof originalApiUrl === 'undefined') {
     delete process.env.NEXT_PUBLIC_API_URL;
     return;

--- a/frontend/tests/unit/routes/auth-register-route.test.ts
+++ b/frontend/tests/unit/routes/auth-register-route.test.ts
@@ -3,10 +3,12 @@ import { POST } from '@/app/api/auth/register/route';
 import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
 describe('auth register route', () => {
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_API_URL = 'http://backend.test';
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
     vi.restoreAllMocks();
   });
 
@@ -107,6 +109,12 @@ describe('auth register route', () => {
 });
 
 afterAll(() => {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
   if (typeof originalApiUrl === 'undefined') {
     delete process.env.NEXT_PUBLIC_API_URL;
     return;

--- a/frontend/tests/unit/services/http-client.test.ts
+++ b/frontend/tests/unit/services/http-client.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildApiUrl } from '@/services/http/client';
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
+
+describe('buildApiUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+
+    if (typeof originalApiUrl === 'undefined') {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+    }
+
+    if (typeof originalInternalApiUrl === 'undefined') {
+      delete process.env.INTERNAL_API_URL;
+    } else {
+      process.env.INTERNAL_API_URL = originalInternalApiUrl;
+    }
+  });
+
+  it('prefers the internal API URL on the server', () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    process.env.INTERNAL_API_URL = 'http://backend:3344';
+
+    expect(buildApiUrl('/health')).toBe('http://backend:3344/health');
+  });
+
+  it('preserves the /api prefix when the public URL uses path routing', () => {
+    delete process.env.INTERNAL_API_URL;
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
+
+    expect(buildApiUrl('/auth/login')).toBe('http://localhost/api/auth/login');
+  });
+});

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -1,0 +1,60 @@
+http:
+  routers:
+    backend-health:
+      entryPoints:
+        - web
+      rule: Path(`/api/health`)
+      priority: 100
+      middlewares:
+        - strip-api-prefix
+      service: backend
+
+    presence-ws:
+      entryPoints:
+        - web
+      rule: PathPrefix(`/ws/presence`)
+      priority: 100
+      service: presence
+
+    presence-http:
+      entryPoints:
+        - web
+      rule: Path(`/presence/health`) || Path(`/presence/stats`)
+      priority: 90
+      middlewares:
+        - strip-presence-prefix
+      service: presence
+
+    frontend:
+      entryPoints:
+        - web
+      rule: PathPrefix(`/`)
+      priority: 1
+      service: frontend
+
+  middlewares:
+    strip-api-prefix:
+      stripPrefix:
+        prefixes:
+          - /api
+
+    strip-presence-prefix:
+      stripPrefix:
+        prefixes:
+          - /presence
+
+  services:
+    frontend:
+      loadBalancer:
+        servers:
+          - url: http://frontend:3000
+
+    backend:
+      loadBalancer:
+        servers:
+          - url: http://backend:3344
+
+    presence:
+      loadBalancer:
+        servers:
+          - url: http://presence:8080


### PR DESCRIPTION
## Resumo
Migra o ambiente local do CLUTCH para um modelo container-first com porta unica externa via Traefik, mantendo service discovery por nome e eliminando a exposicao direta de frontend, backend, presence, Postgres e Redis. Tambem corrige o runtime do backend em container para Prisma, incluindo compatibilidade com OpenSSL e boot confiavel em Docker.

## O que foi alterado
- Reestruturei o `docker-compose.yml` para usar Traefik como unico ponto de entrada externo.
- Adicionei imagens Docker para frontend e backend, com `node_modules` persistidos em volumes de desenvolvimento.
- Ajustei o backend para runtime Debian slim com OpenSSL, `prisma generate` e script de boot que reinstala dependencias e aplica migrations/seed no container.
- Substitui o provider Docker do Traefik por configuracao dinamica em arquivo para compatibilidade com Docker Desktop no Windows.
- Separei `INTERNAL_API_URL` e `NEXT_PUBLIC_API_URL` no frontend e atualizei os testes das rotas BFF.
- Atualizei a documentacao de boot local e validacao operacional.

## Motiva??o
O ambiente anterior dependia de varias portas expostas manualmente e falhava em cenarios reais de desenvolvimento local. A mudanca aproxima a topologia local da topologia de producao, reduz conflito de portas e elimina o acoplamento entre servicos via `localhost:porta`.

## Como validar
- Execute `docker compose up -d --build` na raiz do repositorio.
- Confirme `docker compose ps` com `backend` e `presence` em estado `healthy`.
- Execute `curl http://localhost/api/health` e verifique resposta `200` com `{"status":"ok"}`.
- Execute `curl http://localhost/presence/health` e verifique resposta `200`.
- Acesse `http://localhost/login`.
- Fa?a login com `clutchplayer@clutch.gg` / `clutch123` e confirme resposta `200` em `POST /api/auth/login`.

## Riscos e impactos
- O backend agora depende de imagem Debian slim para compatibilidade com Prisma/OpenSSL em container; isso aumenta o tamanho da imagem em troca de estabilidade.
- O bootstrap do backend em desenvolvimento pode demorar mais no primeiro boot porque recomp?e `node_modules`, regenera Prisma client, aplica migrations e roda seed.
- O proxy Traefik passou a usar configuracao por arquivo em vez de labels Docker; futuras rotas precisam ser registradas em `infra/traefik/dynamic.yml`.

## Evid?ncias
- `docker compose up -d --build` executado com sucesso.
- `curl http://localhost/api/health` retornando `200`.
- `curl http://localhost/presence/health` retornando `200`.
- `POST http://localhost/api/auth/login` retornando `200` com a conta demo.

## Checklist
- [x] Altera??o limitada ao objetivo da PR
- [x] Sem mudan?as desconexas
- [x] Impactos principais descritos
- [x] Valida??o documentada
- [x] Riscos identificados

Closes #137
