### PR TITLE
fix(infra): força sync inicial quando runtime stamps estiverem ausentes

### DIFF
--- a/backend/src/config/container-runtime.ts
+++ b/backend/src/config/container-runtime.ts
@@ -15,8 +15,13 @@ export type ContainerRuntimePlan = {
 export function resolveContainerRuntimePlan(
   state: ContainerRuntimeState,
 ): ContainerRuntimePlan {
+  const missingRuntimeStamps =
+    state.storedPackageLockHash === null ||
+    state.storedPrismaSchemaHash === null;
+
   const installDependencies =
     !state.nodeModulesReady ||
+    missingRuntimeStamps ||
     (state.storedPackageLockHash !== null &&
       state.storedPackageLockHash !== state.packageLockHash);
 

--- a/backend/tests/unit/config/container-runtime.test.ts
+++ b/backend/tests/unit/config/container-runtime.test.ts
@@ -19,14 +19,14 @@ function buildState(
 }
 
 describe('container-runtime', () => {
-  it('não reinstala dependências nem regenera o Prisma quando o runtime já está sincronizado', () => {
+  it('nao reinstala dependencias nem regenera o Prisma quando o runtime ja esta sincronizado', () => {
     expect(resolveContainerRuntimePlan(buildState())).toEqual({
       installDependencies: false,
       generatePrismaClient: false,
     });
   });
 
-  it('instala dependências e regenera o Prisma quando node_modules ainda não está pronto', () => {
+  it('instala dependencias e regenera o Prisma quando node_modules ainda nao esta pronto', () => {
     expect(
       resolveContainerRuntimePlan(
         buildState({
@@ -39,7 +39,7 @@ describe('container-runtime', () => {
     });
   });
 
-  it('reinstala dependências quando o package-lock mudou depois do baseline salvo', () => {
+  it('reinstala dependencias quando o package-lock mudou depois do baseline salvo', () => {
     expect(
       resolveContainerRuntimePlan(
         buildState({
@@ -52,7 +52,7 @@ describe('container-runtime', () => {
     });
   });
 
-  it('adota o baseline atual sem reinstalar quando ainda não existe hash persistido', () => {
+  it('reinstala dependencias e regenera o Prisma quando os runtime stamps ainda nao existem', () => {
     expect(
       resolveContainerRuntimePlan(
         buildState({
@@ -61,12 +61,25 @@ describe('container-runtime', () => {
         }),
       ),
     ).toEqual({
-      installDependencies: false,
-      generatePrismaClient: false,
+      installDependencies: true,
+      generatePrismaClient: true,
     });
   });
 
-  it('regenera o Prisma quando o schema muda sem alterar dependências', () => {
+  it('forca a sincronizacao inicial quando apenas um dos runtime stamps esta ausente', () => {
+    expect(
+      resolveContainerRuntimePlan(
+        buildState({
+          storedPrismaSchemaHash: null,
+        }),
+      ),
+    ).toEqual({
+      installDependencies: true,
+      generatePrismaClient: true,
+    });
+  });
+
+  it('regenera o Prisma quando o schema muda sem alterar dependencias', () => {
     expect(
       resolveContainerRuntimePlan(
         buildState({
@@ -79,7 +92,7 @@ describe('container-runtime', () => {
     });
   });
 
-  it('regenera o Prisma quando o client ainda não existe no volume atual', () => {
+  it('regenera o Prisma quando o client ainda nao existe no volume atual', () => {
     expect(
       resolveContainerRuntimePlan(
         buildState({


### PR DESCRIPTION
## Resumo
Corrige o bootstrap do backend em container para tratar runtime stamps ausentes como estado não confiável. Isso evita que volumes antigos de `node_modules` sejam considerados sincronizados por engano e preserva o boot leve apenas quando o baseline persistido já existe.

## O que foi alterado
- ajustada a resolução do plano de runtime para forçar sincronização quando qualquer runtime stamp estiver ausente
- atualizados os testes unitários do container runtime para cobrir ausência total e parcial dos stamps
- mantido o comportamento da issue #141: seed continua fora do restart automático e o runtime só grava novos stamps após sincronização bem-sucedida

## Motivação
Volumes antigos do `backend_node_modules` não carregam os arquivos `.clutch-runtime`. No fluxo atual, a ausência desses stamps podia ser interpretada como baseline válido, mascarando drift do volume e permitindo que artefatos desatualizados fossem aceitos como sincronizados.

## Como validar
- executar `npm run test -- tests/unit/config/container-runtime.test.ts` em `backend/`
- executar `npm run lint`, `npm run typecheck` e `npm run build` em `backend/`
- subir o ambiente com `docker compose up -d backend postgres redis`
- remover os stamps em `node_modules/.clutch-runtime` dentro do container do backend
- reiniciar o serviço com `docker compose restart backend`
- verificar nos logs que o backend roda `npm install` e `prisma generate` uma vez, regrava os stamps e volta healthy

## Riscos e impactos
- o primeiro restart de um volume legado sem stamps ficará mais lento por causa da sincronização forçada
- volumes já sincronizados continuam seguindo o caminho leve de boot
- não há mudança de contrato HTTP nem reintrodução de seed automático

## Evidências
- `npm run test -- tests/unit/config/container-runtime.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `docker compose logs backend` após remover os stamps, mostrando `Sincronizando dependências do backend...` e `Regenerando Prisma Client...`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #150