### PR TITLE
feat(observability): padroniza logs estruturados entre backend, frontend e presence

### DIFF
--- a/backend/presence-service/hub.go
+++ b/backend/presence-service/hub.go
@@ -3,17 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"log"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
-
-// ─────────────────────────────────────────────────────────────
-// Hub — gerencia todas as conexões WebSocket ativas
-// ─────────────────────────────────────────────────────────────
 
 type WsEvent string
 
@@ -52,7 +47,7 @@ const (
 
 type Hub struct {
 	mu          sync.RWMutex
-	clients     map[string]*Client // userId → Client
+	clients     map[string]*Client
 	register    chan *Client
 	unregister  chan *Client
 	redisClient *redis.Client
@@ -71,7 +66,7 @@ func (h *Hub) Run(ctx context.Context) {
 	pubsub := h.redisClient.PSubscribe(ctx, presenceChannelPrefix+"*", notificationsChannelPrefix+"*")
 	defer func() {
 		if err := pubsub.Close(); err != nil {
-			log.Printf("error closing pubsub: %v", err)
+			writePresenceLog("error", "redis_pubsub_close_failed", "Failed to close Redis pubsub", errorFields(err))
 		}
 	}()
 
@@ -86,7 +81,11 @@ func (h *Hub) Run(ctx context.Context) {
 			h.mu.Lock()
 			h.clients[client.userId] = client
 			h.mu.Unlock()
-			log.Printf("client registered: %s (total: %d)", client.userId, h.Count())
+			writePresenceLog("info", "websocket_client_registered", "WebSocket client registered", map[string]interface{}{
+				"userId":       client.userId,
+				"connectionId": client.connectionId,
+				"connections":  h.Count(),
+			})
 
 		case client := <-h.unregister:
 			h.mu.Lock()
@@ -95,7 +94,11 @@ func (h *Hub) Run(ctx context.Context) {
 				close(client.send)
 			}
 			h.mu.Unlock()
-			log.Printf("client unregistered: %s (total: %d)", client.userId, h.Count())
+			writePresenceLog("info", "websocket_client_unregistered", "WebSocket client unregistered", map[string]interface{}{
+				"userId":       client.userId,
+				"connectionId": client.connectionId,
+				"connections":  h.Count(),
+			})
 
 		case msg := <-redisCh:
 			h.routeRealtimeMessage(msg.Channel, msg.Payload)
@@ -110,31 +113,42 @@ func (h *Hub) routeRealtimeMessage(channel string, payload string) {
 	case strings.HasPrefix(channel, notificationsChannelPrefix):
 		h.deliverNotification(channel, payload)
 	default:
-		log.Printf("unsupported realtime channel: %s", channel)
+		writePresenceLog("warn", "redis_channel_unsupported", "Unsupported realtime channel received", map[string]interface{}{
+			"channel": channel,
+		})
 	}
 }
 
 func (h *Hub) deliverPresenceUpdate(channel string, payload string) {
 	recipientID, ok := channelRecipientID(channel, presenceChannelPrefix)
 	if !ok {
-		log.Printf("invalid presence channel: %s", channel)
+		writePresenceLog("warn", "presence_channel_invalid", "Invalid presence channel received", map[string]interface{}{
+			"channel": channel,
+		})
 		return
 	}
 
 	var message WsMessage
 	if err := json.Unmarshal([]byte(payload), &message); err != nil {
-		log.Printf("error parsing presence update: %v", err)
+		fields := errorFields(err)
+		fields["channel"] = channel
+		writePresenceLog("error", "presence_payload_parse_failed", "Failed to parse presence update payload", fields)
 		return
 	}
 
 	if message.Event != EventFriendPresence {
-		log.Printf("unexpected presence event: %s", message.Event)
+		writePresenceLog("warn", "presence_event_unexpected", "Unexpected presence event received", map[string]interface{}{
+			"channel": channel,
+			"event":   string(message.Event),
+		})
 		return
 	}
 
 	data, err := json.Marshal(message)
 	if err != nil {
-		log.Printf("error marshaling presence message: %v", err)
+		fields := errorFields(err)
+		fields["channel"] = channel
+		writePresenceLog("error", "presence_payload_marshal_failed", "Failed to marshal presence message", fields)
 		return
 	}
 
@@ -144,13 +158,17 @@ func (h *Hub) deliverPresenceUpdate(channel string, payload string) {
 func (h *Hub) deliverNotification(channel string, payload string) {
 	recipientID, ok := channelRecipientID(channel, notificationsChannelPrefix)
 	if !ok {
-		log.Printf("invalid notification channel: %s", channel)
+		writePresenceLog("warn", "notification_channel_invalid", "Invalid notification channel received", map[string]interface{}{
+			"channel": channel,
+		})
 		return
 	}
 
 	var notification NotificationPayload
 	if err := json.Unmarshal([]byte(payload), &notification); err != nil {
-		log.Printf("error parsing notification payload: %v", err)
+		fields := errorFields(err)
+		fields["channel"] = channel
+		writePresenceLog("error", "notification_payload_parse_failed", "Failed to parse notification payload", fields)
 		return
 	}
 
@@ -162,7 +180,9 @@ func (h *Hub) deliverNotification(channel string, payload string) {
 
 	data, err := json.Marshal(message)
 	if err != nil {
-		log.Printf("error marshaling notification message: %v", err)
+		fields := errorFields(err)
+		fields["channel"] = channel
+		writePresenceLog("error", "notification_payload_marshal_failed", "Failed to marshal notification message", fields)
 		return
 	}
 
@@ -199,6 +219,10 @@ func (h *Hub) sendToUser(userID string, data []byte) {
 			delete(h.clients, userID)
 		}
 		h.mu.Unlock()
+		writePresenceLog("warn", "websocket_client_dropped", "Dropped slow websocket client", map[string]interface{}{
+			"userId":       userID,
+			"connectionId": client.connectionId,
+		})
 	}
 }
 

--- a/backend/presence-service/logging.go
+++ b/backend/presence-service/logging.go
@@ -2,13 +2,25 @@ package main
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 )
 
 const presenceServiceName = "presence"
 
 type logEntry map[string]interface{}
+
+type sanitizedConnectionTarget struct {
+	Scheme      string
+	Host        string
+	Port        string
+	RedactedURL string
+}
+
+var sensitiveURLPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9+.-]*://[^\s"'<>]+`)
 
 func newPresenceLogEntry(level string, event string, message string, fields map[string]interface{}) logEntry {
 	entry := logEntry{
@@ -60,6 +72,129 @@ func errorFields(err error) map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"error": err.Error(),
+		"error": sanitizeSensitiveText(err.Error()),
 	}
+}
+
+func sanitizeConnectionURL(rawURL string) sanitizedConnectionTarget {
+	trimmedURL := strings.TrimSpace(rawURL)
+	if trimmedURL == "" {
+		return sanitizedConnectionTarget{}
+	}
+
+	parsedURL, err := url.Parse(trimmedURL)
+	if err != nil {
+		return sanitizedConnectionTarget{
+			RedactedURL: redactConnectionURLFallback(trimmedURL),
+		}
+	}
+
+	redactedURL := parsedURL.String()
+	if parsedURL.User != nil {
+		username := parsedURL.User.Username()
+		if _, hasPassword := parsedURL.User.Password(); hasPassword {
+			redactedURL = buildRedactedURL(parsedURL, username)
+		}
+	}
+
+	return sanitizedConnectionTarget{
+		Scheme:      parsedURL.Scheme,
+		Host:        parsedURL.Hostname(),
+		Port:        parsedURL.Port(),
+		RedactedURL: redactedURL,
+	}
+}
+
+func buildRedactedURL(parsedURL *url.URL, username string) string {
+	var builder strings.Builder
+
+	if parsedURL.Scheme != "" {
+		builder.WriteString(parsedURL.Scheme)
+		builder.WriteString("://")
+	}
+
+	if username != "" {
+		builder.WriteString(username)
+	}
+	builder.WriteString(":***@")
+	builder.WriteString(parsedURL.Host)
+
+	if parsedURL.RawPath != "" {
+		builder.WriteString(parsedURL.RawPath)
+	} else {
+		builder.WriteString(parsedURL.EscapedPath())
+	}
+
+	if parsedURL.RawQuery != "" {
+		builder.WriteString("?")
+		builder.WriteString(parsedURL.RawQuery)
+	}
+
+	if parsedURL.Fragment != "" {
+		builder.WriteString("#")
+		builder.WriteString(parsedURL.Fragment)
+	}
+
+	return builder.String()
+}
+
+func redactConnectionURLFallback(rawURL string) string {
+	schemeSeparatorIndex := strings.Index(rawURL, "://")
+	if schemeSeparatorIndex < 0 {
+		return rawURL
+	}
+
+	scheme := rawURL[:schemeSeparatorIndex+3]
+	remainder := rawURL[schemeSeparatorIndex+3:]
+	atIndex := strings.LastIndex(remainder, "@")
+	if atIndex < 0 {
+		return rawURL
+	}
+
+	userInfo := remainder[:atIndex]
+	hostAndPath := remainder[atIndex+1:]
+
+	colonIndex := strings.Index(userInfo, ":")
+	if colonIndex < 0 {
+		return rawURL
+	}
+
+	username := userInfo[:colonIndex]
+	return scheme + username + ":***@" + hostAndPath
+}
+
+func connectionLogFields(prefix string, rawURL string, status string) map[string]interface{} {
+	fields := map[string]interface{}{
+		"status": status,
+	}
+
+	target := sanitizeConnectionURL(rawURL)
+	if target.Scheme != "" {
+		fields[prefix+"Scheme"] = target.Scheme
+	}
+	if target.Host != "" {
+		fields[prefix+"Host"] = target.Host
+	}
+	if target.Port != "" {
+		fields[prefix+"Port"] = target.Port
+	}
+	if target.RedactedURL != "" && target.Host == "" {
+		fields[prefix+"UrlRedacted"] = target.RedactedURL
+	}
+
+	return fields
+}
+
+func sanitizeSensitiveText(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return value
+	}
+
+	return sensitiveURLPattern.ReplaceAllStringFunc(value, func(match string) string {
+		target := sanitizeConnectionURL(match)
+		if target.RedactedURL == "" {
+			return match
+		}
+		return target.RedactedURL
+	})
 }

--- a/backend/presence-service/logging.go
+++ b/backend/presence-service/logging.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+const presenceServiceName = "presence"
+
+type logEntry map[string]interface{}
+
+func newPresenceLogEntry(level string, event string, message string, fields map[string]interface{}) logEntry {
+	entry := logEntry{
+		"level":     level,
+		"service":   presenceServiceName,
+		"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+		"event":     event,
+		"message":   message,
+	}
+
+	for key, value := range fields {
+		if value == nil {
+			continue
+		}
+		entry[key] = value
+	}
+
+	return entry
+}
+
+func writePresenceLog(level string, event string, message string, fields map[string]interface{}) {
+	entry := newPresenceLogEntry(level, event, message, fields)
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		fallback, _ := json.Marshal(logEntry{
+			"level":       "error",
+			"service":     presenceServiceName,
+			"timestamp":   time.Now().UTC().Format(time.RFC3339Nano),
+			"event":       "log_encoding_failed",
+			"message":     "Failed to encode structured log entry",
+			"error":       err.Error(),
+			"failedEvent": event,
+		})
+		_, _ = os.Stderr.Write(append(fallback, '\n'))
+		return
+	}
+
+	target := os.Stdout
+	if level == "error" {
+		target = os.Stderr
+	}
+
+	_, _ = target.Write(append(encoded, '\n'))
+}
+
+func errorFields(err error) map[string]interface{} {
+	if err == nil {
+		return map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"error": err.Error(),
+	}
+}

--- a/backend/presence-service/logging_test.go
+++ b/backend/presence-service/logging_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestNewPresenceLogEntryIncludesRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	entry := newPresenceLogEntry("info", "websocket_connected", "WebSocket connection opened", map[string]interface{}{
+		"userId":       "user-123",
+		"connectionId": "conn-123",
+	})
+
+	if entry["level"] != "info" {
+		t.Fatalf("expected level info, got %v", entry["level"])
+	}
+	if entry["service"] != presenceServiceName {
+		t.Fatalf("expected service %q, got %v", presenceServiceName, entry["service"])
+	}
+	if entry["event"] != "websocket_connected" {
+		t.Fatalf("expected event websocket_connected, got %v", entry["event"])
+	}
+	if entry["message"] != "WebSocket connection opened" {
+		t.Fatalf("expected message to be preserved, got %v", entry["message"])
+	}
+	if entry["userId"] != "user-123" {
+		t.Fatalf("expected userId field, got %v", entry["userId"])
+	}
+	if _, ok := entry["timestamp"].(string); !ok {
+		t.Fatalf("expected timestamp string, got %T", entry["timestamp"])
+	}
+}

--- a/backend/presence-service/logging_test.go
+++ b/backend/presence-service/logging_test.go
@@ -29,3 +29,130 @@ func TestNewPresenceLogEntryIncludesRequiredFields(t *testing.T) {
 		t.Fatalf("expected timestamp string, got %T", entry["timestamp"])
 	}
 }
+
+func TestSanitizeConnectionURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		rawURL         string
+		wantRedacted   string
+		wantScheme     string
+		wantHost       string
+		wantPort       string
+	}{
+		{
+			name:         "masks password while preserving host and port",
+			rawURL:       "redis://default:super-secret@redis.internal:6379/0",
+			wantRedacted: "redis://default:***@redis.internal:6379/0",
+			wantScheme:   "redis",
+			wantHost:     "redis.internal",
+			wantPort:     "6379",
+		},
+		{
+			name:         "preserves url without password",
+			rawURL:       "redis://redis.internal:6379/0",
+			wantRedacted: "redis://redis.internal:6379/0",
+			wantScheme:   "redis",
+			wantHost:     "redis.internal",
+			wantPort:     "6379",
+		},
+		{
+			name:         "redacts invalid url without panicking",
+			rawURL:       "redis://default:super-secret@%zz:6379",
+			wantRedacted: "redis://default:***@%zz:6379",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := sanitizeConnectionURL(tt.rawURL)
+
+			if target.RedactedURL != tt.wantRedacted {
+				t.Fatalf("expected redacted url %q, got %q", tt.wantRedacted, target.RedactedURL)
+			}
+			if target.Scheme != tt.wantScheme {
+				t.Fatalf("expected scheme %q, got %q", tt.wantScheme, target.Scheme)
+			}
+			if target.Host != tt.wantHost {
+				t.Fatalf("expected host %q, got %q", tt.wantHost, target.Host)
+			}
+			if target.Port != tt.wantPort {
+				t.Fatalf("expected port %q, got %q", tt.wantPort, target.Port)
+			}
+		})
+	}
+}
+
+func TestConnectionLogFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses host and port for valid urls", func(t *testing.T) {
+		t.Parallel()
+
+		fields := connectionLogFields("redis", "redis://default:super-secret@redis.internal:6379/0", "connected")
+
+		if fields["status"] != "connected" {
+			t.Fatalf("expected status connected, got %v", fields["status"])
+		}
+		if fields["redisHost"] != "redis.internal" {
+			t.Fatalf("expected redisHost redis.internal, got %v", fields["redisHost"])
+		}
+		if fields["redisPort"] != "6379" {
+			t.Fatalf("expected redisPort 6379, got %v", fields["redisPort"])
+		}
+		if _, ok := fields["redisUrl"]; ok {
+			t.Fatalf("did not expect redisUrl for valid connection target")
+		}
+		if _, ok := fields["redisUrlRedacted"]; ok {
+			t.Fatalf("did not expect redisUrlRedacted for valid connection target")
+		}
+	})
+
+	t.Run("falls back to redacted url for invalid urls", func(t *testing.T) {
+		t.Parallel()
+
+		fields := connectionLogFields("redis", "redis://default:super-secret@%zz:6379", "parse_failed")
+
+		if fields["status"] != "parse_failed" {
+			t.Fatalf("expected status parse_failed, got %v", fields["status"])
+		}
+		if fields["redisUrlRedacted"] != "redis://default:***@%zz:6379" {
+			t.Fatalf("expected redisUrlRedacted to be masked, got %v", fields["redisUrlRedacted"])
+		}
+		if _, ok := fields["redisHost"]; ok {
+			t.Fatalf("did not expect redisHost for invalid connection target")
+		}
+		if _, ok := fields["redisPort"]; ok {
+			t.Fatalf("did not expect redisPort for invalid connection target")
+		}
+	})
+}
+
+func TestSanitizeSensitiveText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("redacts credentials inside error messages", func(t *testing.T) {
+		t.Parallel()
+
+		sanitized := sanitizeSensitiveText(`parse "redis://default:super-secret@%zz:6379": invalid URL escape "%zz"`)
+
+		if sanitized != `parse "redis://default:***@%zz:6379": invalid URL escape "%zz"` {
+			t.Fatalf("expected sanitized error string, got %q", sanitized)
+		}
+	})
+
+	t.Run("preserves urls without passwords", func(t *testing.T) {
+		t.Parallel()
+
+		sanitized := sanitizeSensitiveText(`connected to redis://redis.internal:6379/0`)
+
+		if sanitized != `connected to redis://redis.internal:6379/0` {
+			t.Fatalf("expected url without password to stay unchanged, got %q", sanitized)
+		}
+	})
+}

--- a/backend/presence-service/main.go
+++ b/backend/presence-service/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -34,6 +36,7 @@ var (
 		"http://localhost:3001",
 		"http://127.0.0.1:3001",
 	}
+	connectionCounter atomic.Uint64
 )
 
 type presenceConfig struct {
@@ -48,10 +51,29 @@ type presenceClaims struct {
 }
 
 type Client struct {
-	hub    *Hub
-	conn   *websocket.Conn
-	send   chan []byte
-	userId string
+	hub          *Hub
+	conn         *websocket.Conn
+	send         chan []byte
+	userId       string
+	connectionId string
+}
+
+func newConnectionID() string {
+	return fmt.Sprintf("conn-%d-%d", time.Now().UnixMilli(), connectionCounter.Add(1))
+}
+
+func isIgnorableWebsocketCloseError(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+
+	message := err.Error()
+	return strings.Contains(message, "websocket: close sent") ||
+		strings.Contains(message, "use of closed network connection")
 }
 
 func loadPresenceConfig() presenceConfig {
@@ -159,29 +181,56 @@ func newPresenceHandler(hub *Hub, cfg presenceConfig) http.HandlerFunc {
 	wsUpgrader := newUpgrader(cfg)
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !isOriginAllowed(r.Header.Get("Origin"), cfg.allowedOrigins) {
+		origin := r.Header.Get("Origin")
+
+		if !isOriginAllowed(origin, cfg.allowedOrigins) {
+			writePresenceLog("warn", "websocket_origin_rejected", "WebSocket origin rejected", map[string]interface{}{
+				"origin":     origin,
+				"remoteAddr": r.RemoteAddr,
+			})
 			http.Error(w, errDisallowedOrigin.Error(), http.StatusForbidden)
 			return
 		}
 
 		userID, err := authenticateRequest(r, cfg)
 		if err != nil {
+			fields := errorFields(err)
+			fields["origin"] = origin
+			fields["remoteAddr"] = r.RemoteAddr
+			writePresenceLog("warn", "websocket_handshake_rejected", "WebSocket handshake rejected", fields)
 			http.Error(w, "unauthorized websocket connection", http.StatusUnauthorized)
 			return
 		}
 
+		writePresenceLog("info", "websocket_handshake_authenticated", "WebSocket handshake authenticated", map[string]interface{}{
+			"userId":     userID,
+			"origin":     origin,
+			"remoteAddr": r.RemoteAddr,
+		})
+
 		conn, err := wsUpgrader.Upgrade(w, r, nil)
 		if err != nil {
-			log.Printf("websocket upgrade error: %v", err)
+			fields := errorFields(err)
+			fields["userId"] = userID
+			fields["origin"] = origin
+			writePresenceLog("error", "websocket_upgrade_failed", "WebSocket upgrade failed", fields)
 			return
 		}
 
 		client := &Client{
-			hub:    hub,
-			conn:   conn,
-			send:   make(chan []byte, 256),
-			userId: userID,
+			hub:          hub,
+			conn:         conn,
+			send:         make(chan []byte, 256),
+			userId:       userID,
+			connectionId: newConnectionID(),
 		}
+
+		writePresenceLog("info", "websocket_connection_opened", "WebSocket connection opened", map[string]interface{}{
+			"userId":       userID,
+			"connectionId": client.connectionId,
+			"origin":       origin,
+			"remoteAddr":   r.RemoteAddr,
+		})
 
 		hub.register <- client
 
@@ -194,36 +243,68 @@ func (c *Client) readPump() {
 	defer func() {
 		c.hub.unregister <- c
 		if err := c.conn.Close(); err != nil {
-			log.Printf("error closing connection: %v", err)
+			if !isIgnorableWebsocketCloseError(err) {
+				fields := errorFields(err)
+				fields["userId"] = c.userId
+				fields["connectionId"] = c.connectionId
+				writePresenceLog("error", "websocket_close_failed", "Failed to close websocket connection", fields)
+			}
 		}
+		writePresenceLog("info", "websocket_connection_closed", "WebSocket connection closed", map[string]interface{}{
+			"userId":       c.userId,
+			"connectionId": c.connectionId,
+		})
 	}()
 
 	c.conn.SetReadLimit(maxMessageSize)
 	if err := c.conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
-		log.Printf("error setting read deadline: %v", err)
+		fields := errorFields(err)
+		fields["userId"] = c.userId
+		fields["connectionId"] = c.connectionId
+		writePresenceLog("error", "websocket_read_deadline_failed", "Failed to set websocket read deadline", fields)
 		return
 	}
 	c.conn.SetPongHandler(func(string) error {
+		writePresenceLog("info", "websocket_pong_received", "WebSocket pong received", map[string]interface{}{
+			"userId":       c.userId,
+			"connectionId": c.connectionId,
+		})
 		return c.conn.SetReadDeadline(time.Now().Add(pongWait))
 	})
 
 	for {
 		_, message, err := c.conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				log.Printf("websocket error: %v", err)
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived) {
+				break
+			}
+
+			if !isIgnorableWebsocketCloseError(err) {
+				fields := errorFields(err)
+				fields["userId"] = c.userId
+				fields["connectionId"] = c.connectionId
+				writePresenceLog("error", "websocket_read_failed", "Unexpected websocket read error", fields)
 			}
 			break
 		}
 
 		var msg map[string]interface{}
 		if err := json.Unmarshal(message, &msg); err == nil && msg["event"] == "PING" {
+			writePresenceLog("info", "websocket_ping_received", "WebSocket ping received", map[string]interface{}{
+				"userId":       c.userId,
+				"connectionId": c.connectionId,
+			})
+
 			pong, _ := json.Marshal(WsMessage{
 				Event:   EventPong,
 				Payload: nil,
 				Ts:      time.Now().UnixMilli(),
 			})
 			c.send <- pong
+			writePresenceLog("info", "websocket_pong_sent", "WebSocket pong sent", map[string]interface{}{
+				"userId":       c.userId,
+				"connectionId": c.connectionId,
+			})
 		}
 	}
 }
@@ -233,7 +314,12 @@ func (c *Client) writePump() {
 	defer func() {
 		ticker.Stop()
 		if err := c.conn.Close(); err != nil {
-			log.Printf("error closing connection: %v", err)
+			if !isIgnorableWebsocketCloseError(err) {
+				fields := errorFields(err)
+				fields["userId"] = c.userId
+				fields["connectionId"] = c.connectionId
+				writePresenceLog("error", "websocket_close_failed", "Failed to close websocket connection", fields)
+			}
 		}
 	}()
 
@@ -241,28 +327,50 @@ func (c *Client) writePump() {
 		select {
 		case message, ok := <-c.send:
 			if err := c.conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
-				log.Printf("error setting write deadline: %v", err)
+				fields := errorFields(err)
+				fields["userId"] = c.userId
+				fields["connectionId"] = c.connectionId
+				writePresenceLog("error", "websocket_write_deadline_failed", "Failed to set websocket write deadline", fields)
 				return
 			}
 			if !ok {
 				if err := c.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
-					log.Printf("error writing close message: %v", err)
+					if !isIgnorableWebsocketCloseError(err) {
+						fields := errorFields(err)
+						fields["userId"] = c.userId
+						fields["connectionId"] = c.connectionId
+						writePresenceLog("error", "websocket_close_message_failed", "Failed to write websocket close message", fields)
+					}
 				}
 				return
 			}
 			if err := c.conn.WriteMessage(websocket.TextMessage, message); err != nil {
-				log.Printf("error writing message: %v", err)
+				fields := errorFields(err)
+				fields["userId"] = c.userId
+				fields["connectionId"] = c.connectionId
+				writePresenceLog("error", "websocket_write_failed", "Failed to write websocket message", fields)
 				return
 			}
 
 		case <-ticker.C:
 			if err := c.conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
-				log.Printf("error setting write deadline: %v", err)
+				fields := errorFields(err)
+				fields["userId"] = c.userId
+				fields["connectionId"] = c.connectionId
+				writePresenceLog("error", "websocket_write_deadline_failed", "Failed to set websocket write deadline", fields)
 				return
 			}
 			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				fields := errorFields(err)
+				fields["userId"] = c.userId
+				fields["connectionId"] = c.connectionId
+				writePresenceLog("error", "websocket_ping_failed", "Failed to send websocket ping", fields)
 				return
 			}
+			writePresenceLog("info", "websocket_ping_sent", "WebSocket ping sent", map[string]interface{}{
+				"userId":       c.userId,
+				"connectionId": c.connectionId,
+			})
 		}
 	}
 }
@@ -278,14 +386,22 @@ func main() {
 
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
-		log.Fatalf("failed to parse Redis URL: %v", err)
+		fields := errorFields(err)
+		fields["redisUrl"] = redisURL
+		writePresenceLog("error", "redis_url_parse_failed", "Failed to parse Redis URL", fields)
+		os.Exit(1)
 	}
 
 	redisClient := redis.NewClient(opt)
 	if err := redisClient.Ping(ctx).Err(); err != nil {
-		log.Fatalf("failed to connect to Redis: %v", err)
+		fields := errorFields(err)
+		fields["redisUrl"] = redisURL
+		writePresenceLog("error", "redis_connect_failed", "Failed to connect to Redis", fields)
+		os.Exit(1)
 	}
-	log.Println("connected to Redis")
+	writePresenceLog("info", "redis_connected", "Connected to Redis", map[string]interface{}{
+		"redisUrl": redisURL,
+	})
 
 	hub := NewHub(redisClient)
 	go hub.Run(ctx)
@@ -299,7 +415,9 @@ func main() {
 			"service":     "clutch-presence",
 			"status":      "ok",
 		}); err != nil {
-			log.Printf("error encoding stats: %v", err)
+			fields := errorFields(err)
+			fields["path"] = r.URL.Path
+			writePresenceLog("error", "stats_encode_failed", "Failed to encode stats response", fields)
 		}
 	})
 
@@ -309,7 +427,9 @@ func main() {
 			"status":  "ok",
 			"service": "clutch-presence",
 		}); err != nil {
-			log.Printf("error encoding health: %v", err)
+			fields := errorFields(err)
+			fields["path"] = r.URL.Path
+			writePresenceLog("error", "health_encode_failed", "Failed to encode health response", fields)
 		}
 	})
 
@@ -318,8 +438,14 @@ func main() {
 		port = "8080"
 	}
 
-	log.Printf("CLUTCH Presence Service listening on ws://localhost:%s/ws/presence", port)
+	writePresenceLog("info", "presence_server_listening", "Presence service listening", map[string]interface{}{
+		"port": port,
+		"path": "/ws/presence",
+	})
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
-		log.Fatalf("server error: %v", err)
+		fields := errorFields(err)
+		fields["port"] = port
+		writePresenceLog("error", "presence_server_failed", "Presence service stopped unexpectedly", fields)
+		os.Exit(1)
 	}
 }

--- a/backend/presence-service/main.go
+++ b/backend/presence-service/main.go
@@ -387,7 +387,9 @@ func main() {
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
 		fields := errorFields(err)
-		fields["redisUrl"] = redisURL
+		for key, value := range connectionLogFields("redis", redisURL, "parse_failed") {
+			fields[key] = value
+		}
 		writePresenceLog("error", "redis_url_parse_failed", "Failed to parse Redis URL", fields)
 		os.Exit(1)
 	}
