### PR TITLE
fix(infra): alinhar readiness do stack container-first

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Todos os serviços se comunicam por nome Docker (`frontend`, `backend`, `presenc
 - Frontend: `http://localhost`
 - Login: `http://localhost/login`
 - Backend health via frontend proxy: `http://localhost/api/health`
+- Backend liveness via frontend proxy: `http://localhost/api/health/live`
+- Backend readiness via frontend proxy: `http://localhost/api/health/ready`
 - Presence health via proxy: `http://localhost/presence/health`
 
 ### 5. Bootstrap dos dados demo
@@ -108,6 +110,12 @@ Senha: clutch123
 curl http://localhost/api/health
 ```
 
+### Liveness e readiness do backend
+```bash
+curl http://localhost/api/health/live
+curl http://localhost/api/health/ready
+```
+
 ### Health do presence
 ```bash
 curl http://localhost/presence/health
@@ -130,6 +138,11 @@ ws://localhost/ws/presence?token=<jwt>
 ```
 
 O token continua vindo da rota local autenticada do frontend.
+
+### Readiness do stack
+- `backend` fica saudável quando banco e Redis respondem em `/health/ready`
+- `frontend` fica saudável quando `http://127.0.0.1:3000/login` responde no container
+- `traefik` só sobe como healthy depois do ping interno e das dependências saudáveis
 
 ### Desenvolvimento manual fora de containers
 Ainda é possível rodar serviços manualmente, mas esse fluxo deixou de ser o padrão.  

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,10 +8,15 @@ import { integrationRoutes } from './api/routes/integrations.routes';
 import { postRoutes } from './api/routes/posts.routes';
 import { notificationRoutes } from './api/routes/notifications.routes';
 import { authenticate } from './api/middlewares/authenticate';
+import {
+  runReadinessChecks,
+  type ReadinessReport,
+} from './config/health';
 
-type BuildAppOptions = {
+export type BuildAppOptions = {
   jwtSecret?: string;
   logger?: boolean;
+  readinessCheck?: () => Promise<ReadinessReport>;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -23,9 +28,25 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
 
   app.decorate('authenticate', authenticate);
 
+  const readinessCheck = options.readinessCheck ?? runReadinessChecks;
+
   app.get('/health', async () => ({
     status: 'ok',
   }));
+
+  app.get('/health/live', async () => ({
+    status: 'ok',
+  }));
+
+  app.get('/health/ready', async (_request, reply) => {
+    const readiness = await readinessCheck();
+
+    if (readiness.status === 'error') {
+      return reply.status(503).send(readiness);
+    }
+
+    return reply.status(200).send(readiness);
+  });
 
   await app.register(authRoutes, { prefix: '/auth' });
   await app.register(profileRoutes, { prefix: '/profiles' });

--- a/backend/src/config/health.ts
+++ b/backend/src/config/health.ts
@@ -1,0 +1,56 @@
+export type DependencyHealthStatus = 'ok' | 'error';
+
+export type ReadinessReport = {
+  status: 'ok' | 'error';
+  checks: {
+    database: DependencyHealthStatus;
+    redis: DependencyHealthStatus;
+  };
+};
+
+type ReadinessCheckDependencies = {
+  checkDatabase?: () => Promise<unknown>;
+  checkRedis?: () => Promise<unknown>;
+};
+
+async function defaultDatabaseCheck(): Promise<void> {
+  const { prisma } = await import('../infra/database/client');
+  await prisma.$queryRaw`SELECT 1`;
+}
+
+async function defaultRedisCheck(): Promise<void> {
+  const { redis } = await import('../infra/cache/redis');
+  await redis.ping();
+}
+
+export async function runReadinessChecks(
+  dependencies: ReadinessCheckDependencies = {},
+): Promise<ReadinessReport> {
+  const checkDatabase = dependencies.checkDatabase ?? defaultDatabaseCheck;
+  const checkRedis = dependencies.checkRedis ?? defaultRedisCheck;
+
+  const checks: ReadinessReport['checks'] = {
+    database: 'ok',
+    redis: 'ok',
+  };
+
+  try {
+    await checkDatabase();
+  } catch {
+    checks.database = 'error';
+  }
+
+  try {
+    await checkRedis();
+  } catch {
+    checks.redis = 'error';
+  }
+
+  return {
+    status:
+      checks.database === 'ok' && checks.redis === 'ok'
+        ? 'ok'
+        : 'error',
+    checks,
+  };
+}

--- a/backend/tests/helpers/build-app.ts
+++ b/backend/tests/helpers/build-app.ts
@@ -1,12 +1,18 @@
 import { FastifyInstance } from 'fastify';
-import { buildApp as createApp } from '../../src/app';
+import {
+  buildApp as createApp,
+  type BuildAppOptions,
+} from '../../src/app';
 
 export const TEST_JWT_SECRET = 'clutch-test-secret';
 
-export const buildApp = async (): Promise<FastifyInstance> => {
+export const buildApp = async (
+  options: Omit<BuildAppOptions, 'jwtSecret' | 'logger'> = {},
+): Promise<FastifyInstance> => {
   return createApp({
     jwtSecret: TEST_JWT_SECRET,
     logger: false,
+    ...options,
   });
 };
 

--- a/backend/tests/integration/health.routes.test.ts
+++ b/backend/tests/integration/health.routes.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../helpers/build-app';
+
+describe('Health Routes', () => {
+  it('retorna 200 em /health e /health/live', async () => {
+    const app = await buildApp();
+
+    const [healthResponse, liveResponse] = await Promise.all([
+      app.inject({
+        method: 'GET',
+        url: '/health',
+      }),
+      app.inject({
+        method: 'GET',
+        url: '/health/live',
+      }),
+    ]);
+
+    expect(healthResponse.statusCode).toBe(200);
+    expect(healthResponse.json()).toEqual({ status: 'ok' });
+    expect(liveResponse.statusCode).toBe(200);
+    expect(liveResponse.json()).toEqual({ status: 'ok' });
+
+    await app.close();
+  });
+
+  it('retorna 200 em /health/ready quando as dependências estão prontas', async () => {
+    const app = await buildApp({
+      readinessCheck: async () => ({
+        status: 'ok',
+        checks: {
+          database: 'ok',
+          redis: 'ok',
+        },
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/health/ready',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      status: 'ok',
+      checks: {
+        database: 'ok',
+        redis: 'ok',
+      },
+    });
+
+    await app.close();
+  });
+
+  it('retorna 503 em /health/ready quando alguma dependência crítica falha', async () => {
+    const app = await buildApp({
+      readinessCheck: async () => ({
+        status: 'error',
+        checks: {
+          database: 'error',
+          redis: 'ok',
+        },
+      }),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/health/ready',
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.json()).toEqual({
+      status: 'error',
+      checks: {
+        database: 'error',
+        redis: 'ok',
+      },
+    });
+
+    await app.close();
+  });
+});

--- a/backend/tests/unit/config/health.test.ts
+++ b/backend/tests/unit/config/health.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runReadinessChecks } from '../../../src/config/health';
+
+describe('health config', () => {
+  it('retorna ok quando banco e redis respondem', async () => {
+    const readiness = await runReadinessChecks({
+      checkDatabase: vi.fn().mockResolvedValue(undefined),
+      checkRedis: vi.fn().mockResolvedValue('PONG'),
+    });
+
+    expect(readiness).toEqual({
+      status: 'ok',
+      checks: {
+        database: 'ok',
+        redis: 'ok',
+      },
+    });
+  });
+
+  it('marca database como error quando o ping do banco falha', async () => {
+    const readiness = await runReadinessChecks({
+      checkDatabase: vi.fn().mockRejectedValue(new Error('db offline')),
+      checkRedis: vi.fn().mockResolvedValue('PONG'),
+    });
+
+    expect(readiness).toEqual({
+      status: 'error',
+      checks: {
+        database: 'error',
+        redis: 'ok',
+      },
+    });
+  });
+
+  it('marca redis como error quando o ping do redis falha', async () => {
+    const readiness = await runReadinessChecks({
+      checkDatabase: vi.fn().mockResolvedValue(undefined),
+      checkRedis: vi.fn().mockRejectedValue(new Error('redis offline')),
+    });
+
+    expect(readiness).toEqual({
+      status: 'error',
+      checks: {
+        database: 'ok',
+        redis: 'error',
+      },
+    });
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - --api.dashboard=false
       - --providers.file.filename=/etc/traefik/dynamic.yml
       - --entrypoints.web.address=:80
+      - --entrypoints.ping.address=:8082
+      - --ping=true
+      - --ping.entrypoint=ping
       - --log.level=INFO
       - --accesslog=true
     ports:
@@ -15,9 +18,17 @@ services:
       - ./infra/traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
     depends_on:
       frontend:
-        condition: service_started
+        condition: service_healthy
+      backend:
+        condition: service_healthy
       presence:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8082/ping >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
     networks:
       - clutch
 
@@ -43,6 +54,18 @@ services:
         condition: service_healthy
     expose:
       - "3000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/login').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 45s
     networks:
       - clutch
 
@@ -77,7 +100,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "fetch('http://127.0.0.1:3344/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))",
+          "fetch('http://127.0.0.1:3344/health/ready').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))",
         ]
       interval: 10s
       timeout: 5s

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -3,7 +3,7 @@ http:
     backend-health:
       entryPoints:
         - web
-      rule: Path(`/api/health`)
+      rule: PathPrefix(`/api/health`)
       priority: 100
       middlewares:
         - strip-api-prefix


### PR DESCRIPTION
## Resumo

Esta PR unifica a entrega das issues #140 e #142, alinhando o stack container-first a um contrato explícito de liveness/readiness. O backend passa a expor endpoints distintos para vida do processo e prontidão real, e o compose só considera o ambiente pronto quando backend, frontend e traefik respondem de forma consistente.

## O que foi alterado

- Adicionado contrato de health do backend com `/health/live` e `/health/ready`, preservando `/health` por compatibilidade.
- Implementada checagem de readiness do backend com verificação explícita de banco e Redis.
- Tornado o check de readiness lazy para não puxar Prisma e Redis no carregamento de todo o app.
- Ajustado o helper de testes do backend para permitir injeção do readiness check.
- Adicionados testes unitários da lógica de readiness e testes de integração das rotas de health.
- Atualizado o `docker-compose.yml` para:
  - usar `/health/ready` no healthcheck do backend
  - considerar o frontend saudável apenas quando `/login` responde no container
  - considerar o traefik saudável via ping interno
  - subir o traefik apenas após backend, frontend e presence saudáveis
- Atualizado o roteamento do Traefik para cobrir `/api/health/*`.
- Documentados os novos endpoints operacionais e o critério de readiness do stack.
- Adicionada normalização de `LF` para `*.sh` em `.gitattributes`, evitando falha de shell no backend containerizado em ambientes Windows.

## Motivação

O ambiente moderno já dependia de um ponto de entrada único via proxy, mas ainda não distinguia vida do processo de prontidão real das dependências. Isso gerava startup order ambíguo, healthchecks fracos e risco de ambiente parcialmente pronto. A entrega corrige essa ambiguidade sem alterar o contrato funcional da API.

## Como validar

- Executar `docker compose up -d --build` na raiz do repositório.
- Executar `docker compose exec -T backend sh ./scripts/container-bootstrap.sh` para garantir a base demo.
- Validar `docker compose ps` com `backend`, `frontend`, `presence`, `postgres`, `redis` e `traefik` saudáveis.
- Validar `GET http://localhost/api/health` retornando `200`.
- Validar `GET http://localhost/api/health/live` retornando `200`.
- Validar `GET http://localhost/api/health/ready` retornando `200` com `database=ok` e `redis=ok`.
- Validar `GET http://localhost/login` retornando `200`.
- Validar `GET http://localhost/presence/health` retornando `200`.
- Validar `POST http://localhost/api/auth/login` com `clutchplayer@clutch.gg / clutch123` retornando `200`.
- Executar `npm run test -- tests/unit/config/health.test.ts tests/integration/health.routes.test.ts` em `backend/`.
- Executar `docker compose exec -T backend npm run test`.
- Executar `docker compose exec -T backend npm run typecheck`.
- Executar `docker compose exec -T backend npm run lint`.

## Riscos e impactos

- O endpoint `/health` foi preservado como alias simples de compatibilidade; o compose e as verificações operacionais devem migrar para `/health/ready` quando a intenção for prontidão.
- O readiness do backend depende de Prisma e Redis reais; qualquer regressão nessas dependências agora será refletida de forma explícita no estado do container.
- O healthcheck do frontend usa `/login` em modo `next dev`, portanto o tempo de primeira compilação continua relevante para o `start_period`.
- A inclusão de `.gitattributes` para `*.sh` reduz drift de line ending em Windows, mas outros tipos de script continuam sem política global de EOL.

## Evidências

- `docker compose up -d --build` com stack saudável no host único.
- `GET /api/health`, `/api/health/live` e `/api/health/ready` respondendo via Traefik.
- `GET /login` respondendo `200`.
- `POST /api/auth/login` respondendo `200` com a conta demo.
- `docker compose exec -T backend npm run test` com 21 arquivos e 159 testes passando.

## Checklist

- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #140
Closes #142