### PR TITLE
ci(workflow): valida frontend e stack containerizado no pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,18 +184,54 @@ jobs:
       - name: Validate frontend login route
         run: curl -fsS http://localhost/login > /dev/null
 
-      - name: Validate login via proxy
+      - name: Validate session login via proxy
         shell: bash
         run: |
           set -euo pipefail
 
-          status="$(curl -sS -o /tmp/login-response.json -w "%{http_code}" \
+          login_status="$(curl -sS \
+            -D /tmp/login-headers.txt \
+            -c /tmp/clutch-session.cookies \
+            -o /tmp/login-response.json \
+            -w "%{http_code}" \
             -X POST http://localhost/api/auth/login \
             -H "Content-Type: application/json" \
             -d '{"email":"clutchplayer@clutch.gg","password":"clutch123"}')"
 
-          test "${status}" = "200"
-          grep -q '"token"' /tmp/login-response.json
+          if [ "${login_status}" != "200" ]; then
+            echo "Falha no login via proxy. Status: ${login_status}"
+            echo "--- login headers ---"
+            cat /tmp/login-headers.txt
+            echo "--- login body ---"
+            cat /tmp/login-response.json
+            exit 1
+          fi
+
+          if ! grep -iq '^set-cookie: clutch_session=' /tmp/login-headers.txt; then
+            echo "Login nao retornou o cookie de sessao esperado."
+            echo "--- login headers ---"
+            cat /tmp/login-headers.txt
+            echo "--- login body ---"
+            cat /tmp/login-response.json
+            exit 1
+          fi
+
+          me_status="$(curl -sS \
+            -b /tmp/clutch-session.cookies \
+            -o /tmp/auth-me-response.json \
+            -w "%{http_code}" \
+            http://localhost/api/auth/me)"
+
+          if [ "${me_status}" != "200" ]; then
+            echo "Falha ao restaurar sessao via /api/auth/me. Status: ${me_status}"
+            echo "--- login headers ---"
+            cat /tmp/login-headers.txt
+            echo "--- auth/me body ---"
+            cat /tmp/auth-me-response.json
+            exit 1
+          fi
+
+          grep -q '"username":"clutchplayer"' /tmp/auth-me-response.json
 
       - name: Show compose status
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,20 @@ on:
   push:
     branches: [develop]
 
+permissions:
+  contents: read
+
 jobs:
-  ci:
-    name: 🧪 Type check, Lint and Test
+  backend:
+    name: Backend - Typecheck, Lint, Test and Build
     runs-on: ubuntu-latest
 
     services:
       postgres:
         image: postgres:15-alpine
         env:
-          POSTGRES_DB:       clutch_main_db
-          POSTGRES_USER:     clutch_admin
+          POSTGRES_DB: clutch_main_db
+          POSTGRES_USER: clutch_admin
           POSTGRES_PASSWORD: clutch_test_pass
         ports:
           - 5432:5432
@@ -40,34 +43,168 @@ jobs:
       run:
         working-directory: backend
 
+    env:
+      DATABASE_URL: postgresql://clutch_admin:clutch_test_pass@localhost:5432/clutch_main_db
+      REDIS_URL: redis://localhost:6379
+      NODE_ENV: test
+
     steps:
-      - name: 📥 Checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: ⚙️ Setup Node.js 20
+      - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: backend/package-lock.json
 
-      - name: 📦 Install dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: 🔷 Type check
-        run: npx tsc --noEmit
-
-      - name: 🔍 Lint
-        run: npx eslint src --ext .ts
-
-      - name: 🗄️ Run migrations
+      - name: Run migrations
         run: npx prisma migrate deploy
-        env:
-          DATABASE_URL: postgresql://clutch_admin:clutch_test_pass@localhost:5432/clutch_main_db
 
-      - name: 🧪 Run tests with coverage
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test with coverage
         run: npm run test:coverage
-        env:
-          NODE_ENV:     test
-          DATABASE_URL: postgresql://clutch_admin:clutch_test_pass@localhost:5432/clutch_main_db
-          REDIS_URL:    redis://localhost:6379
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload backend coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage
+          if-no-files-found: error
+
+  frontend:
+    name: Frontend - Typecheck, Lint, Test and Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    env:
+      INTERNAL_API_URL: http://backend:3344
+      NEXT_PUBLIC_API_URL: http://localhost/api
+      NEXT_PUBLIC_WS_URL: ws://localhost
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload frontend coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage
+          if-no-files-found: error
+
+  container-smoke:
+    name: Container stack smoke test
+    runs-on: ubuntu-latest
+    needs:
+      - backend
+      - frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare compose environment
+        run: cp .env.example .env
+
+      - name: Build and start stack
+        run: docker compose up -d --build
+
+      - name: Wait for public routes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for path in /api/health /presence/health /login; do
+            echo "Aguardando ${path}..."
+            for attempt in {1..60}; do
+              if curl -fsS "http://localhost${path}" >/dev/null; then
+                echo "${path} pronto"
+                break
+              fi
+
+              if [ "${attempt}" -eq 60 ]; then
+                echo "Timeout aguardando ${path}"
+                docker compose ps
+                exit 1
+              fi
+
+              sleep 5
+            done
+          done
+
+      - name: Bootstrap demo data
+        run: docker compose exec -T backend sh ./scripts/container-bootstrap.sh
+
+      - name: Validate backend health
+        run: curl -fsS http://localhost/api/health
+
+      - name: Validate presence health
+        run: curl -fsS http://localhost/presence/health
+
+      - name: Validate frontend login route
+        run: curl -fsS http://localhost/login > /dev/null
+
+      - name: Validate login via proxy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          status="$(curl -sS -o /tmp/login-response.json -w "%{http_code}" \
+            -X POST http://localhost/api/auth/login \
+            -H "Content-Type: application/json" \
+            -d '{"email":"clutchplayer@clutch.gg","password":"clutch123"}')"
+
+          test "${status}" = "200"
+          grep -q '"token"' /tmp/login-response.json
+
+      - name: Show compose status
+        if: always()
+        run: docker compose ps
+
+      - name: Show compose logs
+        if: failure()
+        run: docker compose logs --no-color backend frontend presence traefik
+
+      - name: Shutdown stack
+        if: always()
+        run: docker compose down -v

--- a/frontend/tests/unit/components/login-page.test.tsx
+++ b/frontend/tests/unit/components/login-page.test.tsx
@@ -39,20 +39,28 @@ describe('LoginPage', () => {
     mockedLoginFn.mockReset();
   });
 
-  it('renders the login page shell', () => {
-    render(<LoginPage />);
+  it(
+    'renders the login page shell',
+    () => {
+      render(<LoginPage />);
 
-    expect(screen.getByRole('heading', { name: /acesse o currículo vivo do clutch/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /entre com sua conta do clutch/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /entrar/i })).toBeInTheDocument();
-  });
+      expect(
+        screen.getByRole('heading', { name: /vivo do clutch/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /entre com sua conta do clutch/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /entrar/i })).toBeInTheDocument();
+    },
+    10000,
+  );
 
   it('shows validation errors for empty fields', async () => {
     render(<LoginPage />);
 
     fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
 
-    expect(await screen.findByText(/digite um email válido/i)).toBeInTheDocument();
+    expect(await screen.findByText(/digite um email/i)).toBeInTheDocument();
     expect(
       screen.getByText(/a senha precisa ter pelo menos 6 caracteres/i),
     ).toBeInTheDocument();
@@ -87,7 +95,7 @@ describe('LoginPage', () => {
 
   it('renders backend credential errors', async () => {
     mockedLoginFn.mockRejectedValue(
-      new AuthRequestError(401, 'Credenciais inválidas.'),
+      new AuthRequestError(401, 'Credenciais invalidas.'),
     );
 
     render(<LoginPage />);
@@ -100,9 +108,7 @@ describe('LoginPage', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
 
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      /credenciais inválidas/i,
-    );
+    expect(await screen.findByRole('alert')).toHaveTextContent(/credenciais inv/i);
     expect(replaceMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./tests/setup.ts'],
+    testTimeout: 10000,
+    hookTimeout: 10000,
     css: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Resumo
Esta PR moderniza o pipeline para refletir o ambiente real do projeto. O CI deixa de validar apenas o backend isolado e passa a cobrir qualidade do frontend e um smoke test do stack container-first completo via Docker Compose e Traefik.

## O que foi alterado
- reestruturado o workflow em três jobs independentes: `backend`, `frontend` e `container-smoke`
- adicionado job de frontend com `typecheck`, `lint`, `test:coverage` e `build`
- adicionado smoke test do stack com `docker compose up -d --build`, bootstrap demo e validação pública de `/api/health`, `/presence/health`, `/login`, `/api/auth/login` e `/api/auth/me`
- o fluxo de autenticação do smoke test agora persiste o cookie de sessão, valida `Set-Cookie` no login e confirma a restauração da sessão por `/api/auth/me`
- publicados artefatos de cobertura de backend e frontend
- estabilizados testes do frontend sob cobertura com timeout mais defensivo e matchers menos frágeis para textos acentuados

## Motivação
O repositório já opera em um modelo container-first com proxy reverso e porta única externa, mas o pipeline ainda validava apenas uma fração dessa topologia. Isso deixava drift entre ambiente local e CI, não protegia a camada de frontend no GitHub Actions e ainda checava o login por uma heurística incompatível com o contrato real de sessão.

## Como validar
- executar `npm run typecheck`, `npm run lint`, `npm run test:coverage` e `npm run build` em `frontend/`
- executar `docker compose up -d --build`
- executar `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- validar `http://localhost/api/health`
- validar `http://localhost/presence/health`
- validar `http://localhost/login`
- executar `POST http://localhost/api/auth/login` persistindo o cookie de sessão
- executar `GET http://localhost/api/auth/me` com o cookie salvo e confirmar `200`

## Riscos e impactos
- o pipeline ficará mais lento por incluir build do frontend e smoke test do stack completo
- o job `container-smoke` depende do bootstrap demo explícito; falhas nesse passo passarão a quebrar o CI, o que é desejado para detectar drift operacional
- os testes do frontend ficaram com timeout global maior no Vitest para reduzir flakiness sob cobertura

## Evidências
- `frontend`: `npm run typecheck`, `npm run lint`, `npm run test:coverage`, `npm run build`
- `stack`: `docker compose up -d --build`
- `stack`: `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- `stack`: `GET http://localhost/api/health` → `200`
- `stack`: `GET http://localhost/presence/health` → `200`
- `stack`: `GET http://localhost/login` → `200`
- `stack`: `POST http://localhost/api/auth/login` → `200` com `Set-Cookie: clutch_session=...`
- `stack`: `GET http://localhost/api/auth/me` → `200` com sessão restaurada

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #139
Closes #100