@@ -395,13 +397,13 @@ func main() {
 	redisClient := redis.NewClient(opt)
 	if err := redisClient.Ping(ctx).Err(); err != nil {
 		fields := errorFields(err)
-		fields["redisUrl"] = redisURL
+		for key, value := range connectionLogFields("redis", redisURL, "connect_failed") {
+			fields[key] = value
+		}
 		writePresenceLog("error", "redis_connect_failed", "Failed to connect to Redis", fields)
 		os.Exit(1)
 	}
-	writePresenceLog("info", "redis_connected", "Connected to Redis", map[string]interface{}{
-		"redisUrl": redisURL,
-	})
+	writePresenceLog("info", "redis_connected", "Connected to Redis", connectionLogFields("redis", redisURL, "connected"))
 
 	hub := NewHub(redisClient)
 	go hub.Run(ctx)

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,12 @@ import {
   runReadinessChecks,
   type ReadinessReport,
 } from './config/health';
+import {
+  createFastifyLoggerOptions,
+  logBackendError,
+  REQUEST_ID_HEADER,
+  resolveBackendRequestId,
+} from './config/logging';
 
 export type BuildAppOptions = {
   jwtSecret?: string;
@@ -20,7 +26,14 @@ export type BuildAppOptions = {
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
-  const app = Fastify({ logger: options.logger ?? true });
+  const requestStartTimes = new WeakMap<object, number>();
+
+  const app = Fastify({
+    logger: options.logger === false ? false : createFastifyLoggerOptions(),
+    disableRequestLogging: true,
+    requestIdHeader: REQUEST_ID_HEADER,
+    genReqId: (request) => resolveBackendRequestId(request.headers),
+  });
 
   await app.register(fastifyJwt, {
     secret: options.jwtSecret ?? process.env['JWT_SECRET'] ?? 'clutch-dev-secret-change-in-production',
@@ -29,6 +42,53 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   app.decorate('authenticate', authenticate);
 
   const readinessCheck = options.readinessCheck ?? runReadinessChecks;
+
+  app.addHook('onRequest', async (request) => {
+    requestStartTimes.set(request, Date.now());
+    request.log.info(
+      {
+        event: 'http_request_start',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+      },
+      'HTTP request started',
+    );
+  });
+
+  app.addHook('onResponse', async (request, reply) => {
+    const startedAt = requestStartTimes.get(request) ?? Date.now();
+
+    request.log.info(
+      {
+        event: 'http_request_complete',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: reply.statusCode,
+        duration_ms: Math.max(Date.now() - startedAt, 0),
+      },
+      'HTTP request completed',
+    );
+  });
+
+  app.addHook('onError', async (request, reply, error) => {
+    const startedAt = requestStartTimes.get(request) ?? Date.now();
+
+    logBackendError(
+      request.log,
+      'http_request_error',
+      'HTTP request failed',
+      error,
+      {
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: reply.statusCode >= 400 ? reply.statusCode : 500,
+        duration_ms: Math.max(Date.now() - startedAt, 0),
+      },
+    );
+  });
 
   app.get('/health', async () => ({
     status: 'ok',

--- a/backend/src/config/logging.ts
+++ b/backend/src/config/logging.ts
@@ -4,10 +4,18 @@ import type { FastifyBaseLogger, FastifyServerOptions } from 'fastify';
 
 export const BACKEND_SERVICE_NAME = 'backend';
 export const REQUEST_ID_HEADER = 'x-request-id';
+const SENSITIVE_URL_PATTERN = /[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'<>]+/g;
 
 type RuntimeLogLevel = 'info' | 'warn' | 'error';
 
 type RuntimeLogContext = Record<string, unknown>;
+
+type SanitizedConnectionTarget = {
+  scheme: string;
+  host: string;
+  port: string;
+  redactedUrl: string;
+};
 
 type RuntimeLogEntry = RuntimeLogContext & {
   level: RuntimeLogLevel;
@@ -82,17 +90,83 @@ export function createFastifyLoggerOptions(): FastifyServerOptions['logger'] {
   } satisfies FastifyServerOptions['logger'];
 }
 
+function redactConnectionUrlFallback(rawUrl: string): string {
+  const schemeSeparatorIndex = rawUrl.indexOf('://');
+  if (schemeSeparatorIndex < 0) {
+    return rawUrl;
+  }
+
+  const scheme = rawUrl.slice(0, schemeSeparatorIndex + 3);
+  const remainder = rawUrl.slice(schemeSeparatorIndex + 3);
+  const atIndex = remainder.lastIndexOf('@');
+  if (atIndex < 0) {
+    return rawUrl;
+  }
+
+  const userInfo = remainder.slice(0, atIndex);
+  const hostAndPath = remainder.slice(atIndex + 1);
+  const colonIndex = userInfo.indexOf(':');
+  if (colonIndex < 0) {
+    return rawUrl;
+  }
+
+  const username = userInfo.slice(0, colonIndex);
+  return `${scheme}${username}:***@${hostAndPath}`;
+}
+
+export function sanitizeConnectionUrl(rawUrl: string): SanitizedConnectionTarget {
+  const trimmedUrl = rawUrl.trim();
+  if (!trimmedUrl) {
+    return {
+      scheme: '',
+      host: '',
+      port: '',
+      redactedUrl: '',
+    };
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedUrl);
+    const redactedUrl =
+      parsedUrl.password.length > 0
+        ? `${parsedUrl.protocol}//${parsedUrl.username}:***@${parsedUrl.host}${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
+        : parsedUrl.toString();
+
+    return {
+      scheme: parsedUrl.protocol.replace(/:$/, ''),
+      host: parsedUrl.hostname,
+      port: parsedUrl.port,
+      redactedUrl,
+    };
+  } catch {
+    return {
+      scheme: '',
+      host: '',
+      port: '',
+      redactedUrl: redactConnectionUrlFallback(trimmedUrl),
+    };
+  }
+}
+
+export function sanitizeSensitiveText(value: string): string {
+  if (!value.trim()) {
+    return value;
+  }
+
+  return value.replace(SENSITIVE_URL_PATTERN, (match) => sanitizeConnectionUrl(match).redactedUrl || match);
+}
+
 export function serializeErrorDetails(error: unknown): RuntimeLogContext {
   if (error instanceof Error) {
     return {
       errorName: error.name,
-      errorMessage: error.message,
-      stack: error.stack,
+      errorMessage: sanitizeSensitiveText(error.message),
+      stack: error.stack ? sanitizeSensitiveText(error.stack) : undefined,
     };
   }
 
   return {
-    errorMessage: String(error),
+    errorMessage: sanitizeSensitiveText(String(error)),
   };
 }
 

--- a/backend/src/config/logging.ts
+++ b/backend/src/config/logging.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from 'node:crypto';
+import type { IncomingHttpHeaders } from 'node:http';
+import type { FastifyBaseLogger, FastifyServerOptions } from 'fastify';
+
+export const BACKEND_SERVICE_NAME = 'backend';
+export const REQUEST_ID_HEADER = 'x-request-id';
+
+type RuntimeLogLevel = 'info' | 'warn' | 'error';
+
+type RuntimeLogContext = Record<string, unknown>;
+
+type RuntimeLogEntry = RuntimeLogContext & {
+  level: RuntimeLogLevel;
+  service: typeof BACKEND_SERVICE_NAME;
+  timestamp: string;
+  event: string;
+  message: string;
+};
+
+function resolveHeaderValue(value: string | string[] | undefined): string | null {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  if (Array.isArray(value) && typeof value[0] === 'string' && value[0].trim().length > 0) {
+    return value[0].trim();
+  }
+
+  return null;
+}
+
+export function resolveBackendRequestId(headers: IncomingHttpHeaders): string {
+  return resolveHeaderValue(headers[REQUEST_ID_HEADER]) ?? randomUUID();
+}
+
+export function createBackendRuntimeLogEntry(
+  level: RuntimeLogLevel,
+  event: string,
+  message: string,
+  context: RuntimeLogContext = {},
+): RuntimeLogEntry {
+  return {
+    level,
+    service: BACKEND_SERVICE_NAME,
+    timestamp: new Date().toISOString(),
+    event,
+    message,
+    ...context,
+  };
+}
+
+export function writeBackendRuntimeLog(
+  level: RuntimeLogLevel,
+  event: string,
+  message: string,
+  context: RuntimeLogContext = {},
+): void {
+  const entry = createBackendRuntimeLogEntry(level, event, message, context);
+  const serialized = `${JSON.stringify(entry)}\n`;
+
+  if (level === 'error') {
+    process.stderr.write(serialized);
+    return;
+  }
+
+  process.stdout.write(serialized);
+}
+
+export function createFastifyLoggerOptions(): FastifyServerOptions['logger'] {
+  return {
+    level: process.env['LOG_LEVEL'] ?? 'info',
+    base: {
+      service: BACKEND_SERVICE_NAME,
+    },
+    messageKey: 'message',
+    timestamp: () => `,"timestamp":"${new Date().toISOString()}"`,
+    formatters: {
+      level(label): { level: string } {
+        return { level: label };
+      },
+    },
+  } satisfies FastifyServerOptions['logger'];
+}
+
+export function serializeErrorDetails(error: unknown): RuntimeLogContext {
+  if (error instanceof Error) {
+    return {
+      errorName: error.name,
+      errorMessage: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    errorMessage: String(error),
+  };
+}
+
+export function logBackendError(
+  logger: FastifyBaseLogger,
+  event: string,
+  message: string,
+  error: unknown,
+  context: RuntimeLogContext = {},
+): void {
+  logger.error(
+    {
+      event,
+      ...serializeErrorDetails(error),
+      ...context,
+    },
+    message,
+  );
+}

--- a/backend/src/core/services/notification.service.ts
+++ b/backend/src/core/services/notification.service.ts
@@ -1,10 +1,6 @@
-import { notificationRepository } from '../repositories/notification.repository';
 import { redis, REDIS_KEYS } from '../../infra/cache/redis';
-
-// ─────────────────────────────────────────────────────────────
-// Notification Service
-// Salva no Postgres + publica no Redis para entrega em tempo real
-// ─────────────────────────────────────────────────────────────
+import { writeBackendRuntimeLog } from '../../config/logging';
+import { notificationRepository } from '../repositories/notification.repository';
 
 export type NotificationType =
   | 'FRIEND_REQUEST'
@@ -16,38 +12,44 @@ export type NotificationType =
   | 'SYSTEM';
 
 export interface CreateNotificationInput {
-  userId:   string;
+  userId: string;
   actorId?: string | null;
-  type:     NotificationType;
-  payload:  Record<string, unknown>;
+  type: NotificationType;
+  payload: Record<string, unknown>;
 }
 
 export const notificationService = {
-
   async create(input: CreateNotificationInput): Promise<void> {
-    // ── Salva no Postgres ──────────────────────────────────
     const notification = await notificationRepository.create({
-      userId:  input.userId,
+      userId: input.userId,
       actorId: input.actorId ?? null,
-      type:    input.type,
+      type: input.type,
       payload: input.payload,
     });
 
-    // ── Publica no Redis → Go service entrega via WebSocket ─
-    await redis.publish(
-      REDIS_KEYS.notifications(input.userId),
-      JSON.stringify({
-        id:        notification.id,
-        type:      notification.type,
-        payload:   notification.payload,
-        actorId:   notification.actorId,
-        isRead:    notification.isRead,
-        createdAt: notification.createdAt,
-      }),
-    ).catch((err: unknown) => {
-      // Redis offline não deve derrubar o servidor
-      console.warn('[notifications] Redis publish failed:', err);
-    });
+    await redis
+      .publish(
+        REDIS_KEYS.notifications(input.userId),
+        JSON.stringify({
+          id: notification.id,
+          type: notification.type,
+          payload: notification.payload,
+          actorId: notification.actorId,
+          isRead: notification.isRead,
+          createdAt: notification.createdAt,
+        }),
+      )
+      .catch((err: unknown) => {
+        writeBackendRuntimeLog(
+          'warn',
+          'notification_redis_publish_failed',
+          'Redis publish failed while broadcasting notification',
+          {
+            userId: input.userId,
+            type: input.type,
+            errorMessage: err instanceof Error ? err.message : String(err),
+          },
+        );
+      });
   },
-
 };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,12 +1,18 @@
 import type { FastifyInstance } from 'fastify';
 import { buildApp } from './app';
+import {
+  createBackendRuntimeLogEntry,
+  logBackendError,
+  serializeErrorDetails,
+  writeBackendRuntimeLog,
+} from './config/logging';
 import { resolveServerPort } from './config/server-config';
 
 const port = resolveServerPort(process.env['PORT']);
 const host = '0.0.0.0';
 
 function logUnhandledError(label: string, error: unknown): void {
-  console.error(label, error);
+  writeBackendRuntimeLog('error', 'backend_runtime_error', label, serializeErrorDetails(error));
 }
 
 process.on('uncaughtException', (error) => {
@@ -21,25 +27,41 @@ const start = async (): Promise<void> => {
   let app: FastifyInstance | undefined;
 
   try {
-    // eslint-disable-next-line no-console
-    console.log('Server booting...');
-    // eslint-disable-next-line no-console
-    console.log('PORT:', process.env['PORT'] ?? port);
+    writeBackendRuntimeLog('info', 'server_boot', 'Server booting', {
+      port: process.env['PORT'] ?? port,
+      host,
+    });
 
     app = await buildApp({ logger: true });
     await app.listen({ port, host });
 
-    // eslint-disable-next-line no-console
-    console.log('ADDRESS:', app.server.address());
+    app.log.info(
+      {
+        event: 'server_listening',
+        address: app.server.address(),
+      },
+      'Backend server listening',
+    );
   } catch (err) {
     if (err instanceof Error && 'code' in err && err.code === 'EADDRINUSE') {
-      console.error(`Port ${port} is already in use. Stop the running API instance or set PORT to a different value.`);
+      writeBackendRuntimeLog(
+        'error',
+        'server_port_in_use',
+        `Port ${port} is already in use. Stop the running API instance or set PORT to a different value.`,
+        { port },
+      );
     }
 
     if (app) {
-      app.log.error(err);
+      logBackendError(app.log, 'server_startup_failed', 'Backend startup failed', err);
     } else {
-      console.error(err);
+      const entry = createBackendRuntimeLogEntry(
+        'error',
+        'server_startup_failed',
+        'Backend startup failed',
+        serializeErrorDetails(err),
+      );
+      process.stderr.write(`${JSON.stringify(entry)}\n`);
     }
 
     process.exit(1);

--- a/backend/tests/unit/config/logging.test.ts
+++ b/backend/tests/unit/config/logging.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BACKEND_SERVICE_NAME,
+  REQUEST_ID_HEADER,
+  createBackendRuntimeLogEntry,
+  createFastifyLoggerOptions,
+  resolveBackendRequestId,
+} from '@/config/logging';
+
+describe('logging config', () => {
+  it('reaproveita o request id recebido no header', () => {
+    const requestId = resolveBackendRequestId({
+      [REQUEST_ID_HEADER]: 'req-123',
+    });
+
+    expect(requestId).toBe('req-123');
+  });
+
+  it('gera um request id quando o header nao existe', () => {
+    const requestId = resolveBackendRequestId({});
+
+    expect(typeof requestId).toBe('string');
+    expect(requestId.length).toBeGreaterThan(0);
+  });
+
+  it('cria um log de runtime com campos obrigatorios', () => {
+    const entry = createBackendRuntimeLogEntry('info', 'server_boot', 'Server booting', {
+      port: 3344,
+    });
+
+    expect(entry.level).toBe('info');
+    expect(entry.service).toBe(BACKEND_SERVICE_NAME);
+    expect(entry.event).toBe('server_boot');
+    expect(entry.message).toBe('Server booting');
+    expect(entry.port).toBe(3344);
+    expect(typeof entry.timestamp).toBe('string');
+  });
+
+  it('configura o logger do fastify com service e timestamp estruturados', () => {
+    const loggerOptions = createFastifyLoggerOptions();
+
+    expect(loggerOptions).toBeTruthy();
+    expect(typeof loggerOptions).toBe('object');
+
+    if (!loggerOptions || typeof loggerOptions !== 'object') {
+      throw new Error('Logger options should be an object.');
+    }
+
+    expect(loggerOptions.base).toEqual({ service: BACKEND_SERVICE_NAME });
+    expect(loggerOptions.messageKey).toBe('message');
+    expect(typeof loggerOptions.timestamp).toBe('function');
+  });
+});

--- a/backend/tests/unit/config/logging.test.ts
+++ b/backend/tests/unit/config/logging.test.ts
@@ -5,6 +5,9 @@ import {
   createBackendRuntimeLogEntry,
   createFastifyLoggerOptions,
   resolveBackendRequestId,
+  sanitizeConnectionUrl,
+  sanitizeSensitiveText,
+  serializeErrorDetails,
 } from '@/config/logging';
 
 describe('logging config', () => {
@@ -49,5 +52,42 @@ describe('logging config', () => {
     expect(loggerOptions.base).toEqual({ service: BACKEND_SERVICE_NAME });
     expect(loggerOptions.messageKey).toBe('message');
     expect(typeof loggerOptions.timestamp).toBe('function');
+  });
+
+  it('mascara senha em url de conexao preservando host e porta', () => {
+    const target = sanitizeConnectionUrl('redis://default:super-secret@redis.internal:6379/0');
+
+    expect(target.redactedUrl).toBe('redis://default:***@redis.internal:6379/0');
+    expect(target.scheme).toBe('redis');
+    expect(target.host).toBe('redis.internal');
+    expect(target.port).toBe('6379');
+  });
+
+  it('preserva url sem senha', () => {
+    const target = sanitizeConnectionUrl('redis://redis.internal:6379/0');
+
+    expect(target.redactedUrl).toBe('redis://redis.internal:6379/0');
+    expect(target.host).toBe('redis.internal');
+    expect(target.port).toBe('6379');
+  });
+
+  it('mascara senha em url invalida sem quebrar o parse', () => {
+    const target = sanitizeConnectionUrl('redis://default:super-secret@%zz:6379');
+
+    expect(target.redactedUrl).toBe('redis://default:***@%zz:6379');
+    expect(target.host).toBe('%zz');
+    expect(target.port).toBe('6379');
+  });
+
+  it('sanitiza urls sensiveis dentro de mensagens de erro', () => {
+    const error = new Error('parse "redis://default:super-secret@%zz:6379": invalid URL escape "%zz"');
+
+    const details = serializeErrorDetails(error);
+
+    expect(sanitizeSensitiveText(error.message)).toBe(
+      'parse "redis://default:***@%zz:6379": invalid URL escape "%zz"',
+    );
+    expect(details.errorMessage).toBe('parse "redis://default:***@%zz:6379": invalid URL escape "%zz"');
+    expect(String(details.stack)).not.toContain('super-secret');
   });
 });

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+import {
+  logServerEvent,
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+  serializeServerError,
+} from '@/lib/server/logger';
 import { buildApiUrl } from '@/services/http/client';
 
 type RouteContext = {
@@ -9,12 +15,22 @@ type RouteContext = {
 };
 
 async function proxyRequest(request: NextRequest, pathSegments: string[]) {
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const startedAt = Date.now();
   const backendUrl = new URL(buildApiUrl(`/${pathSegments.join('/')}`));
   backendUrl.search = new URL(request.url).search;
+
+  logServerEvent('info', 'frontend_api_proxy_start', 'Frontend API proxy request started', {
+    requestId,
+    method: request.method,
+    path: request.nextUrl.pathname,
+    target: backendUrl.pathname,
+  });
 
   const headers = new Headers(request.headers);
   headers.delete('host');
   headers.delete('cookie');
+  headers.set(REQUEST_ID_HEADER, requestId);
 
   const sessionCookie = request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value;
 
@@ -27,11 +43,28 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
       ? undefined
       : await request.text();
 
-  const backendResponse = await fetch(backendUrl, {
-    method: request.method,
-    headers,
-    body: body && body.length > 0 ? body : undefined,
-  });
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(backendUrl, {
+      method: request.method,
+      headers,
+      body: body && body.length > 0 ? body : undefined,
+    });
+  } catch (error) {
+    logServerEvent('error', 'frontend_api_proxy_backend_unreachable', 'Frontend API proxy could not reach backend', {
+      requestId,
+      target: backendUrl.pathname,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+      ...serializeServerError(error),
+    });
+
+    return NextResponse.json(
+      { message: 'Nao foi possivel contatar o backend.' },
+      { status: 502 },
+    );
+  }
 
   const responseHeaders = new Headers(backendResponse.headers);
   const responseBody = await backendResponse.text();
@@ -47,6 +80,20 @@ async function proxyRequest(request: NextRequest, pathSegments: string[]) {
       getClearedAuthSessionCookieOptions(),
     );
   }
+
+  logServerEvent(
+    backendResponse.ok ? 'info' : 'warn',
+    'frontend_api_proxy_complete',
+    'Frontend API proxy request completed',
+    {
+      requestId,
+      method: request.method,
+      path: request.nextUrl.pathname,
+      target: backendUrl.pathname,
+      status: backendResponse.status,
+      duration_ms: Date.now() - startedAt,
+    },
+  );
 
   return response;
 }

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from 'next/server';
-import { loginBackendResponseSchema, loginRequestSchema } from '@/schemas/auth';
 import { AUTH_SESSION_COOKIE_NAME, getAuthSessionCookieOptions } from '@/lib/auth/session';
+import {
+  logServerEvent,
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+  serializeServerError,
+} from '@/lib/server/logger';
+import { loginBackendResponseSchema, loginRequestSchema } from '@/schemas/auth';
 import { buildApiUrl } from '@/services/http/client';
 
 type ErrorBody = {
@@ -34,13 +40,29 @@ function resolveMessage(payload: unknown, fallback: string): string {
 }
 
 export async function POST(request: Request) {
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const startedAt = Date.now();
+  const path = new URL(request.url).pathname;
+
+  logServerEvent('info', 'frontend_auth_login_start', 'Frontend auth login started', {
+    requestId,
+    method: request.method,
+    path,
+  });
+
   let parsedBody: unknown;
 
   try {
     parsedBody = await request.json();
   } catch {
+    logServerEvent('warn', 'frontend_auth_login_invalid_body', 'Frontend auth login received invalid body', {
+      requestId,
+      status: 400,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
-      { message: 'Requisição de login inválida.' },
+      { message: 'Requisicao de login invalida.' },
       { status: 400 },
     );
   }
@@ -48,8 +70,14 @@ export async function POST(request: Request) {
   const credentialsResult = loginRequestSchema.safeParse(parsedBody);
 
   if (!credentialsResult.success) {
+    logServerEvent('warn', 'frontend_auth_login_validation_failed', 'Frontend auth login validation failed', {
+      requestId,
+      status: 400,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
-      { message: 'Email e senha são obrigatórios.' },
+      { message: 'Email e senha sao obrigatorios.' },
       { status: 400 },
     );
   }
@@ -61,12 +89,20 @@ export async function POST(request: Request) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        [REQUEST_ID_HEADER]: requestId,
       },
       body: JSON.stringify(credentialsResult.data),
     });
-  } catch {
+  } catch (error) {
+    logServerEvent('error', 'frontend_auth_login_backend_unreachable', 'Frontend auth login could not reach backend', {
+      requestId,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+      ...serializeServerError(error),
+    });
+
     return NextResponse.json(
-      { message: 'Não foi possível contatar o backend de autenticação.' },
+      { message: 'Nao foi possivel contatar o backend de autenticacao.' },
       { status: 502 },
     );
   }
@@ -74,12 +110,19 @@ export async function POST(request: Request) {
   const payload = await readJsonBody(backendResponse);
 
   if (!backendResponse.ok) {
+    logServerEvent('warn', 'frontend_auth_login_rejected', 'Frontend auth login was rejected by backend', {
+      requestId,
+      backendStatus: backendResponse.status,
+      status: backendResponse.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
       {
         message: resolveMessage(
           payload,
           backendResponse.status === 401
-            ? 'Credenciais inválidas.'
+            ? 'Credenciais invalidas.'
             : 'Falha ao autenticar.',
         ),
       },
@@ -90,8 +133,14 @@ export async function POST(request: Request) {
   const sessionResult = loginBackendResponseSchema.safeParse(payload);
 
   if (!sessionResult.success) {
+    logServerEvent('error', 'frontend_auth_login_invalid_backend_payload', 'Frontend auth login received invalid backend payload', {
+      requestId,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
-      { message: 'Resposta inválida do backend de autenticação.' },
+      { message: 'Resposta invalida do backend de autenticacao.' },
       { status: 502 },
     );
   }
@@ -110,6 +159,13 @@ export async function POST(request: Request) {
     sessionResult.data.token,
     getAuthSessionCookieOptions(),
   );
+
+  logServerEvent('info', 'frontend_auth_login_success', 'Frontend auth login completed', {
+    requestId,
+    status: 200,
+    duration_ms: Date.now() - startedAt,
+    username: sessionResult.data.username,
+  });
 
   return response;
 }

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,14 +1,25 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+import { logServerEvent, REQUEST_ID_HEADER, resolveServerRequestId } from '@/lib/server/logger';
 
-export async function POST(_request: NextRequest) {
-  const response = NextResponse.json({ message: 'Sessão encerrada.' }, { status: 200 });
+export async function POST(request: NextRequest) {
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const startedAt = Date.now();
+  const response = NextResponse.json({ message: 'Sessao encerrada.' }, { status: 200 });
 
   response.cookies.set(
     AUTH_SESSION_COOKIE_NAME,
     '',
     getClearedAuthSessionCookieOptions(),
   );
+
+  logServerEvent('info', 'frontend_auth_logout', 'Frontend auth logout completed', {
+    requestId,
+    method: request.method,
+    path: request.nextUrl.pathname,
+    status: 200,
+    duration_ms: Date.now() - startedAt,
+  });
 
   return response;
 }

--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -1,13 +1,33 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { authSessionSchema } from '@/schemas/auth';
 import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+import {
+  logServerEvent,
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+  serializeServerError,
+} from '@/lib/server/logger';
+import { authSessionSchema } from '@/schemas/auth';
 import { buildApiUrl } from '@/services/http/client';
 
 export async function GET(request: NextRequest) {
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const startedAt = Date.now();
   const token = request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value;
 
+  logServerEvent('info', 'frontend_auth_me_start', 'Frontend auth session restore started', {
+    requestId,
+    method: request.method,
+    path: request.nextUrl.pathname,
+  });
+
   if (!token) {
-    return NextResponse.json({ message: 'Sessão inexistente.' }, { status: 401 });
+    logServerEvent('warn', 'frontend_auth_me_missing_session', 'Frontend auth session cookie is missing', {
+      requestId,
+      status: 401,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return NextResponse.json({ message: 'Sessao inexistente.' }, { status: 401 });
   }
 
   let backendResponse: Response;
@@ -17,11 +37,19 @@ export async function GET(request: NextRequest) {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
+        [REQUEST_ID_HEADER]: requestId,
       },
     });
-  } catch {
+  } catch (error) {
+    logServerEvent('error', 'frontend_auth_me_backend_unreachable', 'Frontend auth session restore could not reach backend', {
+      requestId,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+      ...serializeServerError(error),
+    });
+
     return NextResponse.json(
-      { message: 'Não foi possível contatar o backend de autenticação.' },
+      { message: 'Nao foi possivel contatar o backend de autenticacao.' },
       { status: 502 },
     );
   }
@@ -29,12 +57,19 @@ export async function GET(request: NextRequest) {
   const payload = await backendResponse.json().catch(() => null);
 
   if (!backendResponse.ok) {
+    logServerEvent('warn', 'frontend_auth_me_rejected', 'Frontend auth session restore was rejected by backend', {
+      requestId,
+      backendStatus: backendResponse.status,
+      status: backendResponse.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
     const response = NextResponse.json(
       {
         message:
           backendResponse.status === 401
-            ? 'Token inválido ou expirado.'
-            : 'Falha ao restaurar a sessão.',
+            ? 'Token invalido ou expirado.'
+            : 'Falha ao restaurar a sessao.',
       },
       { status: backendResponse.status },
     );
@@ -53,11 +88,24 @@ export async function GET(request: NextRequest) {
   const parsed = authSessionSchema.safeParse(payload);
 
   if (!parsed.success) {
+    logServerEvent('error', 'frontend_auth_me_invalid_backend_payload', 'Frontend auth session restore received invalid backend payload', {
+      requestId,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
-      { message: 'Resposta inválida do backend de sessão.' },
+      { message: 'Resposta invalida do backend de sessao.' },
       { status: 502 },
     );
   }
+
+  logServerEvent('info', 'frontend_auth_me_success', 'Frontend auth session restored', {
+    requestId,
+    status: 200,
+    duration_ms: Date.now() - startedAt,
+    username: parsed.data.username,
+  });
 
   return NextResponse.json(parsed.data, { status: 200 });
 }

--- a/frontend/src/app/api/auth/presence-token/route.ts
+++ b/frontend/src/app/api/auth/presence-token/route.ts
@@ -3,12 +3,32 @@ import {
   AUTH_SESSION_COOKIE_NAME,
   getClearedAuthSessionCookieOptions,
 } from '@/lib/auth/session';
+import {
+  logServerEvent,
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+  serializeServerError,
+} from '@/lib/server/logger';
 import { buildApiUrl } from '@/services/http/client';
 
 export async function GET(request: NextRequest) {
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const startedAt = Date.now();
   const token = request.cookies.get(AUTH_SESSION_COOKIE_NAME)?.value;
 
+  logServerEvent('info', 'frontend_presence_token_start', 'Frontend presence token validation started', {
+    requestId,
+    method: request.method,
+    path: request.nextUrl.pathname,
+  });
+
   if (!token) {
+    logServerEvent('warn', 'frontend_presence_token_missing_session', 'Frontend presence token request is missing session cookie', {
+      requestId,
+      status: 401,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json({ message: 'Sessao inexistente.' }, { status: 401 });
   }
 
@@ -19,10 +39,18 @@ export async function GET(request: NextRequest) {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
+        [REQUEST_ID_HEADER]: requestId,
       },
       cache: 'no-store',
     });
-  } catch {
+  } catch (error) {
+    logServerEvent('error', 'frontend_presence_token_backend_unreachable', 'Frontend presence token validation could not reach backend', {
+      requestId,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+      ...serializeServerError(error),
+    });
+
     return NextResponse.json(
       { message: 'Nao foi possivel validar a sessao de realtime.' },
       { status: 502 },
@@ -30,6 +58,13 @@ export async function GET(request: NextRequest) {
   }
 
   if (!backendResponse.ok) {
+    logServerEvent('warn', 'frontend_presence_token_rejected', 'Frontend presence token validation was rejected by backend', {
+      requestId,
+      backendStatus: backendResponse.status,
+      status: backendResponse.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
     const response = NextResponse.json(
       {
         message:
@@ -53,6 +88,12 @@ export async function GET(request: NextRequest) {
 
   const response = NextResponse.json({ token }, { status: 200 });
   response.headers.set('Cache-Control', 'no-store');
+
+  logServerEvent('info', 'frontend_presence_token_success', 'Frontend presence token issued', {
+    requestId,
+    status: 200,
+    duration_ms: Date.now() - startedAt,
+  });
 
   return response;
 }

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from 'next/server';
 import {
-  registerBackendResponseSchema,
-  registerRequestSchema,
-} from '@/schemas/auth';
-import {
   AUTH_SESSION_COOKIE_NAME,
   getAuthSessionCookieOptions,
 } from '@/lib/auth/session';
+import {
+  logServerEvent,
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+  serializeServerError,
+} from '@/lib/server/logger';
+import {
+  registerBackendResponseSchema,
+  registerRequestSchema,
+} from '@/schemas/auth';
 import { buildApiUrl } from '@/services/http/client';
 
 type ErrorBody = {
@@ -40,11 +46,27 @@ function resolveMessage(payload: unknown, fallback: string): string {
 }
 
 export async function POST(request: Request) {
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const startedAt = Date.now();
+  const path = new URL(request.url).pathname;
+
+  logServerEvent('info', 'frontend_auth_register_start', 'Frontend auth register started', {
+    requestId,
+    method: request.method,
+    path,
+  });
+
   let parsedBody: unknown;
 
   try {
     parsedBody = await request.json();
   } catch {
+    logServerEvent('warn', 'frontend_auth_register_invalid_body', 'Frontend auth register received invalid body', {
+      requestId,
+      status: 400,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
       { message: 'Requisicao de cadastro invalida.' },
       { status: 400 },
@@ -54,6 +76,12 @@ export async function POST(request: Request) {
   const registerResult = registerRequestSchema.safeParse(parsedBody);
 
   if (!registerResult.success) {
+    logServerEvent('warn', 'frontend_auth_register_validation_failed', 'Frontend auth register validation failed', {
+      requestId,
+      status: 400,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
       { message: 'Username, email e senha sao obrigatorios.' },
       { status: 400 },
@@ -67,10 +95,18 @@ export async function POST(request: Request) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        [REQUEST_ID_HEADER]: requestId,
       },
       body: JSON.stringify(registerResult.data),
     });
-  } catch {
+  } catch (error) {
+    logServerEvent('error', 'frontend_auth_register_backend_unreachable', 'Frontend auth register could not reach backend', {
+      requestId,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+      ...serializeServerError(error),
+    });
+
     return NextResponse.json(
       { message: 'Nao foi possivel contatar o backend de autenticacao.' },
       { status: 502 },
@@ -80,6 +116,13 @@ export async function POST(request: Request) {
   const payload = await readJsonBody(backendResponse);
 
   if (!backendResponse.ok) {
+    logServerEvent('warn', 'frontend_auth_register_rejected', 'Frontend auth register was rejected by backend', {
+      requestId,
+      backendStatus: backendResponse.status,
+      status: backendResponse.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
       {
         message: resolveMessage(
@@ -96,6 +139,12 @@ export async function POST(request: Request) {
   const sessionResult = registerBackendResponseSchema.safeParse(payload);
 
   if (!sessionResult.success) {
+    logServerEvent('error', 'frontend_auth_register_invalid_backend_payload', 'Frontend auth register received invalid backend payload', {
+      requestId,
+      status: 502,
+      duration_ms: Date.now() - startedAt,
+    });
+
     return NextResponse.json(
       { message: 'Resposta invalida do backend de autenticacao.' },
       { status: 502 },
@@ -116,6 +165,13 @@ export async function POST(request: Request) {
     sessionResult.data.token,
     getAuthSessionCookieOptions(),
   );
+
+  logServerEvent('info', 'frontend_auth_register_success', 'Frontend auth register completed', {
+    requestId,
+    status: 201,
+    duration_ms: Date.now() - startedAt,
+    username: sessionResult.data.username,
+  });
 
   return response;
 }

--- a/frontend/src/lib/server/logger.ts
+++ b/frontend/src/lib/server/logger.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from 'node:crypto';
+
+export const FRONTEND_SERVICE_NAME = 'frontend';
+export const REQUEST_ID_HEADER = 'x-request-id';
+
+type LogLevel = 'info' | 'warn' | 'error';
+type LogContext = Record<string, unknown>;
+
+type LogEntry = LogContext & {
+  level: LogLevel;
+  service: typeof FRONTEND_SERVICE_NAME;
+  timestamp: string;
+  event: string;
+  message: string;
+};
+
+function writeLog(level: LogLevel, entry: LogEntry): void {
+  const serialized = `${JSON.stringify(entry)}\n`;
+
+  if (level === 'error') {
+    process.stderr.write(serialized);
+    return;
+  }
+
+  process.stdout.write(serialized);
+}
+
+export function resolveServerRequestId(headerValue: string | null): string {
+  if (typeof headerValue === 'string' && headerValue.trim().length > 0) {
+    return headerValue.trim();
+  }
+
+  return randomUUID();
+}
+
+export function createServerLogEntry(
+  level: LogLevel,
+  event: string,
+  message: string,
+  context: LogContext = {},
+): LogEntry {
+  return {
+    level,
+    service: FRONTEND_SERVICE_NAME,
+    timestamp: new Date().toISOString(),
+    event,
+    message,
+    ...context,
+  };
+}
+
+export function logServerEvent(
+  level: LogLevel,
+  event: string,
+  message: string,
+  context: LogContext = {},
+): void {
+  writeLog(level, createServerLogEntry(level, event, message, context));
+}
+
+export function serializeServerError(error: unknown): LogContext {
+  if (error instanceof Error) {
+    return {
+      errorName: error.name,
+      errorMessage: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    errorMessage: String(error),
+  };
+}

--- a/frontend/tests/unit/lib/server-logger.test.ts
+++ b/frontend/tests/unit/lib/server-logger.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FRONTEND_SERVICE_NAME,
+  createServerLogEntry,
+  resolveServerRequestId,
+} from '@/lib/server/logger';
+
+describe('server logger', () => {
+  it('reutiliza o request id recebido no header', () => {
+    expect(resolveServerRequestId('req-123')).toBe('req-123');
+  });
+
+  it('gera um request id quando o header nao existe', () => {
+    const requestId = resolveServerRequestId(null);
+
+    expect(typeof requestId).toBe('string');
+    expect(requestId.length).toBeGreaterThan(0);
+  });
+
+  it('cria um log estruturado com campos obrigatorios', () => {
+    const entry = createServerLogEntry('info', 'frontend_route_request', 'Frontend route request started', {
+      route: '/api/auth/login',
+    });
+
+    expect(entry.level).toBe('info');
+    expect(entry.service).toBe(FRONTEND_SERVICE_NAME);
+    expect(entry.event).toBe('frontend_route_request');
+    expect(entry.message).toBe('Frontend route request started');
+    expect(entry.route).toBe('/api/auth/login');
+    expect(typeof entry.timestamp).toBe('string');
+  });
+});

--- a/frontend/tests/unit/routes/api-proxy-route.test.ts
+++ b/frontend/tests/unit/routes/api-proxy-route.test.ts
@@ -17,6 +17,7 @@ describe('api proxy route', () => {
       expect(init?.headers).toBeDefined();
       const headers = new Headers(init?.headers);
       expect(headers.get('authorization')).toBe('Bearer jwt-token');
+      expect(headers.get('x-request-id')).toBe('req-proxy-123');
 
       return new Response(
         JSON.stringify({
@@ -38,6 +39,7 @@ describe('api proxy route', () => {
     const request = new NextRequest('http://localhost/api/profiles/clutchplayer', {
       headers: {
         cookie: 'clutch_session=jwt-token',
+        'x-request-id': 'req-proxy-123',
       },
     });
 
@@ -50,17 +52,19 @@ describe('api proxy route', () => {
   });
 
   it('clears the session cookie on backend 401 responses', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
-          status: 401,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-      }) as typeof fetch,
-    );
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get('x-request-id')).toBeTruthy();
+
+      return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const request = new NextRequest('http://localhost/api/profiles/clutchplayer', {
       headers: {
@@ -73,6 +77,7 @@ describe('api proxy route', () => {
     });
 
     expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
   });
 });

--- a/frontend/tests/unit/routes/auth-login-route.test.ts
+++ b/frontend/tests/unit/routes/auth-login-route.test.ts
@@ -17,31 +17,35 @@ describe('auth login route', () => {
   });
 
   it('sets an httpOnly cookie when login succeeds', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        return new Response(
-          JSON.stringify({
-            id: 'user-1',
-            username: 'clutchplayer',
-            token: 'jwt-token',
-            message: 'Acesso autorizado.',
-          }),
-          {
-            status: 200,
-            headers: {
-              'Content-Type': 'application/json',
-            },
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      expect(headers.get('x-request-id')).toBe('req-login-123');
+
+      return new Response(
+        JSON.stringify({
+          id: 'user-1',
+          username: 'clutchplayer',
+          token: 'jwt-token',
+          message: 'Acesso autorizado.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
           },
-        );
-      }) as typeof fetch,
-    );
+        },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const response = await POST(
       new Request('http://localhost/api/auth/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'x-request-id': 'req-login-123',
         },
         body: JSON.stringify({
           email: 'clutchplayer@clutch.gg',
@@ -51,23 +55,27 @@ describe('auth login route', () => {
     );
 
     expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.headers.get('set-cookie')).toContain(AUTH_SESSION_COOKIE_NAME);
     expect(response.headers.get('set-cookie')).toContain('HttpOnly');
     expect(response.headers.get('set-cookie')).toContain('jwt-token');
   });
 
   it('propagates invalid credentials without setting a session cookie', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        return new Response(JSON.stringify({ message: 'Credenciais inválidas.' }), {
-          status: 401,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-      }) as typeof fetch,
-    );
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      expect(headers.get('x-request-id')).toBeTruthy();
+
+      return new Response(JSON.stringify({ message: 'Credenciais inválidas.' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const response = await POST(
       new Request('http://localhost/api/auth/login', {
@@ -83,6 +91,7 @@ describe('auth login route', () => {
     );
 
     expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.headers.get('set-cookie')).toBeNull();
     await expect(response.json()).resolves.toEqual({
       message: 'Credenciais inválidas.',

--- a/frontend/tests/unit/routes/auth-me-route.test.ts
+++ b/frontend/tests/unit/routes/auth-me-route.test.ts
@@ -13,34 +13,39 @@ describe('auth me route', () => {
   });
 
   it('returns the hydrated session when the cookie is valid', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        return new Response(
-          JSON.stringify({
-            id: 'user-1',
-            username: 'clutchplayer',
-            email: 'clutchplayer@clutch.gg',
-          }),
-          {
-            status: 200,
-            headers: {
-              'Content-Type': 'application/json',
-            },
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      expect(headers.get('x-request-id')).toBe('req-auth-me-123');
+
+      return new Response(
+        JSON.stringify({
+          id: 'user-1',
+          username: 'clutchplayer',
+          email: 'clutchplayer@clutch.gg',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
           },
-        );
-      }) as typeof fetch,
-    );
+        },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const request = new NextRequest('http://localhost/api/auth/me', {
       headers: {
         cookie: 'clutch_session=jwt-token',
+        'x-request-id': 'req-auth-me-123',
       },
     });
 
     const response = await GET(request);
 
     expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     await expect(response.json()).resolves.toEqual({
       id: 'user-1',
       username: 'clutchplayer',
@@ -49,17 +54,20 @@ describe('auth me route', () => {
   });
 
   it('clears the cookie when the backend rejects the token', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
-          status: 401,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-      }) as typeof fetch,
-    );
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      expect(headers.get('x-request-id')).toBeTruthy();
+
+      return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const request = new NextRequest('http://localhost/api/auth/me', {
       headers: {
@@ -70,6 +78,7 @@ describe('auth me route', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
   });
 });

--- a/frontend/tests/unit/routes/auth-presence-token-route.test.ts
+++ b/frontend/tests/unit/routes/auth-presence-token-route.test.ts
@@ -13,50 +13,58 @@ describe('auth presence token route', () => {
   });
 
   it('returns the websocket credential when the session cookie is valid', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        return new Response(
-          JSON.stringify({
-            id: 'user-1',
-            username: 'clutchplayer',
-            email: 'clutchplayer@clutch.gg',
-          }),
-          {
-            status: 200,
-            headers: {
-              'Content-Type': 'application/json',
-            },
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      expect(headers.get('x-request-id')).toBe('req-presence-123');
+
+      return new Response(
+        JSON.stringify({
+          id: 'user-1',
+          username: 'clutchplayer',
+          email: 'clutchplayer@clutch.gg',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
           },
-        );
-      }) as typeof fetch,
-    );
+        },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const request = new NextRequest('http://localhost/api/auth/presence-token', {
       headers: {
         cookie: 'clutch_session=jwt-token',
+        'x-request-id': 'req-presence-123',
       },
     });
 
     const response = await GET(request);
 
     expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     await expect(response.json()).resolves.toEqual({ token: 'jwt-token' });
     expect(response.headers.get('cache-control')).toBe('no-store');
   });
 
   it('clears the cookie when the backend rejects the session token', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
-          status: 401,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
-      }) as typeof fetch,
-    );
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+
+      expect(headers.get('x-request-id')).toBeTruthy();
+
+      return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
+        status: 401,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const request = new NextRequest('http://localhost/api/auth/presence-token', {
       headers: {
@@ -67,6 +75,7 @@ describe('auth presence token route', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
   });
 });


### PR DESCRIPTION
## Resumo

Padroniza logs estruturados entre backend, frontend server-side e presence para melhorar a rastreabilidade de requests HTTP, autenticação e eventos websocket no stack container-first. A mudança também introduz correlação leve por `x-request-id` entre frontend e backend, sem alterar contratos externos.

## O que foi alterado

- Backend:
  - Adiciona logger estruturado com `service`, `timestamp`, `event` e `message`.
  - Gera e reaproveia `requestId` por request via `x-request-id`.
  - Registra início, resposta e erro do ciclo HTTP sem duplicar o request logging padrão.
  - Substitui logs soltos de runtime e warning de notificação por JSON estruturado.
- Frontend server-side:
  - Adiciona logger reutilizável para rotas internas.
  - Instrumenta `auth/login`, `auth/logout`, `auth/me`, `auth/register`, `auth/presence-token` e proxy catch-all.
  - Propaga `x-request-id` para o backend nas chamadas server-side.
- Presence:
  - Substitui `log.Printf` por logs JSON one-line.
  - Registra handshake autenticado, conexão aberta/fechada, registro/desregistro no hub e ping/pong.
  - Suprime falsos erros em fechamento normal de websocket.
- Testes:
  - Adiciona cobertura para utilitários de logging do backend, frontend e presence.
  - Atualiza testes de rotas server-side para validar propagação de `x-request-id`.

## Motivação

O stack já está funcional, mas sem observabilidade consistente entre serviços. Isso dificulta depuração de falhas HTTP, autenticação e realtime, especialmente no ambiente containerizado e no CI.

## Como validar

- Executar no backend:
  - `npm run test -- tests/unit/config/logging.test.ts tests/unit/config/health.test.ts tests/integration/health.routes.test.ts`
  - `npm run lint`
- Executar no frontend:
  - `npm run test -- tests/unit/lib/server-logger.test.ts tests/unit/routes/auth-login-route.test.ts tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-presence-token-route.test.ts tests/unit/routes/api-proxy-route.test.ts tests/unit/routes/auth-register-route.test.ts tests/unit/routes/auth-logout-route.test.ts`
  - `npm run typecheck`
  - `npm run lint`
- Subir o stack:
  - `docker compose build backend presence frontend`
  - `docker compose up -d backend presence frontend`
- Validar:
  - `GET http://localhost/api/health`
  - `GET http://localhost/presence/health`
  - `POST http://localhost/api/auth/login`
  - `GET http://localhost/api/auth/me`
  - Inspecionar `docker compose logs backend`, `docker compose logs frontend` e `docker compose logs presence`.

## Riscos e impactos

- O frontend em `next dev` continua emitindo logs próprios do framework além dos logs JSON da aplicação.
- O `go test` local pode continuar bloqueado por política do host Windows; a validação do presence permanece apoiada no runtime containerizado.
- Não há mudança de contrato HTTP ou websocket exposto para clientes externos.

## Evidências

- Backend: logs com `service=backend`, `requestId` e eventos `http_request_start` e `http_request_complete`.
- Frontend: logs estruturados nas rotas `auth/login`, `auth/me` e `auth/presence-token`.
- Presence: logs estruturados de handshake, conexão e ping/pong sem falso erro de close normal.

## Checklist

- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #143