### PR TITLE
test(realtime): valida handshake websocket autenticado no stack containerizado

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js 24 for websocket smoke helper
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Prepare compose environment
         run: cp .env.example .env
 
@@ -232,6 +237,34 @@ jobs:
           fi
 
           grep -q '"username":"clutchplayer"' /tmp/auth-me-response.json
+
+      - name: Validate presence credential route
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          presence_status="$(curl -sS \
+            -b /tmp/clutch-session.cookies \
+            -o /tmp/presence-token-response.json \
+            -w "%{http_code}" \
+            http://localhost/api/auth/presence-token)"
+
+          if [ "${presence_status}" != "200" ]; then
+            echo "Falha ao obter a credencial de presence. Status: ${presence_status}"
+            echo "--- presence token body ---"
+            cat /tmp/presence-token-response.json
+            exit 1
+          fi
+
+          grep -q '"token":"' /tmp/presence-token-response.json
+
+      - name: Validate authenticated websocket handshake
+        env:
+          PRESENCE_TOKEN_FILE: /tmp/presence-token-response.json
+          PRESENCE_WS_URL: ws://localhost
+          PRESENCE_WS_ORIGIN: http://localhost
+          PRESENCE_WS_TIMEOUT_MS: 15000
+        run: node ./scripts/ci/validate-presence-handshake.mjs
 
       - name: Show compose status
         if: always()

--- a/scripts/ci/validate-presence-handshake.mjs
+++ b/scripts/ci/validate-presence-handshake.mjs
@@ -1,0 +1,133 @@
+import { readFile } from 'node:fs/promises';
+
+const tokenFile = process.env.PRESENCE_TOKEN_FILE;
+const wsUrl = process.env.PRESENCE_WS_URL;
+const wsOrigin = process.env.PRESENCE_WS_ORIGIN ?? 'http://localhost';
+const timeoutMs = Number(process.env.PRESENCE_WS_TIMEOUT_MS ?? '15000');
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function readPresenceToken() {
+  if (!tokenFile) {
+    fail('PRESENCE_TOKEN_FILE nao foi definido.');
+  }
+
+  const raw = await readFile(tokenFile, 'utf8');
+  let parsed;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    fail('Nao foi possivel interpretar a resposta de /api/auth/presence-token.');
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('token' in parsed) ||
+    typeof parsed.token !== 'string' ||
+    parsed.token.length === 0
+  ) {
+    fail('A resposta de /api/auth/presence-token nao contem um token valido.');
+  }
+
+  return parsed.token;
+}
+
+async function validatePresenceHandshake() {
+  if (!wsUrl || wsUrl.trim().length === 0) {
+    fail('PRESENCE_WS_URL nao foi definido.');
+  }
+
+  if (typeof WebSocket !== 'function') {
+    fail('O runtime Node atual nao expoe WebSocket global para o smoke test.');
+  }
+
+  const token = await readPresenceToken();
+  const socketUrl = new URL('/ws/presence', wsUrl);
+  socketUrl.searchParams.set('token', token);
+
+  console.log(`[presence-smoke] connecting to ${socketUrl.toString()}`);
+
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timeout aguardando handshake websocket em ${timeoutMs}ms.`));
+    }, timeoutMs);
+
+    let settled = false;
+
+    const settle = (callback) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    };
+
+    const socket = new WebSocket(socketUrl, {
+      headers: {
+        Origin: wsOrigin,
+      },
+    });
+
+    socket.addEventListener('open', () => {
+      console.log('[presence-smoke] websocket connected');
+      socket.send(
+        JSON.stringify({
+          event: 'PING',
+          payload: null,
+          ts: Date.now(),
+        }),
+      );
+    });
+
+    socket.addEventListener('message', (event) => {
+      console.log(`[presence-smoke] message: ${event.data}`);
+
+      let parsed;
+
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        settle(() => reject(new Error('Mensagem websocket invalida durante o smoke test.')));
+        return;
+      }
+
+      if (parsed?.event === 'PONG') {
+        settle(() => {
+          socket.close();
+          resolve(undefined);
+        });
+      }
+    });
+
+    socket.addEventListener('error', (event) => {
+      settle(() => reject(new Error(`Falha no websocket de presence: ${event.type}`)));
+    });
+
+    socket.addEventListener('close', (event) => {
+      if (!settled) {
+        settle(() =>
+          reject(
+            new Error(
+              `Conexao websocket encerrada antes do PONG. code=${event.code} reason=${event.reason || 'n/a'}`,
+            ),
+          ),
+        );
+      } else {
+        console.log(
+          `[presence-smoke] websocket closed after success. code=${event.code} reason=${event.reason || 'n/a'}`,
+        );
+      }
+    });
+  });
+}
+
+validatePresenceHandshake().catch((error) => {
+  console.error('[presence-smoke] validation failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Resumo
Esta PR adiciona validação operacional do handshake websocket autenticado no stack containerizado real. O smoke test do CI agora cobre a cadeia completa de presence: sessão por cookie, credencial oficial via frontend e conexão websocket pelo proxy com tráfego mínimo `PING`/`PONG`.

## O que foi alterado
- estendido o job `container-smoke` em `.github/workflows/ci.yml` para validar `/api/auth/presence-token` com a sessão restaurada
- adicionado um helper dedicado em `scripts/ci/validate-presence-handshake.mjs` para abrir o websocket autenticado no endpoint público `/ws/presence`
- o helper envia `PING`, espera `PONG` e falha com mensagens diagnósticas quando token, proxy, origin ou handshake quebram
- adicionado `setup-node` no job de smoke para executar o helper websocket com runtime compatível

## Motivação
O projeto já validava health, login e sessão HTTP no ambiente container-first, mas ainda não havia proteção contra regressões no fluxo realtime autenticado. Isso deixava uma lacuna real entre o contrato implementado no frontend/backend e o que o CI garantia.

## Como validar
- executar `docker compose up -d --build`
- executar `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- autenticar a sessão via `POST http://localhost/api/auth/login`
- restaurar a sessão via `GET http://localhost/api/auth/me`
- obter a credencial oficial de presence via `GET http://localhost/api/auth/presence-token`
- executar `node ./scripts/ci/validate-presence-handshake.mjs` com:
  - `PRESENCE_TOKEN_FILE`
  - `PRESENCE_WS_URL=ws://localhost`
  - `PRESENCE_WS_ORIGIN=http://localhost`
- confirmar que o helper conecta em `/ws/presence`, envia `PING` e recebe `PONG`

## Riscos e impactos
- o job `container-smoke` ficará um pouco mais lento por incluir a validação websocket
- o helper depende de runtime Node com `WebSocket` global; por isso o job agora fixa `setup-node` para esse passo
- o teste cobre o cenário positivo do handshake autenticado; cenários negativos continuam fora do escopo para evitar flakiness desnecessária neste momento

## Evidências
- `docker compose up -d`
- `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- `POST http://localhost/api/auth/login` com sessão por cookie → `200`
- `GET http://localhost/api/auth/presence-token` → `200`
- `node ./scripts/ci/validate-presence-handshake.mjs` → conexão estabelecida e `PONG` recebido

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #144