### PR TITLE
refactor(auth): reduzir tempo de vida do access token

### DIFF
--- a/backend/src/api/middlewares/authenticate.ts
+++ b/backend/src/api/middlewares/authenticate.ts
@@ -1,4 +1,5 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
+import jwt from 'jsonwebtoken';
 import { extractBearerToken, type JwtPayload } from '../../config/jwt';
 
 // ─────────────────────────────────────────────────────────────
@@ -21,13 +22,40 @@ export async function authenticate(
     const token = extractBearerToken(request.headers.authorization);
 
     if (!token) {
+      request.log.warn({
+        event: 'auth_access_token_rejected',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: 'missing_access_token',
+      }, 'Access token is missing or malformed');
       return reply.status(401).send({ message: 'Token inválido ou expirado.' });
     }
 
     const payload = request.server.verifyAccessToken(token) as JwtPayload;
     request.userId   = payload.id;
     request.username = payload.username;
-  } catch {
+  } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      request.log.warn({
+        event: 'auth_access_token_expired',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+      }, 'Access token expired');
+    } else {
+      request.log.warn({
+        event: 'auth_access_token_rejected',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: 'invalid_access_token',
+      }, 'Access token rejected');
+    }
+
     return reply.status(401).send({ message: 'Token inválido ou expirado.' });
   }
 }

--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -114,12 +114,28 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     const refreshToken = parseCookieValue(request.headers.cookie, REFRESH_TOKEN_COOKIE_NAME);
 
     if (!refreshToken) {
+      request.log.warn({
+        event: 'auth_refresh_failed',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: 'missing_refresh_token',
+      }, 'Refresh token is missing');
       reply.header('Set-Cookie', serializeClearedRefreshTokenCookie());
       return reply.status(401).send({ message: 'Refresh token inválido ou expirado.' });
     }
 
     try {
       const session = await app.refreshTokenService.rotateSession(refreshToken);
+
+      request.log.info({
+        event: 'auth_access_token_refreshed',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 200,
+      }, 'Access token refreshed');
 
       reply.header('Set-Cookie', serializeRefreshTokenCookie(session.refreshToken));
 
@@ -131,10 +147,26 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       reply.header('Set-Cookie', serializeClearedRefreshTokenCookie());
 
       if (error instanceof RefreshTokenReuseError) {
+        request.log.warn({
+          event: 'auth_refresh_failed',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          status: 401,
+          reason: 'refresh_token_reuse',
+        }, 'Refresh token reuse detected');
         return reply.status(401).send({ message: 'Refresh token reutilizado ou inválido.' });
       }
 
       if (error instanceof RefreshTokenInvalidError) {
+        request.log.warn({
+          event: 'auth_refresh_failed',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          status: 401,
+          reason: 'invalid_refresh_token',
+        }, 'Refresh token rejected');
         return reply.status(401).send({ message: 'Refresh token inválido ou expirado.' });
       }
 

--- a/backend/src/config/jwt.ts
+++ b/backend/src/config/jwt.ts
@@ -19,7 +19,8 @@ export interface RefreshTokenPayload extends JwtPayload {
 const JWT_ALGORITHM = 'HS256';
 const DEFAULT_DEVELOPMENT_JWT_SECRET = 'clutch-dev-secret-change-in-production';
 const BEARER_TOKEN_PATTERN = /^Bearer (?<token>[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)$/u;
-const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60 * 15;
+// 10 minutos reduz a janela de ataque sem forcar refresh excessivo em navegacao comum.
+const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60 * 10;
 const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7;
 
 function resolveJwtSecret(secret?: string): Secret {
@@ -69,6 +70,10 @@ function resolveAccessTokenTtlSeconds(): number {
   return DEFAULT_ACCESS_TOKEN_TTL_SECONDS;
 }
 
+export function getAccessTokenTtlSeconds(): number {
+  return resolveAccessTokenTtlSeconds();
+}
+
 function resolveRefreshTokenTtlSeconds(): number {
   const rawValue = process.env['REFRESH_TOKEN_TTL_SECONDS'];
   const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
@@ -112,7 +117,7 @@ export function createJwtSigner(secret?: string) {
   return (payload: JwtPayload): string => {
     const signOptions: SignOptions = {
       algorithm: JWT_ALGORITHM,
-      expiresIn: `${resolveAccessTokenTtlSeconds()}s`,
+      expiresIn: `${getAccessTokenTtlSeconds()}s`,
     };
 
     return jwt.sign(

--- a/backend/src/core/services/refresh-token.service.ts
+++ b/backend/src/core/services/refresh-token.service.ts
@@ -132,6 +132,31 @@ export function createRefreshTokenService(
   const signRefreshToken = createRefreshTokenSigner(options.jwtSecret);
   const verifyRefreshToken = createRefreshTokenVerifier(options.jwtSecret);
   const refreshTokenTtlSeconds = getRefreshTokenCookieMaxAgeSeconds();
+  const sessionLocks = new Map<string, { tail: Promise<void>; pending: number }>();
+
+  async function withSessionLock<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    const existingLock = sessionLocks.get(sessionId) ?? { tail: Promise.resolve(), pending: 0 };
+    existingLock.pending += 1;
+    const previousTail = existingLock.tail;
+    let releaseCurrentLock!: () => void;
+    existingLock.tail = new Promise<void>((resolve) => {
+      releaseCurrentLock = resolve;
+    });
+    sessionLocks.set(sessionId, existingLock);
+
+    await previousTail;
+
+    try {
+      return await operation();
+    } finally {
+      existingLock.pending -= 1;
+      releaseCurrentLock();
+
+      if (existingLock.pending === 0) {
+        sessionLocks.delete(sessionId);
+      }
+    }
+  }
 
   async function persistRefreshToken(refreshToken: string, payload: RefreshTokenPayload): Promise<void> {
     await refreshSessionStore.set(
@@ -169,43 +194,47 @@ export function createRefreshTokenService(
         throw new RefreshTokenInvalidError();
       }
 
-      const existingSession = await refreshSessionStore.get(payload.sessionId);
+      return withSessionLock(payload.sessionId, async () => {
+        const existingSession = await refreshSessionStore.get(payload.sessionId);
 
-      if (!existingSession) {
-        throw new RefreshTokenInvalidError();
-      }
+        if (!existingSession) {
+          throw new RefreshTokenInvalidError();
+        }
 
-      if (!hashesMatch(existingSession.tokenHash, hashRefreshToken(refreshToken))) {
-        await refreshSessionStore.delete(payload.sessionId);
-        throw new RefreshTokenReuseError();
-      }
+        if (!hashesMatch(existingSession.tokenHash, hashRefreshToken(refreshToken))) {
+          await refreshSessionStore.delete(payload.sessionId);
+          throw new RefreshTokenReuseError();
+        }
 
-      assertRefreshSessionPayload(payload, existingSession);
+        assertRefreshSessionPayload(payload, existingSession);
 
-      const nextPayload: RefreshTokenPayload = {
-        ...payload,
-        tokenType: 'refresh',
-        jti: randomUUID(),
-      };
+        const nextPayload: RefreshTokenPayload = {
+          ...payload,
+          tokenType: 'refresh',
+          jti: randomUUID(),
+        };
 
-      const nextAccessToken = signAccessToken({
-        id: payload.id,
-        username: payload.username,
+        const nextAccessToken = signAccessToken({
+          id: payload.id,
+          username: payload.username,
+        });
+        const nextRefreshToken = signRefreshToken(nextPayload);
+
+        await persistRefreshToken(nextRefreshToken, nextPayload);
+
+        return {
+          accessToken: nextAccessToken,
+          refreshToken: nextRefreshToken,
+        };
       });
-      const nextRefreshToken = signRefreshToken(nextPayload);
-
-      await persistRefreshToken(nextRefreshToken, nextPayload);
-
-      return {
-        accessToken: nextAccessToken,
-        refreshToken: nextRefreshToken,
-      };
     },
 
     async revokeSession(refreshToken: string): Promise<void> {
       try {
         const payload = verifyRefreshToken(refreshToken);
-        await refreshSessionStore.delete(payload.sessionId);
+        await withSessionLock(payload.sessionId, async () => {
+          await refreshSessionStore.delete(payload.sessionId);
+        });
       } catch {
         // Logout precisa ser idempotente e limpar o cookie mesmo com token ausente ou invalido.
       }

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -233,6 +233,19 @@ describe('Auth Routes', () => {
       await app.close();
     });
 
+    it('retorna 401 no refresh quando o cookie de refresh esta ausente', async () => {
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(String(response.headers['set-cookie'])).toContain(`${REFRESH_TOKEN_COOKIE_NAME}=`);
+      await app.close();
+    });
+
     it('rotaciona o refresh token e rejeita reuse do token anterior', async () => {
       vi.mocked(userRepository.findByEmail).mockResolvedValue(mockUser);
       vi.mocked(userRepository.findById).mockResolvedValue(mockUser);

--- a/backend/tests/unit/config/jwt.test.ts
+++ b/backend/tests/unit/config/jwt.test.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import {
   createRefreshTokenSigner,
   createRefreshTokenVerifier,
+  getAccessTokenTtlSeconds,
   createJwtSigner,
   createJwtVerifier,
   extractBearerToken,
@@ -62,6 +63,21 @@ describe('JWT config', () => {
         typ: 'JWT',
       },
     });
+  });
+
+  it('usa um TTL curto de 10 minutos para o access token', () => {
+    const signAccessToken = createJwtSigner(secret);
+    const token = signAccessToken({
+      id: 'user-id-1',
+      username: 'clutchplayer',
+    });
+
+    const decoded = jwt.decode(token) as jwt.JwtPayload | null;
+
+    expect(getAccessTokenTtlSeconds()).toBe(60 * 10);
+    expect(decoded?.exp).toBeTypeOf('number');
+    expect(decoded?.iat).toBeTypeOf('number');
+    expect((decoded?.exp ?? 0) - (decoded?.iat ?? 0)).toBe(60 * 10);
   });
 
   it('rejeita token invalido', () => {

--- a/backend/tests/unit/core/refresh-token.service.test.ts
+++ b/backend/tests/unit/core/refresh-token.service.test.ts
@@ -42,6 +42,36 @@ describe('refresh token service', () => {
     await expect(service.rotateSession(initialSession.refreshToken)).rejects.toBeInstanceOf(RefreshTokenReuseError);
   });
 
+  it('serializa refresh concorrente da mesma sessao sem gerar duas rotacoes validas', async () => {
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore: createInMemoryRefreshSessionStore(),
+    });
+
+    const initialSession = await service.issueSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+    });
+
+    const results = await Promise.allSettled([
+      service.rotateSession(initialSession.refreshToken),
+      service.rotateSession(initialSession.refreshToken),
+    ]);
+
+    const fulfilledResults = results.filter(
+      (result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof service.rotateSession>>> =>
+        result.status === 'fulfilled',
+    );
+    const rejectedResults = results.filter(
+      (result): result is PromiseRejectedResult =>
+        result.status === 'rejected',
+    );
+
+    expect(fulfilledResults).toHaveLength(1);
+    expect(rejectedResults).toHaveLength(1);
+    expect(rejectedResults[0]?.reason).toBeInstanceOf(RefreshTokenReuseError);
+  });
+
   it('rejeita refresh token invalido ou expirado', async () => {
     const service = createRefreshTokenService({
       jwtSecret,

--- a/frontend/tests/unit/routes/auth-me-route.test.ts
+++ b/frontend/tests/unit/routes/auth-me-route.test.ts
@@ -113,6 +113,50 @@ describe('auth me route', () => {
       email: 'clutchplayer@clutch.gg',
     });
   });
+
+  it('clears the session when the refresh token is invalid', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/me')) {
+        return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(
+        JSON.stringify({
+          message: 'Refresh token inválido ou expirado.',
+        }),
+        {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0',
+          },
+        },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const request = new NextRequest('http://localhost/api/auth/me', {
+      headers: {
+        cookie: 'clutch_session=expired-token; clutch_refresh=invalid-refresh-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+    expect(response.headers.get('set-cookie')).toContain('clutch_refresh=');
+    await expect(response.json()).resolves.toEqual({
+      message: 'Token invalido ou expirado.',
+    });
+  });
 });
 
 afterAll(() => {

--- a/frontend/tests/unit/routes/auth-presence-token-route.test.ts
+++ b/frontend/tests/unit/routes/auth-presence-token-route.test.ts
@@ -106,6 +106,50 @@ describe('auth presence token route', () => {
     expect(response.headers.get('set-cookie')).toContain('clutch_refresh=refresh-rotated');
     await expect(response.json()).resolves.toEqual({ token: 'new-access-token' });
   });
+
+  it('returns 401 and clears cookies when refresh fails', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/me')) {
+        return new Response(JSON.stringify({ message: 'Token inválido ou expirado.' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(
+        JSON.stringify({
+          message: 'Refresh token inválido ou expirado.',
+        }),
+        {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0',
+          },
+        },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const request = new NextRequest('http://localhost/api/auth/presence-token', {
+      headers: {
+        cookie: 'clutch_session=expired-token; clutch_refresh=invalid-refresh-token',
+      },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+    expect(response.headers.get('set-cookie')).toContain('clutch_refresh=');
+    await expect(response.json()).resolves.toEqual({
+      message: 'Token invalido ou expirado.',
+    });
+  });
 });
 
 afterAll(() => {


### PR DESCRIPTION
﻿## Resumo
Reduz o tempo de vida padrão do access token para 10 minutos, usando o fluxo de refresh já entregue como fonte de verdade da sessão. A mudança mantém o contrato HTTP atual, reduz a janela de ataque e reforça a previsibilidade do refresh no backend e no frontend server-side.

## O que foi alterado
- Backend auth:
- reduz o TTL padrão do access token em `backend/src/config/jwt.ts`
- adiciona logs estruturados para expiração do access token, refresh bem-sucedido e falha de refresh
- serializa rotações concorrentes do mesmo `sessionId` no serviço de refresh para evitar resultados inconsistentes
- Testes backend:
- cobre o TTL efetivo do access token
- cobre refresh sem cookie
- cobre concorrência de refresh da mesma sessão
- Frontend server-side:
- mantém o fluxo atual de refresh transparente em `auth/me` e `presence-token`
- adiciona testes para falha de refresh limpando a sessão corretamente

## Motivação
O projeto já possui refresh token com rotação, então manter access token longo aumenta a janela de comprometimento sem necessidade. Reduzir o TTL do access token aproveita a base já existente e melhora a postura de segurança sem introduzir breaking change nem alterar a UX.

## Como validar
- Backend no host:
- `cd backend && npm run test -- tests/unit/config/jwt.test.ts tests/unit/core/refresh-token.service.test.ts tests/integration/routes/auth.routes.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- Frontend no host:
- `cd frontend && npm run test -- tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-presence-token-route.test.ts tests/unit/routes/auth-refresh-route.test.ts`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- Stack container-first:
- `docker compose up -d --build`
- `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- `GET http://localhost/api/health`
- `GET http://localhost/presence/health`
- `POST http://localhost/api/auth/login`
- expirar manualmente `clutch_session` mantendo `clutch_refresh` válido e validar:
- `GET http://localhost/api/auth/me` → `200`
- `GET http://localhost/api/auth/presence-token` → `200`
- expirar `clutch_session` com `clutch_refresh` inválido e validar:
- `GET http://localhost/api/auth/me` → `401`

## Riscos e impactos
- O branch foi originalmente criado antes do merge da `#162`, então esta PR foi rebaseada sobre `origin/develop` depois que a base entrou em `develop`. O diff final ficou restrito ao escopo da `#166`.
- O frontend em `next dev` ainda pode reiniciar conexões durante recompilações no Windows. A validação operacional foi executada com retry e o comportamento funcional esperado permaneceu estável.
- A serialização de refresh concorrente adiciona coordenação em memória por `sessionId` no processo do backend. O efeito é local ao runtime atual e não altera contrato externo.

## Evidências
- `git diff --name-only origin/develop...HEAD` retornou apenas 9 arquivos do escopo da `#166`.
- Revalidação executada após rebase sobre `origin/develop`.
- Eventos observados nos logs do backend:
- `auth_access_token_expired`
- `auth_access_token_refreshed`
- `auth_refresh_failed`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #166
