### PR TITLE
ci(security): falha o pipeline ao detectar dados sensiveis em logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,13 +266,30 @@ jobs:
           PRESENCE_WS_TIMEOUT_MS: 15000
         run: node ./scripts/ci/validate-presence-handshake.mjs
 
+      - name: Collect stack logs
+        if: always()
+        run: docker compose logs --no-color backend frontend presence traefik > /tmp/clutch-stack.logs
+
+      - name: Fail on sensitive data in stack logs
+        if: success()
+        run: node ./scripts/ci/check-sensitive-logs.mjs scan /tmp/clutch-stack.logs
+
       - name: Show compose status
         if: always()
         run: docker compose ps
 
-      - name: Show compose logs
+      - name: Show sanitized compose logs
         if: failure()
-        run: docker compose logs --no-color backend frontend presence traefik
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -f /tmp/clutch-stack.logs ]; then
+            docker compose logs --no-color backend frontend presence traefik > /tmp/clutch-stack.logs
+          fi
+
+          tail -n 200 /tmp/clutch-stack.logs > /tmp/clutch-stack-tail.logs
+          node ./scripts/ci/check-sensitive-logs.mjs sanitize /tmp/clutch-stack-tail.logs
 
       - name: Shutdown stack
         if: always()

--- a/scripts/ci/check-sensitive-logs.mjs
+++ b/scripts/ci/check-sensitive-logs.mjs
@@ -1,0 +1,138 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const URL_WITH_CREDENTIALS_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^/\s@]+@[^\s"']+/giu;
+const URL_PROTOCOL_PATTERN = /\b(?<scheme>redis|postgres|postgresql):\/\/(?<rest>[^\s"']+)/giu;
+const AUTHORIZATION_VALUE_PATTERN =
+  /(?<prefix>\bauthorization\b\s*[:=]\s*)(?<quote>"?)(?<value>[^",}]+)(?<suffix>"?)/giu;
+const BEARER_TOKEN_PATTERN = /\bBearer\s+(?<token>[A-Za-z0-9._~+/=-]{8,})/gu;
+const SENSITIVE_ASSIGNMENT_PATTERN =
+  /(?<key>"?(?:password|secret)"?\s*[:=]\s*)(?<quote>"?)(?<value>[^"\s,}]+)(?<suffix>"?)/giu;
+
+const BLOCKING_PATTERNS = [
+  {
+    id: 'authorization_header',
+    pattern: /authorization\s*[:=]\s*"?[^\s",}]+/iu,
+  },
+  {
+    id: 'bearer_token',
+    pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/u,
+  },
+  {
+    id: 'redis_url',
+    pattern: /\bredis:\/\/[^\s"']+/iu,
+  },
+  {
+    id: 'postgres_url',
+    pattern: /\bpostgres(?:ql)?:\/\/[^\s"']+/iu,
+  },
+  {
+    id: 'url_with_credentials',
+    pattern: /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^/\s@]+@[^\s"']+/iu,
+  },
+  {
+    id: 'password_assignment',
+    pattern: /"?(?:password|secret)"?\s*[:=]\s*"?(?!\*\*\*|redacted|null|undefined|false|true)[^"\s,}]+/iu,
+  },
+];
+
+function sanitizeConnectionUrl(rawUrl) {
+  try {
+    const parsedUrl = new URL(rawUrl);
+    const port = parsedUrl.port || (parsedUrl.protocol === 'redis:' ? '6379' : '');
+    const portSegment = port ? ` port=${port}` : '';
+
+    return `[connection scheme=${parsedUrl.protocol.replace(':', '')} host=${parsedUrl.hostname}${portSegment}]`;
+  } catch {
+    return '[connection redacted]';
+  }
+}
+
+export function sanitizeLogLine(line) {
+  return line
+    .replace(URL_WITH_CREDENTIALS_PATTERN, (match) => sanitizeConnectionUrl(match))
+    .replace(URL_PROTOCOL_PATTERN, (match) => sanitizeConnectionUrl(match))
+    .replace(
+      AUTHORIZATION_VALUE_PATTERN,
+      (_match, prefix, quote, _value, suffix) => `${prefix}${quote}***${suffix}`,
+    )
+    .replace(BEARER_TOKEN_PATTERN, 'Bearer ***')
+    .replace(
+      SENSITIVE_ASSIGNMENT_PATTERN,
+      (_match, key, quote, _value, suffix) => `${key}${quote}***${suffix}`,
+    );
+}
+
+export function scanLogContent(content) {
+  const lines = content.split(/\r?\n/u);
+
+  return lines.flatMap((line, index) => {
+    if (line.trim().length === 0) {
+      return [];
+    }
+
+    const matchedRule = BLOCKING_PATTERNS.find(({ pattern }) => pattern.test(line));
+
+    if (!matchedRule) {
+      return [];
+    }
+
+    return [
+      {
+        ruleId: matchedRule.id,
+        lineNumber: index + 1,
+        line: sanitizeLogLine(line),
+      },
+    ];
+  });
+}
+
+async function loadContent(filePath) {
+  if (!filePath) {
+    throw new Error('Informe o caminho do arquivo de logs.');
+  }
+
+  return readFile(filePath, 'utf8');
+}
+
+async function main() {
+  const [, , mode = 'scan', filePath] = process.argv;
+  const content = await loadContent(filePath);
+
+  if (mode === 'sanitize') {
+    process.stdout.write(sanitizeLogLine(content));
+    return;
+  }
+
+  if (mode !== 'scan') {
+    throw new Error(`Modo nao suportado: ${mode}`);
+  }
+
+  const findings = scanLogContent(content);
+
+  if (findings.length === 0) {
+    console.log(`[log-gate] nenhum padrao bloqueante encontrado em ${filePath}`);
+    return;
+  }
+
+  console.error(`[log-gate] ${findings.length} padrao(oes) bloqueante(s) encontrado(s) em ${filePath}`);
+
+  for (const finding of findings) {
+    console.error(
+      `[log-gate] ${finding.ruleId} na linha ${finding.lineNumber}: ${finding.line}`,
+    );
+  }
+
+  process.exitCode = 1;
+}
+
+const isDirectExecution =
+  typeof process.argv[1] === 'string' && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error('[log-gate] falha ao validar logs:', error);
+    process.exit(1);
+  });
+}

