### PR TITLE
fix(security): remove URLs de conexão dos logs estruturados

### DIFF
--- a/backend/presence-service/logging.go
+++ b/backend/presence-service/logging.go
@@ -17,7 +17,6 @@ type sanitizedConnectionTarget struct {
 	Scheme      string
 	Host        string
 	Port        string
-	RedactedURL string
 }
 
 var sensitiveURLPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9+.-]*://[^\s"'<>]+`)
@@ -84,83 +83,68 @@ func sanitizeConnectionURL(rawURL string) sanitizedConnectionTarget {
 
 	parsedURL, err := url.Parse(trimmedURL)
 	if err != nil {
-		return sanitizedConnectionTarget{
-			RedactedURL: redactConnectionURLFallback(trimmedURL),
-		}
+		return parseConnectionTargetFallback(trimmedURL)
 	}
 
-	redactedURL := parsedURL.String()
-	if parsedURL.User != nil {
-		username := parsedURL.User.Username()
-		if _, hasPassword := parsedURL.User.Password(); hasPassword {
-			redactedURL = buildRedactedURL(parsedURL, username)
+	return sanitizedConnectionTarget{
+		Scheme: parsedURL.Scheme,
+		Host:   parsedURL.Hostname(),
+		Port:   parsedURL.Port(),
+	}
+}
+
+func parseConnectionTargetFallback(rawURL string) sanitizedConnectionTarget {
+	schemeSeparatorIndex := strings.Index(rawURL, "://")
+	if schemeSeparatorIndex < 0 {
+		return sanitizedConnectionTarget{}
+	}
+
+	scheme := rawURL[:schemeSeparatorIndex]
+	remainder := rawURL[schemeSeparatorIndex+3:]
+	atIndex := strings.LastIndex(remainder, "@")
+	hostAndPath := remainder
+	if atIndex >= 0 {
+		hostAndPath = remainder[atIndex+1:]
+	}
+
+	slashIndex := strings.Index(hostAndPath, "/")
+	hostPort := hostAndPath
+	if slashIndex >= 0 {
+		hostPort = hostAndPath[:slashIndex]
+	}
+
+	colonIndex := strings.LastIndex(hostPort, ":")
+	if colonIndex < 0 {
+		return sanitizedConnectionTarget{
+			Scheme: scheme,
+			Host:   hostPort,
 		}
 	}
 
 	return sanitizedConnectionTarget{
-		Scheme:      parsedURL.Scheme,
-		Host:        parsedURL.Hostname(),
-		Port:        parsedURL.Port(),
-		RedactedURL: redactedURL,
+		Scheme: scheme,
+		Host:   hostPort[:colonIndex],
+		Port:   hostPort[colonIndex+1:],
 	}
 }
 
-func buildRedactedURL(parsedURL *url.URL, username string) string {
-	var builder strings.Builder
-
-	if parsedURL.Scheme != "" {
-		builder.WriteString(parsedURL.Scheme)
-		builder.WriteString("://")
+func formatSanitizedConnectionTarget(target sanitizedConnectionTarget) string {
+	parts := make([]string, 0, 3)
+	if target.Scheme != "" {
+		parts = append(parts, "scheme="+target.Scheme)
+	}
+	if target.Host != "" {
+		parts = append(parts, "host="+target.Host)
+	}
+	if target.Port != "" {
+		parts = append(parts, "port="+target.Port)
 	}
 
-	if username != "" {
-		builder.WriteString(username)
-	}
-	builder.WriteString(":***@")
-	builder.WriteString(parsedURL.Host)
-
-	if parsedURL.RawPath != "" {
-		builder.WriteString(parsedURL.RawPath)
-	} else {
-		builder.WriteString(parsedURL.EscapedPath())
+	if len(parts) == 0 {
+		return "[connection redacted]"
 	}
 
-	if parsedURL.RawQuery != "" {
-		builder.WriteString("?")
-		builder.WriteString(parsedURL.RawQuery)
-	}
-
-	if parsedURL.Fragment != "" {
-		builder.WriteString("#")
-		builder.WriteString(parsedURL.Fragment)
-	}
-
-	return builder.String()
-}
-
-func redactConnectionURLFallback(rawURL string) string {
-	schemeSeparatorIndex := strings.Index(rawURL, "://")
-	if schemeSeparatorIndex < 0 {
-		return rawURL
-	}
-
-	scheme := rawURL[:schemeSeparatorIndex+3]
-	remainder := rawURL[schemeSeparatorIndex+3:]
-	atIndex := strings.LastIndex(remainder, "@")
-	if atIndex < 0 {
-		return rawURL
-	}
-
-	userInfo := remainder[:atIndex]
-	hostAndPath := remainder[atIndex+1:]
-
-	colonIndex := strings.Index(userInfo, ":")
-	if colonIndex < 0 {
-		return rawURL
-	}
-
-	username := userInfo[:colonIndex]
-	return scheme + username + ":***@" + hostAndPath
+	return "[connection " + strings.Join(parts, " ") + "]"
 }
 
 func connectionLogFields(prefix string, rawURL string, status string) map[string]interface{} {
@@ -178,9 +162,6 @@ func connectionLogFields(prefix string, rawURL string, status string) map[string
 	if target.Port != "" {
 		fields[prefix+"Port"] = target.Port
 	}
-	if target.RedactedURL != "" && target.Host == "" {
-		fields[prefix+"UrlRedacted"] = target.RedactedURL
-	}
 
 	return fields
 }
@@ -191,10 +172,6 @@ func sanitizeSensitiveText(value string) string {
 	}
 
 	return sensitiveURLPattern.ReplaceAllStringFunc(value, func(match string) string {
-		target := sanitizeConnectionURL(match)
-		if target.RedactedURL == "" {
-			return match
-		}
-		return target.RedactedURL
+		return formatSanitizedConnectionTarget(sanitizeConnectionURL(match))
 	})
 }

--- a/backend/presence-service/logging_test.go
+++ b/backend/presence-service/logging_test.go
@@ -36,7 +36,6 @@ func TestSanitizeConnectionURL(t *testing.T) {
 	tests := []struct {
 		name           string
 		rawURL         string
-		wantRedacted   string
 		wantScheme     string
 		wantHost       string
 		wantPort       string
@@ -44,7 +43,6 @@ func TestSanitizeConnectionURL(t *testing.T) {
 		{
 			name:         "masks password while preserving host and port",
 			rawURL:       "redis://default:super-secret@redis.internal:6379/0",
-			wantRedacted: "redis://default:***@redis.internal:6379/0",
 			wantScheme:   "redis",
 			wantHost:     "redis.internal",
 			wantPort:     "6379",
@@ -52,15 +50,16 @@ func TestSanitizeConnectionURL(t *testing.T) {
 		{
 			name:         "preserves url without password",
 			rawURL:       "redis://redis.internal:6379/0",
-			wantRedacted: "redis://redis.internal:6379/0",
 			wantScheme:   "redis",
 			wantHost:     "redis.internal",
 			wantPort:     "6379",
 		},
 		{
-			name:         "redacts invalid url without panicking",
+			name:       "handles invalid url without panicking",
 			rawURL:       "redis://default:super-secret@%zz:6379",
-			wantRedacted: "redis://default:***@%zz:6379",
+			wantScheme:   "redis",
+			wantHost:     "%zz",
+			wantPort:     "6379",
 		},
 	}
 
@@ -72,9 +71,6 @@ func TestSanitizeConnectionURL(t *testing.T) {
 
 			target := sanitizeConnectionURL(tt.rawURL)
 
-			if target.RedactedURL != tt.wantRedacted {
-				t.Fatalf("expected redacted url %q, got %q", tt.wantRedacted, target.RedactedURL)
-			}
 			if target.Scheme != tt.wantScheme {
 				t.Fatalf("expected scheme %q, got %q", tt.wantScheme, target.Scheme)
 			}
@@ -108,12 +104,9 @@ func TestConnectionLogFields(t *testing.T) {
 		if _, ok := fields["redisUrl"]; ok {
 			t.Fatalf("did not expect redisUrl for valid connection target")
 		}
-		if _, ok := fields["redisUrlRedacted"]; ok {
-			t.Fatalf("did not expect redisUrlRedacted for valid connection target")
-		}
 	})
 
-	t.Run("falls back to redacted url for invalid urls", func(t *testing.T) {
+	t.Run("uses host and port for urls even when password exists", func(t *testing.T) {
 		t.Parallel()
 
 		fields := connectionLogFields("redis", "redis://default:super-secret@%zz:6379", "parse_failed")
@@ -121,14 +114,11 @@ func TestConnectionLogFields(t *testing.T) {
 		if fields["status"] != "parse_failed" {
 			t.Fatalf("expected status parse_failed, got %v", fields["status"])
 		}
-		if fields["redisUrlRedacted"] != "redis://default:***@%zz:6379" {
-			t.Fatalf("expected redisUrlRedacted to be masked, got %v", fields["redisUrlRedacted"])
+		if fields["redisHost"] != "%zz" {
+			t.Fatalf("expected redisHost %%zz, got %v", fields["redisHost"])
 		}
-		if _, ok := fields["redisHost"]; ok {
-			t.Fatalf("did not expect redisHost for invalid connection target")
-		}
-		if _, ok := fields["redisPort"]; ok {
-			t.Fatalf("did not expect redisPort for invalid connection target")
+		if fields["redisPort"] != "6379" {
+			t.Fatalf("expected redisPort 6379, got %v", fields["redisPort"])
 		}
 	})
 }
@@ -141,7 +131,7 @@ func TestSanitizeSensitiveText(t *testing.T) {
 
 		sanitized := sanitizeSensitiveText(`parse "redis://default:super-secret@%zz:6379": invalid URL escape "%zz"`)
 
-		if sanitized != `parse "redis://default:***@%zz:6379": invalid URL escape "%zz"` {
+		if sanitized != `parse "[connection scheme=redis host=%zz port=6379]": invalid URL escape "%zz"` {
 			t.Fatalf("expected sanitized error string, got %q", sanitized)
 		}
 	})
@@ -151,7 +141,7 @@ func TestSanitizeSensitiveText(t *testing.T) {
 
 		sanitized := sanitizeSensitiveText(`connected to redis://redis.internal:6379/0`)
 
-		if sanitized != `connected to redis://redis.internal:6379/0` {
+		if sanitized != `connected to [connection scheme=redis host=redis.internal port=6379]` {
 			t.Fatalf("expected url without password to stay unchanged, got %q", sanitized)
 		}
 	})

--- a/backend/src/config/logging.ts
+++ b/backend/src/config/logging.ts
@@ -14,7 +14,6 @@ type SanitizedConnectionTarget = {
   scheme: string;
   host: string;
   port: string;
-  redactedUrl: string;
 };
 
 type RuntimeLogEntry = RuntimeLogContext & {
@@ -90,28 +89,43 @@ export function createFastifyLoggerOptions(): FastifyServerOptions['logger'] {
   } satisfies FastifyServerOptions['logger'];
 }
 
-function redactConnectionUrlFallback(rawUrl: string): string {
+function parseConnectionTargetFallback(rawUrl: string): SanitizedConnectionTarget {
   const schemeSeparatorIndex = rawUrl.indexOf('://');
   if (schemeSeparatorIndex < 0) {
-    return rawUrl;
+    return {
+      scheme: '',
+      host: '',
+      port: '',
+    };
   }
 
-  const scheme = rawUrl.slice(0, schemeSeparatorIndex + 3);
+  const scheme = rawUrl.slice(0, schemeSeparatorIndex);
   const remainder = rawUrl.slice(schemeSeparatorIndex + 3);
   const atIndex = remainder.lastIndexOf('@');
-  if (atIndex < 0) {
-    return rawUrl;
+  const hostAndPath = atIndex >= 0 ? remainder.slice(atIndex + 1) : remainder;
+  const slashIndex = hostAndPath.indexOf('/');
+  const hostPort = slashIndex >= 0 ? hostAndPath.slice(0, slashIndex) : hostAndPath;
+  const colonIndex = hostPort.lastIndexOf(':');
+
+  return {
+    scheme,
+    host: colonIndex >= 0 ? hostPort.slice(0, colonIndex) : hostPort,
+    port: colonIndex >= 0 ? hostPort.slice(colonIndex + 1) : '',
+  };
+}
+
+function formatSanitizedConnectionTarget(target: SanitizedConnectionTarget): string {
+  const parts = [
+    target.scheme ? `scheme=${target.scheme}` : null,
+    target.host ? `host=${target.host}` : null,
+    target.port ? `port=${target.port}` : null,
+  ].filter((value): value is string => Boolean(value));
+
+  if (parts.length === 0) {
+    return '[connection redacted]';
   }
 
-  const userInfo = remainder.slice(0, atIndex);
-  const hostAndPath = remainder.slice(atIndex + 1);
-  const colonIndex = userInfo.indexOf(':');
-  if (colonIndex < 0) {
-    return rawUrl;
-  }
-
-  const username = userInfo.slice(0, colonIndex);
-  return `${scheme}${username}:***@${hostAndPath}`;
+  return `[connection ${parts.join(' ')}]`;
 }
 
 export function sanitizeConnectionUrl(rawUrl: string): SanitizedConnectionTarget {
@@ -121,30 +135,18 @@ export function sanitizeConnectionUrl(rawUrl: string): SanitizedConnectionTarget
       scheme: '',
       host: '',
       port: '',
-      redactedUrl: '',
     };
   }
 
   try {
     const parsedUrl = new URL(trimmedUrl);
-    const redactedUrl =
-      parsedUrl.password.length > 0
-        ? `${parsedUrl.protocol}//${parsedUrl.username}:***@${parsedUrl.host}${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`
-        : parsedUrl.toString();
-
     return {
       scheme: parsedUrl.protocol.replace(/:$/, ''),
       host: parsedUrl.hostname,
       port: parsedUrl.port,
-      redactedUrl,
     };
   } catch {
-    return {
-      scheme: '',
-      host: '',
-      port: '',
-      redactedUrl: redactConnectionUrlFallback(trimmedUrl),
-    };
+    return parseConnectionTargetFallback(trimmedUrl);
   }
 }
 
@@ -153,7 +155,7 @@ export function sanitizeSensitiveText(value: string): string {
     return value;
   }
 
-  return value.replace(SENSITIVE_URL_PATTERN, (match) => sanitizeConnectionUrl(match).redactedUrl || match);
+  return value.replace(SENSITIVE_URL_PATTERN, (match) => formatSanitizedConnectionTarget(sanitizeConnectionUrl(match)));
 }
 
 export function serializeErrorDetails(error: unknown): RuntimeLogContext {

--- a/backend/tests/unit/config/logging.test.ts
+++ b/backend/tests/unit/config/logging.test.ts
@@ -57,7 +57,6 @@ describe('logging config', () => {
   it('mascara senha em url de conexao preservando host e porta', () => {
     const target = sanitizeConnectionUrl('redis://default:super-secret@redis.internal:6379/0');
 
-    expect(target.redactedUrl).toBe('redis://default:***@redis.internal:6379/0');
     expect(target.scheme).toBe('redis');
     expect(target.host).toBe('redis.internal');
     expect(target.port).toBe('6379');
@@ -66,7 +65,6 @@ describe('logging config', () => {
   it('preserva url sem senha', () => {
     const target = sanitizeConnectionUrl('redis://redis.internal:6379/0');
 
-    expect(target.redactedUrl).toBe('redis://redis.internal:6379/0');
     expect(target.host).toBe('redis.internal');
     expect(target.port).toBe('6379');
   });
@@ -74,7 +72,6 @@ describe('logging config', () => {
   it('mascara senha em url invalida sem quebrar o parse', () => {
     const target = sanitizeConnectionUrl('redis://default:super-secret@%zz:6379');
 
-    expect(target.redactedUrl).toBe('redis://default:***@%zz:6379');
     expect(target.host).toBe('%zz');
     expect(target.port).toBe('6379');
   });
@@ -85,9 +82,12 @@ describe('logging config', () => {
     const details = serializeErrorDetails(error);
 
     expect(sanitizeSensitiveText(error.message)).toBe(
-      'parse "redis://default:***@%zz:6379": invalid URL escape "%zz"',
+      'parse "[connection scheme=redis host=%zz port=6379]": invalid URL escape "%zz"',
     );
-    expect(details.errorMessage).toBe('parse "redis://default:***@%zz:6379": invalid URL escape "%zz"');
+    expect(details.errorMessage).toBe(
+      'parse "[connection scheme=redis host=%zz port=6379]": invalid URL escape "%zz"',
+    );
     expect(String(details.stack)).not.toContain('super-secret');
+    expect(String(details.stack)).not.toContain('redis://');
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - --ping.entrypoint=ping
       - --log.level=INFO
       - --accesslog=true
+      - --accesslog.format=json
+      - --accesslog.fields.defaultmode=keep
+      - --accesslog.fields.names.RequestPath=drop
+      - --accesslog.fields.names.RequestLine=drop
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
## Resumo
Remove completamente URLs de conexão dos logs estruturados do backend e do presence, substituindo esse contexto por campos seguros e estruturados com scheme, host e port. A mudança também endurece o access log do Traefik para não serializar path e query string, reduzindo vazamento indireto de credenciais no stack container-first.

## O que foi alterado
- Backend:
- ajusta o utilitário de logging para representar alvos de conexão apenas com `scheme`, `host` e `port`
- mantém a sanitização de `error.message` e `stack`, mas sem gerar URLs redigidas no output
- atualiza os testes unitários do logger para o novo contrato sem `*Url`
- Presence:
- remove completamente `redisUrlRedacted` do fluxo de logging estruturado
- padroniza os eventos de Redis para usar apenas `redisScheme`, `redisHost`, `redisPort` e `status`
- mantém a sanitização textual de erros sem serializar URLs em nenhuma forma
- Proxy:
- ajusta o access log do Traefik para JSON com `RequestPath` e `RequestLine` removidos

## Motivação
Mesmo com senha mascarada, manter URLs de conexão nos logs ainda expõe informação desnecessária e foge do padrão mais restritivo de logging seguro. O hardening reduz superfície de vazamento local, no CI e em qualquer pipeline de observabilidade conectado ao stack.

## Como validar
- Executar no backend:
- `npm run test -- tests/unit/config/logging.test.ts`
- `npm run lint`
- `npm run typecheck`
- Executar no presence:
- `docker run --rm -v C:/Github/clutch/backend/presence-service:/workspace -w /workspace golang:1.24-alpine sh -lc "/usr/local/go/bin/go test ./..."`
- Subir o stack:
- `docker compose build`
- `docker compose up -d`
- Validar logs:
- `docker logs clutch_presence | Select-String 'redisUrl|UrlRedacted|redis://'`
- `docker logs clutch_backend | Select-String 'redis://|postgres://|postgresql://'`
- `docker compose logs | Select-String -Pattern 'redis'`
- `docker compose logs | Select-String -Pattern 'password'`
- `docker compose logs | Select-String -Pattern 'token'`

## Riscos e impactos
- O literal `token` ainda pode aparecer em nomes de evento do frontend server-side, sem carregar segredo; este ajuste não renomeia eventos fora do escopo.
- O access log do Traefik perde `RequestPath` e `RequestLine`, o que reduz detalhe bruto de roteamento em troca de segurança melhor para query strings sensíveis.
- Não há alteração de contrato HTTP, websocket ou comportamento funcional da aplicação.

## Evidências
- `docker logs clutch_presence` passou a registrar `redisScheme`, `redisHost`, `redisPort` e `status`, sem qualquer campo `*Url`.
- `docker logs clutch_backend` não retornou `redis://`, `postgres://` ou `postgresql://` durante a validação.
- O access log atual do Traefik em JSON não inclui mais `RequestPath` nem `RequestLine`.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados
