### PR TITLE
feat(auth): implementar fluxo de refresh token seguro

### DIFF
--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -1,12 +1,24 @@
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyReply } from 'fastify';
 import { z } from 'zod';
 import bcrypt from 'bcrypt';
 import { userRepository } from '../../core/repositories/user.repository';
+import {
+  parseCookieValue,
+  REFRESH_TOKEN_COOKIE_NAME,
+  serializeClearedRefreshTokenCookie,
+  serializeRefreshTokenCookie,
+} from '../../config/auth-session';
+import {
+  RefreshTokenInvalidError,
+  RefreshTokenReuseError,
+} from '../../core/services/refresh-token.service';
 
 // ─────────────────────────────────────────────────────────────
 // Auth Routes
 // POST /auth/register
 // POST /auth/login
+// POST /auth/refresh
+// POST /auth/logout
 // GET  /auth/me
 // ─────────────────────────────────────────────────────────────
 
@@ -28,6 +40,19 @@ const loginSchema = z.object({
 });
 
 export async function authRoutes(app: FastifyInstance): Promise<void> {
+  async function issueAuthSession(
+    user: { id: string; username: string },
+    reply: FastifyReply,
+  ): Promise<string> {
+    const session = await app.refreshTokenService.issueSession({
+      id: user.id,
+      username: user.username,
+    });
+
+    reply.header('Set-Cookie', serializeRefreshTokenCookie(session.refreshToken));
+
+    return session.accessToken;
+  }
 
   // ── POST /auth/register ──────────────────────────────────
   app.post('/register', async (request, reply) => {
@@ -48,7 +73,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
     const user         = await userRepository.create({ username, email, password: passwordHash });
 
-    const token = app.signAccessToken({ id: user.id, username: user.username });
+    const token = await issueAuthSession(user, reply);
 
     return reply.status(201).send({ id: user.id, username: user.username, token });
   });
@@ -74,7 +99,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(401).send({ message: 'Credenciais inválidas.' });
     }
 
-    const token = app.signAccessToken({ id: user.id, username: user.username });
+    const token = await issueAuthSession(user, reply);
 
     return reply.status(200).send({
       id:       user.id,
@@ -82,6 +107,52 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       token,
       message:  'Acesso autorizado.',
     });
+  });
+
+  // ── POST /auth/refresh ───────────────────────────────────
+  app.post('/refresh', async (request, reply) => {
+    const refreshToken = parseCookieValue(request.headers.cookie, REFRESH_TOKEN_COOKIE_NAME);
+
+    if (!refreshToken) {
+      reply.header('Set-Cookie', serializeClearedRefreshTokenCookie());
+      return reply.status(401).send({ message: 'Refresh token inválido ou expirado.' });
+    }
+
+    try {
+      const session = await app.refreshTokenService.rotateSession(refreshToken);
+
+      reply.header('Set-Cookie', serializeRefreshTokenCookie(session.refreshToken));
+
+      return reply.status(200).send({
+        token: session.accessToken,
+        message: 'Sessão renovada.',
+      });
+    } catch (error) {
+      reply.header('Set-Cookie', serializeClearedRefreshTokenCookie());
+
+      if (error instanceof RefreshTokenReuseError) {
+        return reply.status(401).send({ message: 'Refresh token reutilizado ou inválido.' });
+      }
+
+      if (error instanceof RefreshTokenInvalidError) {
+        return reply.status(401).send({ message: 'Refresh token inválido ou expirado.' });
+      }
+
+      throw error;
+    }
+  });
+
+  // ── POST /auth/logout ────────────────────────────────────
+  app.post('/logout', async (request, reply) => {
+    const refreshToken = parseCookieValue(request.headers.cookie, REFRESH_TOKEN_COOKIE_NAME);
+
+    if (refreshToken) {
+      await app.refreshTokenService.revokeSession(refreshToken);
+    }
+
+    reply.header('Set-Cookie', serializeClearedRefreshTokenCookie());
+
+    return reply.status(200).send({ message: 'Sessão encerrada.' });
   });
 
   // ── GET /auth/me ─────────────────────────────────────────

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,11 +21,17 @@ import {
   createJwtSigner,
   createJwtVerifier,
 } from './config/jwt';
+import {
+  createRefreshTokenService,
+  type RefreshSessionStore,
+} from './core/services/refresh-token.service';
+import { createRedisRefreshSessionStore } from './infra/cache/refresh-session.store';
 
 export type BuildAppOptions = {
   jwtSecret?: string;
   logger?: boolean;
   readinessCheck?: () => Promise<ReadinessReport>;
+  refreshSessionStore?: RefreshSessionStore;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -39,10 +45,15 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   });
   const signAccessToken = createJwtSigner(options.jwtSecret);
   const verifyAccessToken = createJwtVerifier(options.jwtSecret);
+  const refreshTokenService = createRefreshTokenService({
+    jwtSecret: options.jwtSecret,
+    refreshSessionStore: options.refreshSessionStore ?? createRedisRefreshSessionStore(),
+  });
 
   app.decorate('authenticate', authenticate);
   app.decorate('signAccessToken', signAccessToken);
   app.decorate('verifyAccessToken', verifyAccessToken);
+  app.decorate('refreshTokenService', refreshTokenService);
 
   const readinessCheck = options.readinessCheck ?? runReadinessChecks;
 

--- a/backend/src/config/auth-session.ts
+++ b/backend/src/config/auth-session.ts
@@ -1,0 +1,92 @@
+const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+export const REFRESH_TOKEN_COOKIE_NAME = 'clutch_refresh';
+
+type CookieOptions = {
+  httpOnly: boolean;
+  sameSite: 'Lax' | 'Strict' | 'None';
+  secure: boolean;
+  path: string;
+  maxAge?: number;
+  expires?: Date;
+};
+
+function resolveRefreshTokenTtlSeconds(): number {
+  const rawValue = process.env['REFRESH_TOKEN_TTL_SECONDS'];
+  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
+
+  if (Number.isFinite(parsedValue) && parsedValue > 0) {
+    return Math.floor(parsedValue);
+  }
+
+  return DEFAULT_REFRESH_TOKEN_TTL_SECONDS;
+}
+
+function formatCookieDate(value: Date): string {
+  return value.toUTCString();
+}
+
+function serializeCookie(name: string, value: string, options: CookieOptions): string {
+  const attributes = [
+    `${name}=${encodeURIComponent(value)}`,
+    `Path=${options.path}`,
+    options.httpOnly ? 'HttpOnly' : null,
+    options.secure ? 'Secure' : null,
+    `SameSite=${options.sameSite}`,
+    typeof options.maxAge === 'number' ? `Max-Age=${options.maxAge}` : null,
+    options.expires instanceof Date ? `Expires=${formatCookieDate(options.expires)}` : null,
+  ].filter((attribute): attribute is string => Boolean(attribute));
+
+  return attributes.join('; ');
+}
+
+export function parseCookieValue(cookieHeader: string | undefined, name: string): string | null {
+  if (typeof cookieHeader !== 'string' || cookieHeader.trim().length === 0) {
+    return null;
+  }
+
+  const cookies = cookieHeader.split(';');
+
+  for (const rawCookie of cookies) {
+    const [rawName, ...rawValueParts] = rawCookie.trim().split('=');
+
+    if (rawName !== name || rawValueParts.length === 0) {
+      continue;
+    }
+
+    const rawValue = rawValueParts.join('=');
+
+    try {
+      return decodeURIComponent(rawValue);
+    } catch {
+      return rawValue;
+    }
+  }
+
+  return null;
+}
+
+export function getRefreshTokenCookieMaxAgeSeconds(): number {
+  return resolveRefreshTokenTtlSeconds();
+}
+
+export function serializeRefreshTokenCookie(token: string): string {
+  return serializeCookie(REFRESH_TOKEN_COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: 'Lax',
+    secure: process.env['NODE_ENV'] === 'production',
+    path: '/',
+    maxAge: getRefreshTokenCookieMaxAgeSeconds(),
+  });
+}
+
+export function serializeClearedRefreshTokenCookie(): string {
+  return serializeCookie(REFRESH_TOKEN_COOKIE_NAME, '', {
+    httpOnly: true,
+    sameSite: 'Lax',
+    secure: process.env['NODE_ENV'] === 'production',
+    path: '/',
+    maxAge: 0,
+    expires: new Date(0),
+  });
+}

--- a/backend/src/config/jwt.ts
+++ b/backend/src/config/jwt.ts
@@ -10,9 +10,17 @@ export interface JwtPayload {
   username: string;
 }
 
+export interface RefreshTokenPayload extends JwtPayload {
+  tokenType: 'refresh';
+  sessionId: string;
+  jti: string;
+}
+
 const JWT_ALGORITHM = 'HS256';
 const DEFAULT_DEVELOPMENT_JWT_SECRET = 'clutch-dev-secret-change-in-production';
 const BEARER_TOKEN_PATTERN = /^Bearer (?<token>[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)$/u;
+const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60 * 15;
+const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7;
 
 function resolveJwtSecret(secret?: string): Secret {
   if (typeof secret === 'string' && secret.trim().length > 0) {
@@ -50,16 +58,71 @@ function assertJwtPayload(payload: string | JsonWebTokenPayload): JwtPayload {
   return { id, username };
 }
 
+function resolveAccessTokenTtlSeconds(): number {
+  const rawValue = process.env['ACCESS_TOKEN_TTL_SECONDS'];
+  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
+
+  if (Number.isFinite(parsedValue) && parsedValue > 0) {
+    return Math.floor(parsedValue);
+  }
+
+  return DEFAULT_ACCESS_TOKEN_TTL_SECONDS;
+}
+
+function resolveRefreshTokenTtlSeconds(): number {
+  const rawValue = process.env['REFRESH_TOKEN_TTL_SECONDS'];
+  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
+
+  if (Number.isFinite(parsedValue) && parsedValue > 0) {
+    return Math.floor(parsedValue);
+  }
+
+  return DEFAULT_REFRESH_TOKEN_TTL_SECONDS;
+}
+
+function assertRefreshTokenPayload(payload: string | JsonWebTokenPayload): RefreshTokenPayload {
+  if (!isJwtPayload(payload)) {
+    throw new Error('Refresh token invalido.');
+  }
+
+  const { id, username, tokenType, sessionId, jti } = payload;
+
+  if (
+    typeof id !== 'string' ||
+    typeof username !== 'string' ||
+    tokenType !== 'refresh' ||
+    typeof sessionId !== 'string' ||
+    typeof jti !== 'string'
+  ) {
+    throw new Error('Payload de refresh token invalido.');
+  }
+
+  return {
+    id,
+    username,
+    tokenType,
+    sessionId,
+    jti,
+  };
+}
+
 export function createJwtSigner(secret?: string) {
   const resolvedSecret = resolveJwtSecret(secret);
 
   return (payload: JwtPayload): string => {
     const signOptions: SignOptions = {
       algorithm: JWT_ALGORITHM,
-      expiresIn: '7d',
+      expiresIn: `${resolveAccessTokenTtlSeconds()}s`,
     };
 
-    return jwt.sign(payload, resolvedSecret, signOptions);
+    return jwt.sign(
+      {
+        ...payload,
+        tokenType: 'access',
+      },
+      resolvedSecret,
+      signOptions,
+    );
   };
 }
 
@@ -75,6 +138,34 @@ export function createJwtVerifier(secret?: string) {
     const payload = jwt.verify(token, resolvedSecret, verifyOptions);
 
     return assertJwtPayload(payload);
+  };
+}
+
+export function createRefreshTokenSigner(secret?: string) {
+  const resolvedSecret = resolveJwtSecret(secret);
+
+  return (payload: RefreshTokenPayload): string => {
+    const signOptions: SignOptions = {
+      algorithm: JWT_ALGORITHM,
+      expiresIn: `${resolveRefreshTokenTtlSeconds()}s`,
+    };
+
+    return jwt.sign(payload, resolvedSecret, signOptions);
+  };
+}
+
+export function createRefreshTokenVerifier(secret?: string) {
+  const resolvedSecret = resolveJwtSecret(secret);
+
+  return (token: string): RefreshTokenPayload => {
+    const verifyOptions: VerifyOptions = {
+      algorithms: [JWT_ALGORITHM],
+      ignoreExpiration: false,
+    };
+
+    const payload = jwt.verify(token, resolvedSecret, verifyOptions);
+
+    return assertRefreshTokenPayload(payload);
   };
 }
 

--- a/backend/src/core/services/refresh-token.service.ts
+++ b/backend/src/core/services/refresh-token.service.ts
@@ -1,0 +1,214 @@
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import { getRefreshTokenCookieMaxAgeSeconds } from '../../config/auth-session';
+import {
+  createJwtSigner,
+  createRefreshTokenSigner,
+  createRefreshTokenVerifier,
+  type JwtPayload,
+  type RefreshTokenPayload,
+} from '../../config/jwt';
+
+export type RefreshSessionRecord = {
+  sessionId: string;
+  userId: string;
+  username: string;
+  tokenHash: string;
+};
+
+/* eslint-disable no-unused-vars */
+export type RefreshSessionStore = {
+  get: (sessionId: string) => Promise<RefreshSessionRecord | null>;
+  set: (sessionId: string, session: RefreshSessionRecord, ttlSeconds: number) => Promise<void>;
+  delete: (sessionId: string) => Promise<void>;
+};
+
+export class RefreshTokenReuseError extends Error {
+  constructor() {
+    super('Refresh token reutilizado ou invalido.');
+    this.name = 'RefreshTokenReuseError';
+  }
+}
+
+export class RefreshTokenInvalidError extends Error {
+  constructor() {
+    super('Refresh token invalido ou expirado.');
+    this.name = 'RefreshTokenInvalidError';
+  }
+}
+
+function hashRefreshToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function hashesMatch(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, 'utf8');
+  const rightBuffer = Buffer.from(right, 'utf8');
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function buildSessionRecord(
+  payload: RefreshTokenPayload,
+  token: string,
+): RefreshSessionRecord {
+  return {
+    sessionId: payload.sessionId,
+    userId: payload.id,
+    username: payload.username,
+    tokenHash: hashRefreshToken(token),
+  };
+}
+
+function assertRefreshSessionPayload(payload: RefreshTokenPayload, session: RefreshSessionRecord): void {
+  if (payload.sessionId !== session.sessionId || payload.id !== session.userId || payload.username !== session.username) {
+    throw new RefreshTokenInvalidError();
+  }
+}
+
+export function createInMemoryRefreshSessionStore(): RefreshSessionStore {
+  const sessions = new Map<string, { expiresAt: number; value: RefreshSessionRecord }>();
+
+  return {
+    async get(sessionId: string): Promise<RefreshSessionRecord | null> {
+      const entry = sessions.get(sessionId);
+
+      if (!entry) {
+        return null;
+      }
+
+      if (entry.expiresAt <= Date.now()) {
+        sessions.delete(sessionId);
+        return null;
+      }
+
+      return entry.value;
+    },
+
+    async set(
+      sessionId: string,
+      session: RefreshSessionRecord,
+      ttlSeconds: number,
+    ): Promise<void> {
+      sessions.set(sessionId, {
+        expiresAt: Date.now() + (ttlSeconds * 1000),
+        value: session,
+      });
+    },
+
+    async delete(sessionId: string): Promise<void> {
+      sessions.delete(sessionId);
+    },
+  };
+}
+
+export type IssueRefreshSessionInput = JwtPayload;
+
+export type RefreshSessionResult = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type RefreshTokenService = {
+  issueSession(input: IssueRefreshSessionInput): Promise<RefreshSessionResult>;
+  rotateSession(refreshToken: string): Promise<RefreshSessionResult>;
+  revokeSession(refreshToken: string): Promise<void>;
+};
+/* eslint-enable no-unused-vars */
+
+export type CreateRefreshTokenServiceOptions = {
+  refreshSessionStore: RefreshSessionStore;
+  jwtSecret?: string;
+};
+
+export function createRefreshTokenService(
+  options: CreateRefreshTokenServiceOptions,
+): RefreshTokenService {
+  const refreshSessionStore = options.refreshSessionStore;
+  const signAccessToken = createJwtSigner(options.jwtSecret);
+  const signRefreshToken = createRefreshTokenSigner(options.jwtSecret);
+  const verifyRefreshToken = createRefreshTokenVerifier(options.jwtSecret);
+  const refreshTokenTtlSeconds = getRefreshTokenCookieMaxAgeSeconds();
+
+  async function persistRefreshToken(refreshToken: string, payload: RefreshTokenPayload): Promise<void> {
+    await refreshSessionStore.set(
+      payload.sessionId,
+      buildSessionRecord(payload, refreshToken),
+      refreshTokenTtlSeconds,
+    );
+  }
+
+  return {
+    async issueSession(input: IssueRefreshSessionInput): Promise<RefreshSessionResult> {
+      const accessToken = signAccessToken(input);
+      const refreshPayload: RefreshTokenPayload = {
+        ...input,
+        tokenType: 'refresh',
+        sessionId: randomUUID(),
+        jti: randomUUID(),
+      };
+      const refreshToken = signRefreshToken(refreshPayload);
+
+      await persistRefreshToken(refreshToken, refreshPayload);
+
+      return {
+        accessToken,
+        refreshToken,
+      };
+    },
+
+    async rotateSession(refreshToken: string): Promise<RefreshSessionResult> {
+      let payload: RefreshTokenPayload;
+
+      try {
+        payload = verifyRefreshToken(refreshToken);
+      } catch {
+        throw new RefreshTokenInvalidError();
+      }
+
+      const existingSession = await refreshSessionStore.get(payload.sessionId);
+
+      if (!existingSession) {
+        throw new RefreshTokenInvalidError();
+      }
+
+      if (!hashesMatch(existingSession.tokenHash, hashRefreshToken(refreshToken))) {
+        await refreshSessionStore.delete(payload.sessionId);
+        throw new RefreshTokenReuseError();
+      }
+
+      assertRefreshSessionPayload(payload, existingSession);
+
+      const nextPayload: RefreshTokenPayload = {
+        ...payload,
+        tokenType: 'refresh',
+        jti: randomUUID(),
+      };
+
+      const nextAccessToken = signAccessToken({
+        id: payload.id,
+        username: payload.username,
+      });
+      const nextRefreshToken = signRefreshToken(nextPayload);
+
+      await persistRefreshToken(nextRefreshToken, nextPayload);
+
+      return {
+        accessToken: nextAccessToken,
+        refreshToken: nextRefreshToken,
+      };
+    },
+
+    async revokeSession(refreshToken: string): Promise<void> {
+      try {
+        const payload = verifyRefreshToken(refreshToken);
+        await refreshSessionStore.delete(payload.sessionId);
+      } catch {
+        // Logout precisa ser idempotente e limpar o cookie mesmo com token ausente ou invalido.
+      }
+    },
+  };
+}

--- a/backend/src/infra/cache/redis.ts
+++ b/backend/src/infra/cache/redis.ts
@@ -27,6 +27,7 @@ export const REDIS_KEYS = {
   presenceFeed:   (userId: string) => `realtime:presence:${userId}`,
   notifications:  (userId: string) => `notifications:${userId}`,
   friendsList:    (userId: string) => `friends:${userId}`,
+  refreshSession: (sessionId: string) => `auth:refresh:${sessionId}`,
   presenceUpdate: 'presence:updates',
 } as const;
 

--- a/backend/src/infra/cache/refresh-session.store.ts
+++ b/backend/src/infra/cache/refresh-session.store.ts
@@ -1,0 +1,36 @@
+import { redis, REDIS_KEYS } from './redis';
+import type {
+  RefreshSessionRecord,
+  RefreshSessionStore,
+} from '../../core/services/refresh-token.service';
+
+export function createRedisRefreshSessionStore(): RefreshSessionStore {
+  return {
+    async get(sessionId: string): Promise<RefreshSessionRecord | null> {
+      const payload = await redis.get(REDIS_KEYS.refreshSession(sessionId));
+
+      if (!payload) {
+        return null;
+      }
+
+      return JSON.parse(payload) as RefreshSessionRecord;
+    },
+
+    async set(
+      sessionId: string,
+      session: RefreshSessionRecord,
+      ttlSeconds: number,
+    ): Promise<void> {
+      await redis.set(
+        REDIS_KEYS.refreshSession(sessionId),
+        JSON.stringify(session),
+        'EX',
+        ttlSeconds,
+      );
+    },
+
+    async delete(sessionId: string): Promise<void> {
+      await redis.del(REDIS_KEYS.refreshSession(sessionId));
+    },
+  };
+}

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
 import { FastifyRequest, FastifyReply } from 'fastify';
 import type { JwtPayload } from '../config/jwt';
+import type { RefreshTokenService } from '../core/services/refresh-token.service';
 
 // ─────────────────────────────────────────────────────────────
 // Type augmentation — adiciona authenticate ao FastifyInstance
@@ -12,6 +13,7 @@ declare module 'fastify' {
     authenticate(request: FastifyRequest, reply: FastifyReply): Promise<void>;
     signAccessToken(payload: JwtPayload): string;
     verifyAccessToken(token: string): JwtPayload;
+    refreshTokenService: RefreshTokenService;
   }
 
   interface FastifyRequest {

--- a/backend/tests/helpers/build-app.ts
+++ b/backend/tests/helpers/build-app.ts
@@ -3,6 +3,7 @@ import {
   buildApp as createApp,
   type BuildAppOptions,
 } from '../../src/app';
+import { createInMemoryRefreshSessionStore } from '../../src/core/services/refresh-token.service';
 
 export const TEST_JWT_SECRET = 'clutch-test-secret';
 
@@ -12,6 +13,7 @@ export const buildApp = async (
   return createApp({
     jwtSecret: TEST_JWT_SECRET,
     logger: false,
+    refreshSessionStore: createInMemoryRefreshSessionStore(),
     ...options,
   });
 };

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildApp, generateTestToken, TEST_JWT_SECRET } from '../../helpers/build-app';
 import jwt from 'jsonwebtoken';
+import { REFRESH_TOKEN_COOKIE_NAME } from '@/config/auth-session';
 
 vi.mock('@/core/repositories/user.repository', () => ({
   userRepository: {
@@ -32,6 +33,22 @@ const mockUser = {
   updatedAt:     new Date(),
 };
 
+function extractCookieHeader(setCookieHeader: string | string[] | undefined): string {
+  const rawHeader = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
+
+  if (typeof rawHeader !== 'string') {
+    throw new Error('Set-Cookie ausente no response de teste.');
+  }
+
+  const [cookie] = rawHeader.split(';', 1);
+
+  if (typeof cookie !== 'string' || cookie.length === 0) {
+    throw new Error('Cookie invalido no response de teste.');
+  }
+
+  return cookie;
+}
+
 describe('Auth Routes', () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -49,8 +66,9 @@ describe('Auth Routes', () => {
 
       expect(response.statusCode).toBe(201);
       expect(response.json()).toHaveProperty('token');
+      expect(String(response.headers['set-cookie'])).toContain(REFRESH_TOKEN_COOKIE_NAME);
       await app.close();
-    });
+    }, 10_000);
 
     it('retorna 409 quando usuário já existe', async () => {
       vi.mocked(userRepository.existsByEmailOrUsername).mockResolvedValue(true);
@@ -93,6 +111,7 @@ describe('Auth Routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json()).toHaveProperty('token');
+      expect(String(response.headers['set-cookie'])).toContain(REFRESH_TOKEN_COOKIE_NAME);
       await app.close();
     });
 
@@ -211,6 +230,84 @@ describe('Auth Routes', () => {
       });
 
       expect(response.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('rotaciona o refresh token e rejeita reuse do token anterior', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(mockUser);
+      vi.mocked(userRepository.findById).mockResolvedValue(mockUser);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true as never);
+
+      const app = await buildApp();
+      const loginResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        payload: { email: 'player@clutch.gg', password: 'password123' },
+      });
+
+      const initialRefreshCookie = extractCookieHeader(loginResponse.headers['set-cookie']);
+
+      const refreshResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: { cookie: initialRefreshCookie },
+      });
+
+      expect(refreshResponse.statusCode).toBe(200);
+      expect(refreshResponse.json()).toHaveProperty('token');
+
+      const rotatedRefreshCookie = extractCookieHeader(refreshResponse.headers['set-cookie']);
+      expect(rotatedRefreshCookie).not.toBe(initialRefreshCookie);
+
+      const meResponse = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: {
+          Authorization: `Bearer ${refreshResponse.json().token as string}`,
+        },
+      });
+
+      expect(meResponse.statusCode).toBe(200);
+
+      const replayResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: { cookie: initialRefreshCookie },
+      });
+
+      expect(replayResponse.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('logout invalida a sessao de refresh', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(mockUser);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true as never);
+
+      const app = await buildApp();
+      const loginResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        payload: { email: 'player@clutch.gg', password: 'password123' },
+      });
+
+      const refreshCookie = extractCookieHeader(loginResponse.headers['set-cookie']);
+
+      const logoutResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/logout',
+        headers: { cookie: refreshCookie },
+      });
+
+      expect(logoutResponse.statusCode).toBe(200);
+      expect(String(logoutResponse.headers['set-cookie'])).toContain(`${REFRESH_TOKEN_COOKIE_NAME}=`);
+
+      const refreshAfterLogoutResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: { cookie: refreshCookie },
+      });
+
+      expect(refreshAfterLogoutResponse.statusCode).toBe(401);
       await app.close();
     });
   });

--- a/backend/tests/unit/config/jwt.test.ts
+++ b/backend/tests/unit/config/jwt.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import jwt from 'jsonwebtoken';
 import {
+  createRefreshTokenSigner,
+  createRefreshTokenVerifier,
   createJwtSigner,
   createJwtVerifier,
   extractBearerToken,
@@ -21,6 +23,27 @@ describe('JWT config', () => {
     expect(verifyAccessToken(token)).toEqual({
       id: 'user-id-1',
       username: 'clutchplayer',
+    });
+  });
+
+  it('assina e valida refresh token com sessionId e jti', () => {
+    const signRefreshToken = createRefreshTokenSigner(secret);
+    const verifyRefreshToken = createRefreshTokenVerifier(secret);
+
+    const token = signRefreshToken({
+      id: 'user-id-1',
+      username: 'clutchplayer',
+      tokenType: 'refresh',
+      sessionId: 'session-1',
+      jti: 'refresh-1',
+    });
+
+    expect(verifyRefreshToken(token)).toEqual({
+      id: 'user-id-1',
+      username: 'clutchplayer',
+      tokenType: 'refresh',
+      sessionId: 'session-1',
+      jti: 'refresh-1',
     });
   });
 
@@ -88,6 +111,23 @@ describe('JWT config', () => {
     });
 
     expect(() => verifyAccessToken(token)).toThrow();
+  });
+
+  it('rejeita refresh token com payload incompleto', () => {
+    const verifyRefreshToken = createRefreshTokenVerifier(secret);
+    const token = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+      },
+      secret,
+      {
+        algorithm: 'HS256',
+        expiresIn: '7d',
+      },
+    );
+
+    expect(() => verifyRefreshToken(token)).toThrow();
   });
 
   it('extrai apenas bearer token valido', () => {

--- a/backend/tests/unit/core/refresh-token.service.test.ts
+++ b/backend/tests/unit/core/refresh-token.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInMemoryRefreshSessionStore,
+  createRefreshTokenService,
+  RefreshTokenInvalidError,
+  RefreshTokenReuseError,
+} from '@/core/services/refresh-token.service';
+
+describe('refresh token service', () => {
+  const jwtSecret = 'refresh-token-test-secret';
+
+  it('emite access token e refresh token para uma nova sessao', async () => {
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore: createInMemoryRefreshSessionStore(),
+    });
+
+    const session = await service.issueSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+    });
+
+    expect(session.accessToken).toBeTypeOf('string');
+    expect(session.refreshToken).toBeTypeOf('string');
+    expect(session.accessToken).not.toBe(session.refreshToken);
+  });
+
+  it('rotaciona o refresh token e invalida o anterior por reuse', async () => {
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore: createInMemoryRefreshSessionStore(),
+    });
+
+    const initialSession = await service.issueSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+    });
+
+    const rotatedSession = await service.rotateSession(initialSession.refreshToken);
+
+    expect(rotatedSession.refreshToken).not.toBe(initialSession.refreshToken);
+    await expect(service.rotateSession(initialSession.refreshToken)).rejects.toBeInstanceOf(RefreshTokenReuseError);
+  });
+
+  it('rejeita refresh token invalido ou expirado', async () => {
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore: createInMemoryRefreshSessionStore(),
+    });
+
+    await expect(service.rotateSession('token-invalido')).rejects.toBeInstanceOf(RefreshTokenInvalidError);
+  });
+
+  it('revoga sessao sem falhar quando o token esta ausente ou invalido', async () => {
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore: createInMemoryRefreshSessionStore(),
+    });
+
+    await expect(service.revokeSession('token-invalido')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { AUTH_SESSION_COOKIE_NAME, getAuthSessionCookieOptions } from '@/lib/auth/session';
+import {
+  appendRefreshSetCookie,
+  setAccessSessionCookie,
+} from '@/lib/auth/backend-refresh';
 import {
   logServerEvent,
   REQUEST_ID_HEADER,
@@ -154,11 +157,8 @@ export async function POST(request: Request) {
     { status: 200 },
   );
 
-  response.cookies.set(
-    AUTH_SESSION_COOKIE_NAME,
-    sessionResult.data.token,
-    getAuthSessionCookieOptions(),
-  );
+  setAccessSessionCookie(response, sessionResult.data.token);
+  appendRefreshSetCookie(response, backendResponse.headers.get('set-cookie'));
 
   logServerEvent('info', 'frontend_auth_login_success', 'Frontend auth login completed', {
     requestId,

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,23 +1,52 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+import {
+  appendRefreshSetCookie,
+  clearAccessSessionCookie,
+  clearRefreshSessionCookie,
+} from '@/lib/auth/backend-refresh';
 import { logServerEvent, REQUEST_ID_HEADER, resolveServerRequestId } from '@/lib/server/logger';
+import { buildApiUrl } from '@/services/http/client';
 
 export async function POST(request: NextRequest) {
   const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
   const startedAt = Date.now();
-  const response = NextResponse.json({ message: 'Sessao encerrada.' }, { status: 200 });
+  let backendResponse: Response | null = null;
 
-  response.cookies.set(
-    AUTH_SESSION_COOKIE_NAME,
-    '',
-    getClearedAuthSessionCookieOptions(),
+  try {
+    backendResponse = await fetch(buildApiUrl('/auth/logout'), {
+      method: 'POST',
+      headers: {
+        [REQUEST_ID_HEADER]: requestId,
+        ...(request.headers.get('cookie')
+          ? { cookie: request.headers.get('cookie') as string }
+          : {}),
+      },
+      cache: 'no-store',
+    });
+  } catch {
+    backendResponse = null;
+  }
+
+  const status = backendResponse && !backendResponse.ok ? backendResponse.status : 200;
+  const response = NextResponse.json(
+    {
+      message:
+        backendResponse && !backendResponse.ok
+          ? 'Falha ao encerrar a sessao.'
+          : 'Sessao encerrada.',
+    },
+    { status },
   );
+
+  clearAccessSessionCookie(response);
+  clearRefreshSessionCookie(response);
+  appendRefreshSetCookie(response, backendResponse?.headers.get('set-cookie') ?? null);
 
   logServerEvent('info', 'frontend_auth_logout', 'Frontend auth logout completed', {
     requestId,
     method: request.method,
     path: request.nextUrl.pathname,
-    status: 200,
+    status,
     duration_ms: Date.now() - startedAt,
   });
 

--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -1,5 +1,12 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { AUTH_SESSION_COOKIE_NAME, getClearedAuthSessionCookieOptions } from '@/lib/auth/session';
+import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
+import {
+  appendRefreshSetCookie,
+  clearAccessSessionCookie,
+  clearRefreshSessionCookie,
+  refreshAuthSession,
+  setAccessSessionCookie,
+} from '@/lib/auth/backend-refresh';
 import {
   logServerEvent,
   REQUEST_ID_HEADER,
@@ -8,6 +15,20 @@ import {
 } from '@/lib/server/logger';
 import { authSessionSchema } from '@/schemas/auth';
 import { buildApiUrl } from '@/services/http/client';
+
+async function fetchAuthenticatedSession(
+  accessToken: string,
+  requestId: string,
+): Promise<Response> {
+  return fetch(buildApiUrl('/auth/me'), {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      [REQUEST_ID_HEADER]: requestId,
+    },
+    cache: 'no-store',
+  });
+}
 
 export async function GET(request: NextRequest) {
   const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
@@ -33,13 +54,7 @@ export async function GET(request: NextRequest) {
   let backendResponse: Response;
 
   try {
-    backendResponse = await fetch(buildApiUrl('/auth/me'), {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        [REQUEST_ID_HEADER]: requestId,
-      },
-    });
+    backendResponse = await fetchAuthenticatedSession(token, requestId);
   } catch (error) {
     logServerEvent('error', 'frontend_auth_me_backend_unreachable', 'Frontend auth session restore could not reach backend', {
       requestId,
@@ -52,6 +67,86 @@ export async function GET(request: NextRequest) {
       { message: 'Nao foi possivel contatar o backend de autenticacao.' },
       { status: 502 },
     );
+  }
+
+  if (backendResponse.status === 401) {
+    const refreshResult = await refreshAuthSession(
+      requestId,
+      request.headers.get('cookie'),
+    );
+
+    if (!refreshResult.ok) {
+      const response = NextResponse.json(
+        { message: 'Token invalido ou expirado.' },
+        { status: refreshResult.status },
+      );
+
+      clearAccessSessionCookie(response);
+      clearRefreshSessionCookie(response);
+      appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      logServerEvent('warn', 'frontend_auth_me_refresh_rejected', 'Frontend auth session refresh was rejected', {
+        requestId,
+        status: refreshResult.status,
+        duration_ms: Date.now() - startedAt,
+      });
+
+      return response;
+    }
+
+    try {
+      backendResponse = await fetchAuthenticatedSession(refreshResult.accessToken, requestId);
+    } catch (error) {
+      logServerEvent('error', 'frontend_auth_me_backend_unreachable', 'Frontend auth session restore could not reach backend after refresh', {
+        requestId,
+        status: 502,
+        duration_ms: Date.now() - startedAt,
+        ...serializeServerError(error),
+      });
+
+      const response = NextResponse.json(
+        { message: 'Nao foi possivel contatar o backend de autenticacao.' },
+        { status: 502 },
+      );
+
+      setAccessSessionCookie(response, refreshResult.accessToken);
+      appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      return response;
+    }
+
+    const payloadAfterRefresh = await backendResponse.json().catch(() => null);
+    const parsedAfterRefresh = authSessionSchema.safeParse(payloadAfterRefresh);
+
+    if (!backendResponse.ok || !parsedAfterRefresh.success) {
+      const response = NextResponse.json(
+        {
+          message: backendResponse.ok
+            ? 'Resposta invalida do backend de sessao.'
+            : 'Falha ao restaurar a sessao.',
+        },
+        { status: backendResponse.ok ? 502 : backendResponse.status },
+      );
+
+      clearAccessSessionCookie(response);
+      clearRefreshSessionCookie(response);
+      appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      return response;
+    }
+
+    const response = NextResponse.json(parsedAfterRefresh.data, { status: 200 });
+    setAccessSessionCookie(response, refreshResult.accessToken);
+    appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+    logServerEvent('info', 'frontend_auth_me_success', 'Frontend auth session restored after refresh', {
+      requestId,
+      status: 200,
+      duration_ms: Date.now() - startedAt,
+      username: parsedAfterRefresh.data.username,
+    });
+
+    return response;
   }
 
   const payload = await backendResponse.json().catch(() => null);
@@ -75,11 +170,7 @@ export async function GET(request: NextRequest) {
     );
 
     if (backendResponse.status === 401) {
-      response.cookies.set(
-        AUTH_SESSION_COOKIE_NAME,
-        '',
-        getClearedAuthSessionCookieOptions(),
-      );
+      clearAccessSessionCookie(response);
     }
 
     return response;

--- a/frontend/src/app/api/auth/presence-token/route.ts
+++ b/frontend/src/app/api/auth/presence-token/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
 import {
-  AUTH_SESSION_COOKIE_NAME,
-  getClearedAuthSessionCookieOptions,
-} from '@/lib/auth/session';
+  appendRefreshSetCookie,
+  clearAccessSessionCookie,
+  clearRefreshSessionCookie,
+  refreshAuthSession,
+  setAccessSessionCookie,
+} from '@/lib/auth/backend-refresh';
 import {
   logServerEvent,
   REQUEST_ID_HEADER,
@@ -10,6 +14,17 @@ import {
   serializeServerError,
 } from '@/lib/server/logger';
 import { buildApiUrl } from '@/services/http/client';
+
+async function validateAccessToken(accessToken: string, requestId: string): Promise<Response> {
+  return fetch(buildApiUrl('/auth/me'), {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      [REQUEST_ID_HEADER]: requestId,
+    },
+    cache: 'no-store',
+  });
+}
 
 export async function GET(request: NextRequest) {
   const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
@@ -35,14 +50,7 @@ export async function GET(request: NextRequest) {
   let backendResponse: Response;
 
   try {
-    backendResponse = await fetch(buildApiUrl('/auth/me'), {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        [REQUEST_ID_HEADER]: requestId,
-      },
-      cache: 'no-store',
-    });
+    backendResponse = await validateAccessToken(token, requestId);
   } catch (error) {
     logServerEvent('error', 'frontend_presence_token_backend_unreachable', 'Frontend presence token validation could not reach backend', {
       requestId,
@@ -55,6 +63,73 @@ export async function GET(request: NextRequest) {
       { message: 'Nao foi possivel validar a sessao de realtime.' },
       { status: 502 },
     );
+  }
+
+  if (backendResponse.status === 401) {
+    const refreshResult = await refreshAuthSession(
+      requestId,
+      request.headers.get('cookie'),
+    );
+
+    if (!refreshResult.ok) {
+      const response = NextResponse.json(
+        { message: 'Token invalido ou expirado.' },
+        { status: refreshResult.status },
+      );
+
+      clearAccessSessionCookie(response);
+      clearRefreshSessionCookie(response);
+      appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      return response;
+    }
+
+    try {
+      backendResponse = await validateAccessToken(refreshResult.accessToken, requestId);
+    } catch (error) {
+      logServerEvent('error', 'frontend_presence_token_backend_unreachable', 'Frontend presence token validation could not reach backend after refresh', {
+        requestId,
+        status: 502,
+        duration_ms: Date.now() - startedAt,
+        ...serializeServerError(error),
+      });
+
+      const response = NextResponse.json(
+        { message: 'Nao foi possivel validar a sessao de realtime.' },
+        { status: 502 },
+      );
+
+      setAccessSessionCookie(response, refreshResult.accessToken);
+      appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      return response;
+    }
+
+    if (!backendResponse.ok) {
+      const response = NextResponse.json(
+        { message: 'Nao foi possivel validar a sessao de realtime.' },
+        { status: backendResponse.status },
+      );
+
+      clearAccessSessionCookie(response);
+      clearRefreshSessionCookie(response);
+      appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      return response;
+    }
+
+    const response = NextResponse.json({ token: refreshResult.accessToken }, { status: 200 });
+    response.headers.set('Cache-Control', 'no-store');
+    setAccessSessionCookie(response, refreshResult.accessToken);
+    appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+    logServerEvent('info', 'frontend_presence_token_success', 'Frontend presence token issued', {
+      requestId,
+      status: 200,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return response;
   }
 
   if (!backendResponse.ok) {
@@ -76,11 +151,7 @@ export async function GET(request: NextRequest) {
     );
 
     if (backendResponse.status === 401) {
-      response.cookies.set(
-        AUTH_SESSION_COOKIE_NAME,
-        '',
-        getClearedAuthSessionCookieOptions(),
-      );
+      clearAccessSessionCookie(response);
     }
 
     return response;

--- a/frontend/src/app/api/auth/refresh/route.ts
+++ b/frontend/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import {
+  appendRefreshSetCookie,
+  clearAccessSessionCookie,
+  clearRefreshSessionCookie,
+  refreshAuthSession,
+  setAccessSessionCookie,
+} from '@/lib/auth/backend-refresh';
+import {
+  logServerEvent,
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+} from '@/lib/server/logger';
+
+export async function POST(request: NextRequest) {
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const startedAt = Date.now();
+
+  logServerEvent('info', 'frontend_auth_refresh_start', 'Frontend auth refresh started', {
+    requestId,
+    method: request.method,
+    path: request.nextUrl.pathname,
+  });
+
+  const refreshResult = await refreshAuthSession(
+    requestId,
+    request.headers.get('cookie'),
+  );
+
+  if (!refreshResult.ok) {
+    const response = NextResponse.json(
+      {
+        message:
+          refreshResult.status === 401
+            ? 'Sessao invalida ou expirada.'
+            : 'Nao foi possivel renovar a sessao.',
+      },
+      { status: refreshResult.status },
+    );
+
+    clearAccessSessionCookie(response);
+    clearRefreshSessionCookie(response);
+    appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+    logServerEvent('warn', 'frontend_auth_refresh_rejected', 'Frontend auth refresh failed', {
+      requestId,
+      status: refreshResult.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return response;
+  }
+
+  const response = NextResponse.json({ message: 'Sessao renovada.' }, { status: 200 });
+
+  setAccessSessionCookie(response, refreshResult.accessToken);
+  appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+  logServerEvent('info', 'frontend_auth_refresh_success', 'Frontend auth refresh completed', {
+    requestId,
+    status: 200,
+    duration_ms: Date.now() - startedAt,
+  });
+
+  return response;
+}

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import {
-  AUTH_SESSION_COOKIE_NAME,
-  getAuthSessionCookieOptions,
-} from '@/lib/auth/session';
+  appendRefreshSetCookie,
+  setAccessSessionCookie,
+} from '@/lib/auth/backend-refresh';
 import {
   logServerEvent,
   REQUEST_ID_HEADER,
@@ -160,11 +160,8 @@ export async function POST(request: Request) {
     { status: 201 },
   );
 
-  response.cookies.set(
-    AUTH_SESSION_COOKIE_NAME,
-    sessionResult.data.token,
-    getAuthSessionCookieOptions(),
-  );
+  setAccessSessionCookie(response, sessionResult.data.token);
+  appendRefreshSetCookie(response, backendResponse.headers.get('set-cookie'));
 
   logServerEvent('info', 'frontend_auth_register_success', 'Frontend auth register completed', {
     requestId,

--- a/frontend/src/lib/auth/backend-refresh.ts
+++ b/frontend/src/lib/auth/backend-refresh.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from 'next/server';
+import {
+  AUTH_SESSION_COOKIE_NAME,
+  getAuthSessionCookieOptions,
+  getClearedAuthSessionCookieOptions,
+} from '@/lib/auth/session';
+import {
+  logServerEvent,
+  REQUEST_ID_HEADER,
+  serializeServerError,
+} from '@/lib/server/logger';
+import { refreshBackendResponseSchema } from '@/schemas/auth';
+import { buildApiUrl } from '@/services/http/client';
+
+export const REFRESH_SESSION_COOKIE_NAME = 'clutch_refresh';
+
+type RefreshAuthSessionSuccess = {
+  ok: true;
+  accessToken: string;
+  refreshSetCookie: string | null;
+};
+
+type RefreshAuthSessionFailure = {
+  ok: false;
+  status: number;
+  refreshSetCookie: string | null;
+  payload: unknown;
+};
+
+export type RefreshAuthSessionResult =
+  | RefreshAuthSessionSuccess
+  | RefreshAuthSessionFailure;
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export function appendRefreshSetCookie(response: NextResponse, setCookie: string | null): void {
+  if (typeof setCookie === 'string' && setCookie.length > 0) {
+    response.headers.append('set-cookie', setCookie);
+  }
+}
+
+export function setAccessSessionCookie(response: NextResponse, accessToken: string): void {
+  response.cookies.set(
+    AUTH_SESSION_COOKIE_NAME,
+    accessToken,
+    getAuthSessionCookieOptions(),
+  );
+}
+
+export function clearAccessSessionCookie(response: NextResponse): void {
+  response.cookies.set(
+    AUTH_SESSION_COOKIE_NAME,
+    '',
+    getClearedAuthSessionCookieOptions(),
+  );
+}
+
+export function clearRefreshSessionCookie(response: NextResponse): void {
+  response.cookies.set(
+    REFRESH_SESSION_COOKIE_NAME,
+    '',
+    {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      expires: new Date(0),
+      maxAge: 0,
+    },
+  );
+}
+
+export async function refreshAuthSession(
+  requestId: string,
+  cookieHeader: string | null,
+): Promise<RefreshAuthSessionResult> {
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(buildApiUrl('/auth/refresh'), {
+      method: 'POST',
+      headers: {
+        [REQUEST_ID_HEADER]: requestId,
+        ...(typeof cookieHeader === 'string' && cookieHeader.length > 0
+          ? { cookie: cookieHeader }
+          : {}),
+      },
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logServerEvent('error', 'frontend_auth_refresh_backend_unreachable', 'Frontend auth refresh could not reach backend', {
+      requestId,
+      status: 502,
+      ...serializeServerError(error),
+    });
+
+    return {
+      ok: false,
+      status: 502,
+      refreshSetCookie: null,
+      payload: {
+        message: 'Nao foi possivel contatar o backend de autenticacao.',
+      },
+    };
+  }
+
+  const refreshSetCookie = backendResponse.headers.get('set-cookie');
+  const payload = await readJsonBody(backendResponse);
+
+  if (!backendResponse.ok) {
+    return {
+      ok: false,
+      status: backendResponse.status,
+      refreshSetCookie,
+      payload,
+    };
+  }
+
+  const parsedPayload = refreshBackendResponseSchema.safeParse(payload);
+
+  if (!parsedPayload.success) {
+    return {
+      ok: false,
+      status: 502,
+      refreshSetCookie,
+      payload: {
+        message: 'Resposta invalida do backend de autenticacao.',
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    accessToken: parsedPayload.data.token,
+    refreshSetCookie,
+  };
+}

--- a/frontend/src/schemas/auth.ts
+++ b/frontend/src/schemas/auth.ts
@@ -53,6 +53,11 @@ export const authSessionSchema = z.object({
   email: z.string().email('Email inválido.'),
 });
 
+export const refreshBackendResponseSchema = z.object({
+  token: z.string().min(1),
+  message: z.string().min(1),
+});
+
 export type LoginRequestValues = z.infer<typeof loginRequestSchema>;
 export type LoginSession = z.infer<typeof loginSessionSchema>;
 export type RegisterRequestValues = z.infer<typeof registerRequestSchema>;

--- a/frontend/tests/unit/routes/auth-login-route.test.ts
+++ b/frontend/tests/unit/routes/auth-login-route.test.ts
@@ -16,7 +16,7 @@ describe('auth login route', () => {
     vi.unstubAllGlobals();
   });
 
-  it('sets an httpOnly cookie when login succeeds', async () => {
+  it('sets an httpOnly access cookie and forwards the refresh cookie when login succeeds', async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
 
@@ -33,6 +33,7 @@ describe('auth login route', () => {
           status: 200,
           headers: {
             'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=refresh-token; Path=/; HttpOnly; SameSite=Lax',
           },
         },
       );
@@ -56,9 +57,11 @@ describe('auth login route', () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(response.headers.get('set-cookie')).toContain(AUTH_SESSION_COOKIE_NAME);
-    expect(response.headers.get('set-cookie')).toContain('HttpOnly');
-    expect(response.headers.get('set-cookie')).toContain('jwt-token');
+    const setCookieHeader = response.headers.get('set-cookie');
+    expect(setCookieHeader).toContain(AUTH_SESSION_COOKIE_NAME);
+    expect(setCookieHeader).toContain('HttpOnly');
+    expect(setCookieHeader).toContain('jwt-token');
+    expect(setCookieHeader).toContain('clutch_refresh=refresh-token');
   });
 
   it('propagates invalid credentials without setting a session cookie', async () => {

--- a/frontend/tests/unit/routes/auth-logout-route.test.ts
+++ b/frontend/tests/unit/routes/auth-logout-route.test.ts
@@ -1,16 +1,34 @@
 import { NextRequest } from 'next/server';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { POST } from '@/app/api/auth/logout/route';
 
 describe('auth logout route', () => {
-  it('clears the session cookie', async () => {
+  it('clears the local session cookie and forwards the backend refresh cleanup cookie', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify({ message: 'Sessão encerrada.' }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=; Path=/; HttpOnly; Max-Age=0',
+          },
+        },
+      )) as typeof fetch,
+    );
+
     const response = await POST(
       new NextRequest('http://localhost/api/auth/logout', {
         method: 'POST',
+        headers: {
+          cookie: 'clutch_session=jwt-token; clutch_refresh=refresh-token',
+        },
       }),
     );
 
     expect(response.status).toBe(200);
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+    expect(response.headers.get('set-cookie')).toContain('clutch_refresh=');
   });
 });

--- a/frontend/tests/unit/routes/auth-me-route.test.ts
+++ b/frontend/tests/unit/routes/auth-me-route.test.ts
@@ -53,33 +53,65 @@ describe('auth me route', () => {
     });
   });
 
-  it('clears the cookie when the backend rejects the token', async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
+  it('refreshes the session when the backend rejects the access token', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
 
-      expect(headers.get('x-request-id')).toBeTruthy();
+      if (url.endsWith('/auth/me')) {
+        if (fetchMock.mock.calls.filter(([calledInput]) => String(calledInput).endsWith('/auth/me')).length === 1) {
+          return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
 
-      return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
-        status: 401,
-        headers: {
-          'Content-Type': 'application/json',
+        return new Response(
+          JSON.stringify({
+            id: 'user-1',
+            username: 'clutchplayer',
+            email: 'clutchplayer@clutch.gg',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          token: 'new-access-token',
+          message: 'Sessão renovada.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=refresh-rotated; Path=/; HttpOnly; SameSite=Lax',
+          },
         },
-      });
+      );
     });
 
     vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const request = new NextRequest('http://localhost/api/auth/me', {
       headers: {
-        cookie: 'clutch_session=expired-token',
+        cookie: 'clutch_session=expired-token; clutch_refresh=refresh-token',
       },
     });
 
     const response = await GET(request);
 
-    expect(response.status).toBe(401);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=new-access-token');
+    expect(response.headers.get('set-cookie')).toContain('clutch_refresh=refresh-rotated');
+    await expect(response.json()).resolves.toEqual({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
   });
 });
 

--- a/frontend/tests/unit/routes/auth-presence-token-route.test.ts
+++ b/frontend/tests/unit/routes/auth-presence-token-route.test.ts
@@ -50,33 +50,61 @@ describe('auth presence token route', () => {
     expect(response.headers.get('cache-control')).toBe('no-store');
   });
 
-  it('clears the cookie when the backend rejects the session token', async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
+  it('refreshes the websocket credential when the access token expires', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
 
-      expect(headers.get('x-request-id')).toBeTruthy();
+      if (url.endsWith('/auth/me')) {
+        if (fetchMock.mock.calls.filter(([calledInput]) => String(calledInput).endsWith('/auth/me')).length === 1) {
+          return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
 
-      return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
-        status: 401,
-        headers: {
-          'Content-Type': 'application/json',
+        return new Response(
+          JSON.stringify({
+            id: 'user-1',
+            username: 'clutchplayer',
+            email: 'clutchplayer@clutch.gg',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          token: 'new-access-token',
+          message: 'Sessão renovada.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=refresh-rotated; Path=/; HttpOnly; SameSite=Lax',
+          },
         },
-      });
+      );
     });
 
     vi.stubGlobal('fetch', fetchMock as typeof fetch);
 
     const request = new NextRequest('http://localhost/api/auth/presence-token', {
       headers: {
-        cookie: 'clutch_session=expired-token',
+        cookie: 'clutch_session=expired-token; clutch_refresh=refresh-token',
       },
     });
 
     const response = await GET(request);
 
-    expect(response.status).toBe(401);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=new-access-token');
+    expect(response.headers.get('set-cookie')).toContain('clutch_refresh=refresh-rotated');
+    await expect(response.json()).resolves.toEqual({ token: 'new-access-token' });
   });
 });
 

--- a/frontend/tests/unit/routes/auth-refresh-route.test.ts
+++ b/frontend/tests/unit/routes/auth-refresh-route.test.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '@/app/api/auth/refresh/route';
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
+
+describe('auth refresh route', () => {
+  beforeEach(() => {
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
+    vi.restoreAllMocks();
+  });
+
+  it('renews the access session and forwards the rotated refresh cookie', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify({
+          token: 'renewed-access-token',
+          message: 'Sessão renovada.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=rotated-refresh-token; Path=/; HttpOnly; SameSite=Lax',
+          },
+        },
+      )) as typeof fetch,
+    );
+
+    const response = await POST(
+      new NextRequest('http://localhost/api/auth/refresh', {
+        method: 'POST',
+        headers: {
+          cookie: 'clutch_refresh=initial-refresh-token',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=renewed-access-token');
+    expect(response.headers.get('set-cookie')).toContain('clutch_refresh=rotated-refresh-token');
+    await expect(response.json()).resolves.toEqual({ message: 'Sessao renovada.' });
+  });
+});
+
+afterAll(() => {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
+  if (typeof originalApiUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+});

--- a/frontend/tests/unit/routes/auth-register-route.test.ts
+++ b/frontend/tests/unit/routes/auth-register-route.test.ts
@@ -12,7 +12,7 @@ describe('auth register route', () => {
     vi.restoreAllMocks();
   });
 
-  it('sets an httpOnly cookie when register succeeds', async () => {
+  it('sets an httpOnly access cookie and forwards the refresh cookie when register succeeds', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => {
@@ -26,6 +26,7 @@ describe('auth register route', () => {
             status: 201,
             headers: {
               'Content-Type': 'application/json',
+              'Set-Cookie': 'clutch_refresh=refresh-register-token; Path=/; HttpOnly; SameSite=Lax',
             },
           },
         );
@@ -47,9 +48,11 @@ describe('auth register route', () => {
     );
 
     expect(response.status).toBe(201);
-    expect(response.headers.get('set-cookie')).toContain(AUTH_SESSION_COOKIE_NAME);
-    expect(response.headers.get('set-cookie')).toContain('HttpOnly');
-    expect(response.headers.get('set-cookie')).toContain('jwt-register-token');
+    const setCookieHeader = response.headers.get('set-cookie');
+    expect(setCookieHeader).toContain(AUTH_SESSION_COOKIE_NAME);
+    expect(setCookieHeader).toContain('HttpOnly');
+    expect(setCookieHeader).toContain('jwt-register-token');
+    expect(setCookieHeader).toContain('clutch_refresh=refresh-register-token');
   });
 
   it('returns friendly 409 without setting cookie', async () => {


### PR DESCRIPTION
﻿## Resumo
Implementa o fluxo de refresh token seguro com rotação por sessão, mantendo o contrato atual de login com access token no body e adicionando renovação transparente da sessão no backend e no frontend server-side. A estratégia escolhida usa Redis para armazenar o hash do refresh token por sessão, evitando migration nova e permitindo detecção de reuse.

## O que foi alterado
- Backend auth:
- separação entre access token e refresh token no módulo JWT
- adição de cookie seguro de refresh token e rotas `POST /auth/refresh` e `POST /auth/logout`
- store de sessão de refresh em Redis com hash do token, rotação e bloqueio de reuse
- Frontend server-side:
- propagação do refresh cookie nas rotas de login e registro
- nova rota `POST /api/auth/refresh`
- renovação automática de sessão em `GET /api/auth/me` e `GET /api/auth/presence-token` quando o access token expira
- integração de logout com invalidação da sessão no backend e limpeza local dos cookies
- Testes:
- cobertura unitária do JWT e do serviço de refresh
- cobertura de integração do backend para login, refresh, reuse e logout
- cobertura das rotas server-side do frontend para login, refresh, sessão, presence token e logout

## Motivação
O backend operava apenas com access token de longa duração, o que aumentava a janela de ataque e não permitia rotação de sessão. Esta mudança reduz o acoplamento com tokens longos, prepara o caminho para lifetime curto do access token e adiciona revogação por sessão sem quebrar a integração existente do frontend.

## Como validar
- Executar no host:
- `cd backend && npm run test -- tests/unit/config/jwt.test.ts tests/unit/core/refresh-token.service.test.ts tests/integration/routes/auth.routes.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- `cd frontend && npm run test -- tests/unit/routes/auth-login-route.test.ts tests/unit/routes/auth-register-route.test.ts tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-presence-token-route.test.ts tests/unit/routes/auth-logout-route.test.ts tests/unit/routes/auth-refresh-route.test.ts`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- Executar no stack containerizado:
- `docker compose restart backend frontend`
- `docker compose exec -T backend sh -lc 'npm run test'`
- `docker compose exec -T backend sh -lc 'npm run typecheck'`
- `docker compose exec -T backend sh -lc 'npm run lint'`
- Validar pelo proxy:
- `GET http://localhost/api/health`
- `GET http://localhost/presence/health`
- `POST http://localhost/api/auth/login`
- `GET http://localhost/api/auth/me`
- `POST http://localhost/api/auth/refresh`
- `POST http://localhost/api/auth/logout`
- confirmar que novo refresh após logout retorna `401`

## Riscos e impactos
- O auth path passa a depender de Redis para refresh token; falhas nesse store afetam renovação de sessão, mas não a validação do access token já emitido.
- A validação operacional com `docker compose up -d --build` encontrou falha externa do daemon no export do frontend (`rpc error: ... EOF`). O stack de desenvolvimento permaneceu válido porque `backend` e `frontend` usam bind mount do workspace e a validação foi concluída após restart dos serviços.
- O host local continua não sendo fonte de verdade para a suíte completa do backend por causa dos testes antigos que dependem de `localhost:5432`; a suíte completa foi validada no container do backend.

## Evidências
- `docker compose exec -T backend sh -lc 'npm run test'` executou `188` testes com sucesso no container.
- Validação operacional via proxy resultou em:
- `GET /api/health` → `200`
- `GET /presence/health` → `200`
- `POST /api/auth/login` → `200`
- `GET /api/auth/me` após login → `200`
- `POST /api/auth/refresh` → `200`
- `GET /api/auth/me` após refresh → `200`
- `POST /api/auth/logout` → `200`
- novo `POST /api/auth/refresh` após logout → `401`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #162