--- a/scripts/ci/check-sensitive-logs.test.mjs
+++ b/scripts/ci/check-sensitive-logs.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sanitizeLogLine, scanLogContent } from './check-sensitive-logs.mjs';
+
+test('sanitiza URLs com credenciais preservando host e porta', () => {
+  const sanitized = sanitizeLogLine(
+    '{"redisUrl":"redis://default:super-secret@redis:6379","status":"connected"}',
+  );
+
+  assert.match(sanitized, /scheme=redis/u);
+  assert.match(sanitized, /host=redis/u);
+  assert.match(sanitized, /port=6379/u);
+  assert.doesNotMatch(sanitized, /super-secret/u);
+  assert.doesNotMatch(sanitized, /redis:\/\//u);
+});
+
+test('sanitiza tokens e assignments sensiveis', () => {
+  const sanitized = sanitizeLogLine(
+    '{"authorization":"Bearer abcdefghijklmnop","password":"super-secret","secret":"top-secret"}',
+  );
+
+  assert.match(sanitized, /"authorization":"Bearer \*\*\*"/u);
+  assert.match(sanitized, /"password":"\*\*\*"/u);
+  assert.match(sanitized, /"secret":"\*\*\*"/u);
+  assert.doesNotMatch(sanitized, /abcdefghijklmnop|super-secret|top-secret/u);
+});
+
+test('identifica apenas padroes bloqueantes reais e ignora texto seguro', () => {
+  const findings = scanLogContent(
+    [
+      '{"service":"frontend","event":"presence_token_start","message":"Token route started"}',
+      '{"service":"presence","redisHost":"redis","redisPort":"6379","status":"connected"}',
+      '{"service":"backend","authorization":"Bearer abcdefghijklmnop"}',
+      '{"service":"backend","database":"postgres://user:secret@postgres:5432/app"}',
+    ].join('\n'),
+  );
+
+  assert.equal(findings.length, 2);
+  assert.equal(findings[0].ruleId, 'bearer_token');
+  assert.equal(findings[1].ruleId, 'postgres_url');
+});


### PR DESCRIPTION
## Resumo
Adiciona um gate de seguranca ao pipeline para bloquear regressoes de dados sensiveis nos logs do stack container-first apos o `container-smoke`. A mudanca preserva a capacidade de diagnostico no CI sem voltar a expor logs brutos em caso de falha.

## O que foi alterado
- adiciona um helper dedicado em `scripts/ci/check-sensitive-logs.mjs` para detectar padroes bloqueantes reais e sanitizar a saida de erro
- adiciona testes do helper em `scripts/ci/check-sensitive-logs.test.mjs`
- atualiza o job `container-smoke` em `.github/workflows/ci.yml` para coletar logs, executar o gate e mostrar apenas uma previa sanitizada quando houver falha

## Motivacao
O projeto ja endureceu o logging do stack, mas ainda faltava uma protecao automatica no CI para impedir regressao futura. Sem esse gate, um vazamento acidental poderia voltar aos logs e passar despercebido ate outra revisao manual.

## Como validar
- Executar `node --test scripts/ci/check-sensitive-logs.test.mjs`
- Executar `docker compose up -d`
- Executar `docker compose logs --no-color backend frontend presence traefik > %TEMP%\clutch-stack.logs`
- Executar `node scripts/ci/check-sensitive-logs.mjs scan %TEMP%\clutch-stack.logs`
- Confirmar que `docker compose ps` permanece saudavel

## Riscos e impactos
- O gate usa heuristicas por padrao e pode exigir ajuste fino se surgirem novos formatos legitimos de log
- A saida de falha do workflow passa a ser sanitizada; investigacoes profundas continuam dependentes de reproducao local quando necessario
- O risco funcional e baixo porque a mudanca se limita ao pipeline e a um helper isolado de validacao

## Evidencias
- `node --test scripts/ci/check-sensitive-logs.test.mjs`
- `node scripts/ci/check-sensitive-logs.mjs scan <arquivo-de-logs>` retornando sem padroes bloqueantes nos logs atuais do stack

## Checklist
- [x] Alteracao limitada ao objetivo da PR
- [x] Sem mudancas desconexas
- [x] Impactos principais descritos
- [x] Validacao documentada
- [x] Riscos identificados

Closes #157