### PR TITLE
feat(auth): add refresh-token session revocation

### DIFF
--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -10,6 +10,8 @@ import {
 } from '../../config/auth-session';
 import {
   RefreshTokenInvalidError,
+  type RefreshSessionRevokeResult,
+  RefreshTokenRevokedError,
   RefreshTokenReuseError,
 } from '../../core/services/refresh-token.service';
 
@@ -154,8 +156,22 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
           path: request.url,
           status: 401,
           reason: 'refresh_token_reuse',
+          sessionId: error.sessionId,
         }, 'Refresh token reuse detected');
         return reply.status(401).send({ message: 'Refresh token reutilizado ou inválido.' });
+      }
+
+      if (error instanceof RefreshTokenRevokedError) {
+        request.log.warn({
+          event: 'auth_refresh_rejected_revoked_session',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          status: 401,
+          sessionId: error.sessionId,
+          reason: error.reason ?? 'revoked_session',
+        }, 'Refresh token rejected because session is revoked');
+        return reply.status(401).send({ message: 'Refresh token inválido ou expirado.' });
       }
 
       if (error instanceof RefreshTokenInvalidError) {
@@ -177,12 +193,39 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   // ── POST /auth/logout ────────────────────────────────────
   app.post('/logout', async (request, reply) => {
     const refreshToken = parseCookieValue(request.headers.cookie, REFRESH_TOKEN_COOKIE_NAME);
+    let revocationResult: RefreshSessionRevokeResult = {
+      sessionId: null,
+      status: 'noop',
+      reason: null,
+    };
 
     if (refreshToken) {
-      await app.refreshTokenService.revokeSession(refreshToken);
+      revocationResult = await app.refreshTokenService.revokeSession(refreshToken, 'logout');
+
+      if (revocationResult.status === 'revoked') {
+        request.log.info({
+          event: 'auth_session_revoked',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          status: 200,
+          sessionId: revocationResult.sessionId,
+          reason: revocationResult.reason,
+        }, 'Refresh session revoked');
+      }
     }
 
     reply.header('Set-Cookie', serializeClearedRefreshTokenCookie());
+
+    request.log.info({
+      event: 'auth_logout_completed',
+      requestId: request.id,
+      method: request.method,
+      path: request.url,
+      status: 200,
+      sessionId: revocationResult.sessionId,
+      reason: revocationResult.reason ?? (refreshToken ? 'logout_noop' : 'missing_refresh_token'),
+    }, 'Logout completed');
 
     return reply.status(200).send({ message: 'Sessão encerrada.' });
   });

--- a/backend/src/core/services/refresh-token.service.ts
+++ b/backend/src/core/services/refresh-token.service.ts
@@ -13,6 +13,10 @@ export type RefreshSessionRecord = {
   userId: string;
   username: string;
   tokenHash: string;
+  expiresAt: number;
+  status: 'active' | 'revoked';
+  revokedAt: number | null;
+  revokeReason: RefreshTokenRevokeReason | null;
 };
 
 /* eslint-disable no-unused-vars */
@@ -23,9 +27,12 @@ export type RefreshSessionStore = {
 };
 
 export class RefreshTokenReuseError extends Error {
-  constructor() {
+  readonly sessionId: string | null;
+
+  constructor(sessionId: string | null = null) {
     super('Refresh token reutilizado ou invalido.');
     this.name = 'RefreshTokenReuseError';
+    this.sessionId = sessionId;
   }
 }
 
@@ -35,6 +42,29 @@ export class RefreshTokenInvalidError extends Error {
     this.name = 'RefreshTokenInvalidError';
   }
 }
+
+export class RefreshTokenRevokedError extends Error {
+  readonly sessionId: string;
+  readonly reason: RefreshTokenRevokeReason | null;
+
+  constructor(sessionId: string, reason: RefreshTokenRevokeReason | null) {
+    super('Sessao de refresh revogada.');
+    this.name = 'RefreshTokenRevokedError';
+    this.sessionId = sessionId;
+    this.reason = reason;
+  }
+}
+
+export type RefreshTokenRevokeReason =
+  | 'logout'
+  | 'refresh_token_reuse'
+  | 'security';
+
+export type RefreshSessionRevokeResult = {
+  sessionId: string | null;
+  status: 'revoked' | 'noop';
+  reason: RefreshTokenRevokeReason | null;
+};
 
 function hashRefreshToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
@@ -54,13 +84,34 @@ function hashesMatch(left: string, right: string): boolean {
 function buildSessionRecord(
   payload: RefreshTokenPayload,
   token: string,
+  expiresAt: number,
 ): RefreshSessionRecord {
   return {
     sessionId: payload.sessionId,
     userId: payload.id,
     username: payload.username,
     tokenHash: hashRefreshToken(token),
+    expiresAt,
+    status: 'active',
+    revokedAt: null,
+    revokeReason: null,
   };
+}
+
+function buildRevokedSessionRecord(
+  session: RefreshSessionRecord,
+  reason: RefreshTokenRevokeReason,
+): RefreshSessionRecord {
+  return {
+    ...session,
+    status: 'revoked',
+    revokedAt: Date.now(),
+    revokeReason: reason,
+  };
+}
+
+function resolveSessionTtlSeconds(session: RefreshSessionRecord): number {
+  return Math.max(1, Math.ceil((session.expiresAt - Date.now()) / 1000));
 }
 
 function assertRefreshSessionPayload(payload: RefreshTokenPayload, session: RefreshSessionRecord): void {
@@ -115,7 +166,10 @@ export type RefreshSessionResult = {
 export type RefreshTokenService = {
   issueSession(input: IssueRefreshSessionInput): Promise<RefreshSessionResult>;
   rotateSession(refreshToken: string): Promise<RefreshSessionResult>;
-  revokeSession(refreshToken: string): Promise<void>;
+  revokeSession(
+    refreshToken: string,
+    reason?: RefreshTokenRevokeReason,
+  ): Promise<RefreshSessionRevokeResult>;
 };
 /* eslint-enable no-unused-vars */
 
@@ -159,9 +213,11 @@ export function createRefreshTokenService(
   }
 
   async function persistRefreshToken(refreshToken: string, payload: RefreshTokenPayload): Promise<void> {
+    const expiresAt = Date.now() + (refreshTokenTtlSeconds * 1000);
+
     await refreshSessionStore.set(
       payload.sessionId,
-      buildSessionRecord(payload, refreshToken),
+      buildSessionRecord(payload, refreshToken, expiresAt),
       refreshTokenTtlSeconds,
     );
   }
@@ -201,9 +257,26 @@ export function createRefreshTokenService(
           throw new RefreshTokenInvalidError();
         }
 
+        if (existingSession.status === 'revoked') {
+          throw new RefreshTokenRevokedError(
+            existingSession.sessionId,
+            existingSession.revokeReason,
+          );
+        }
+
         if (!hashesMatch(existingSession.tokenHash, hashRefreshToken(refreshToken))) {
-          await refreshSessionStore.delete(payload.sessionId);
-          throw new RefreshTokenReuseError();
+          const revokedSession = buildRevokedSessionRecord(
+            existingSession,
+            'refresh_token_reuse',
+          );
+
+          await refreshSessionStore.set(
+            payload.sessionId,
+            revokedSession,
+            resolveSessionTtlSeconds(existingSession),
+          );
+
+          throw new RefreshTokenReuseError(payload.sessionId);
         }
 
         assertRefreshSessionPayload(payload, existingSession);
@@ -229,15 +302,55 @@ export function createRefreshTokenService(
       });
     },
 
-    async revokeSession(refreshToken: string): Promise<void> {
+    async revokeSession(
+      refreshToken: string,
+      reason: RefreshTokenRevokeReason = 'logout',
+    ): Promise<RefreshSessionRevokeResult> {
+      let payload: RefreshTokenPayload;
+
       try {
-        const payload = verifyRefreshToken(refreshToken);
-        await withSessionLock(payload.sessionId, async () => {
-          await refreshSessionStore.delete(payload.sessionId);
-        });
+        payload = verifyRefreshToken(refreshToken);
       } catch {
         // Logout precisa ser idempotente e limpar o cookie mesmo com token ausente ou invalido.
+        return {
+          sessionId: null,
+          status: 'noop',
+          reason: null,
+        };
       }
+
+      return withSessionLock(payload.sessionId, async () => {
+        const existingSession = await refreshSessionStore.get(payload.sessionId);
+
+        if (!existingSession) {
+          return {
+            sessionId: payload.sessionId,
+            status: 'noop',
+            reason: null,
+          };
+        }
+
+        if (existingSession.status === 'revoked') {
+          return {
+            sessionId: existingSession.sessionId,
+            status: 'noop',
+            reason: existingSession.revokeReason,
+          };
+        }
+
+        const revokedSession = buildRevokedSessionRecord(existingSession, reason);
+        await refreshSessionStore.set(
+          payload.sessionId,
+          revokedSession,
+          resolveSessionTtlSeconds(existingSession),
+        );
+
+        return {
+          sessionId: payload.sessionId,
+          status: 'revoked',
+          reason,
+        };
+      });
     },
   };
 }

--- a/backend/tests/unit/core/refresh-token.service.test.ts
+++ b/backend/tests/unit/core/refresh-token.service.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   createInMemoryRefreshSessionStore,
   createRefreshTokenService,
+  type RefreshSessionRecord,
+  type RefreshSessionStore,
   RefreshTokenInvalidError,
+  RefreshTokenRevokedError,
   RefreshTokenReuseError,
 } from '@/core/services/refresh-token.service';
 
@@ -81,12 +84,104 @@ describe('refresh token service', () => {
     await expect(service.rotateSession('token-invalido')).rejects.toBeInstanceOf(RefreshTokenInvalidError);
   });
 
+  it('revoga a sessao atual e rejeita refresh posterior como sessao revogada', async () => {
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore: createInMemoryRefreshSessionStore(),
+    });
+
+    const session = await service.issueSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+    });
+
+    const revokeResult = await service.revokeSession(session.refreshToken, 'logout');
+
+    expect(revokeResult).toMatchObject({
+      status: 'revoked',
+      reason: 'logout',
+    });
+    await expect(service.rotateSession(session.refreshToken)).rejects.toBeInstanceOf(RefreshTokenRevokedError);
+    await expect(service.rotateSession(session.refreshToken)).rejects.toBeInstanceOf(RefreshTokenRevokedError);
+  });
+
+  it('preserva o ttl residual ao marcar a sessao como revogada', async () => {
+    const capturedTtls: number[] = [];
+    const sessions = new Map<string, RefreshSessionRecord>();
+    const refreshSessionStore: RefreshSessionStore = {
+      async get(sessionId: string) {
+        return sessions.get(sessionId) ?? null;
+      },
+      async set(sessionId: string, session: RefreshSessionRecord, ttlSeconds: number) {
+        capturedTtls.push(ttlSeconds);
+        sessions.set(sessionId, session);
+      },
+      async delete(sessionId: string) {
+        sessions.delete(sessionId);
+      },
+    };
+
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore,
+    });
+
+    const beforeIssue = Date.now();
+    const session = await service.issueSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+    });
+    const afterIssue = Date.now();
+
+    const storedSession = [...sessions.values()][0];
+
+    expect(storedSession).toBeDefined();
+
+    const issueTtl = capturedTtls[0];
+    if (typeof issueTtl !== 'number') {
+      throw new Error('TTL inicial da sessao nao foi capturado.');
+    }
+    expect(issueTtl).toBeGreaterThan(60 * 60 * 24 * 6);
+
+    await service.revokeSession(session.refreshToken, 'logout');
+
+    const revokeTtl = capturedTtls[1];
+    if (typeof revokeTtl !== 'number') {
+      throw new Error('TTL residual da sessao revogada nao foi capturado.');
+    }
+    expect(revokeTtl).toBeLessThanOrEqual(issueTtl);
+    expect(revokeTtl).toBeGreaterThanOrEqual(issueTtl - Math.ceil((afterIssue - beforeIssue) / 1000) - 2);
+    expect([...sessions.values()][0]).toMatchObject({
+      status: 'revoked',
+      revokeReason: 'logout',
+    });
+  });
+
+  it('mantem o bloqueio de reuse apos rotacao', async () => {
+    const service = createRefreshTokenService({
+      jwtSecret,
+      refreshSessionStore: createInMemoryRefreshSessionStore(),
+    });
+
+    const initialSession = await service.issueSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+    });
+
+    await service.rotateSession(initialSession.refreshToken);
+    await expect(service.rotateSession(initialSession.refreshToken)).rejects.toBeInstanceOf(RefreshTokenReuseError);
+  });
+
   it('revoga sessao sem falhar quando o token esta ausente ou invalido', async () => {
     const service = createRefreshTokenService({
       jwtSecret,
       refreshSessionStore: createInMemoryRefreshSessionStore(),
     });
 
-    await expect(service.revokeSession('token-invalido')).resolves.toBeUndefined();
+    await expect(service.revokeSession('token-invalido')).resolves.toMatchObject({
+      sessionId: null,
+      status: 'noop',
+      reason: null,
+    });
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
     environment:
       NODE_ENV: development
       WATCHPACK_POLLING: "true"
+      WATCHPACK_POLLING_INTERVAL: "1000"
+      CHOKIDAR_USEPOLLING: "true"
       INTERNAL_API_URL: http://backend:3344
       NEXT_PUBLIC_API_URL: http://localhost/api
       NEXT_PUBLIC_WS_URL: ws://localhost

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,16 @@
 import type { NextConfig } from 'next';
 
+function resolveWatchPollingInterval(): number {
+  const rawValue = process.env['WATCHPACK_POLLING_INTERVAL'];
+  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
+
+  if (Number.isFinite(parsedValue) && parsedValue >= 200) {
+    return Math.floor(parsedValue);
+  }
+
+  return 1000;
+}
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
@@ -14,6 +25,19 @@ const nextConfig: NextConfig = {
         hostname: 'images.igdb.com',
       },
     ],
+  },
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.watchOptions = {
+        ...config.watchOptions,
+        // Docker Desktop on Windows/WSL is more stable with polling plus an explicit ignore list.
+        poll: resolveWatchPollingInterval(),
+        aggregateTimeout: 300,
+        ignored: /(^|[\\/])(\.git|\.next|node_modules)([\\/]|$)/,
+      };
+    }
+
+    return config;
   },
 };
 

--- a/frontend/tests/unit/routes/auth-logout-route.test.ts
+++ b/frontend/tests/unit/routes/auth-logout-route.test.ts
@@ -1,21 +1,32 @@
 import { NextRequest } from 'next/server';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { POST } from '@/app/api/auth/logout/route';
 
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
+
 describe('auth logout route', () => {
-  it('clears the local session cookie and forwards the backend refresh cleanup cookie', async () => {
+  beforeEach(() => {
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
+    vi.restoreAllMocks();
+  });
+
+  it('clears the local session cookie and forwards the backend refresh revocation request', async () => {
+    const fetchHandler = vi.fn(async () => new Response(
+      JSON.stringify({ message: 'Sessão encerrada.' }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Set-Cookie': 'clutch_refresh=; Path=/; HttpOnly; Max-Age=0',
+        },
+      },
+    ));
+
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response(
-        JSON.stringify({ message: 'Sessão encerrada.' }),
-        {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json',
-            'Set-Cookie': 'clutch_refresh=; Path=/; HttpOnly; Max-Age=0',
-          },
-        },
-      )) as typeof fetch,
+      fetchHandler as typeof fetch,
     );
 
     const response = await POST(
@@ -28,7 +39,28 @@ describe('auth logout route', () => {
     );
 
     expect(response.status).toBe(200);
+    expect(fetchHandler).toHaveBeenCalledTimes(1);
+    const logoutCall = fetchHandler.mock.calls.at(0) as unknown as
+      | [RequestInfo | URL, RequestInit | undefined]
+      | undefined;
+    const requestInit = logoutCall?.[1];
+    expect(new Headers(requestInit?.headers).get('cookie')).toContain('clutch_refresh=refresh-token');
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
     expect(response.headers.get('set-cookie')).toContain('clutch_refresh=');
   });
+});
+
+afterAll(() => {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
+  if (typeof originalApiUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    return;
+  }
+
+  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
 });

--- a/frontend/tests/unit/routes/auth-me-route.test.ts
+++ b/frontend/tests/unit/routes/auth-me-route.test.ts
@@ -114,7 +114,7 @@ describe('auth me route', () => {
     });
   });
 
-  it('clears the session when the refresh token is invalid', async () => {
+  it('clears the session when the refresh session was revoked', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 

--- a/frontend/tests/unit/routes/auth-presence-token-route.test.ts
+++ b/frontend/tests/unit/routes/auth-presence-token-route.test.ts
@@ -107,7 +107,7 @@ describe('auth presence token route', () => {
     await expect(response.json()).resolves.toEqual({ token: 'new-access-token' });
   });
 
-  it('returns 401 and clears cookies when refresh fails', async () => {
+  it('returns 401 and clears cookies when the refresh session was revoked', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 

--- a/frontend/tests/unit/routes/auth-refresh-route.test.ts
+++ b/frontend/tests/unit/routes/auth-refresh-route.test.ts
@@ -44,6 +44,38 @@ describe('auth refresh route', () => {
     expect(response.headers.get('set-cookie')).toContain('clutch_refresh=rotated-refresh-token');
     await expect(response.json()).resolves.toEqual({ message: 'Sessao renovada.' });
   });
+
+  it('clears cookies when the backend rejects a revoked refresh session', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify({
+          message: 'Refresh token inválido ou expirado.',
+        }),
+        {
+          status: 401,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0',
+          },
+        },
+      )) as typeof fetch,
+    );
+
+    const response = await POST(
+      new NextRequest('http://localhost/api/auth/refresh', {
+        method: 'POST',
+        headers: {
+          cookie: 'clutch_refresh=revoked-refresh-token',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('set-cookie')).toContain('clutch_session=');
+    expect(response.headers.get('set-cookie')).toContain('clutch_refresh=');
+    await expect(response.json()).resolves.toEqual({ message: 'Sessao invalida ou expirada.' });
+  });
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Resumo
Esta PR implementa revogação explícita da sessão atual baseada em refresh token, preservando o contrato existente de login, refresh e logout. A sessão revogada passa a permanecer bloqueada até o fim do TTL residual e o frontend limpa a sessão local quando a revogação resulta em 401.

## O que foi alterado
- persistência de estado `revoked` na sessão de refresh, com preservação do TTL residual e rejeição explícita de refresh para sessão revogada
- logs estruturados de revogação e rejeição de refresh revogado no backend, sem expor tokens, cookies ou segredos
- testes de backend e frontend para logout, refresh revogado, limpeza de cookies e bloqueio repetido após revogação
- ajuste operacional já commitado em `12fce5f` para estabilizar o `next dev` no container e permitir a validação operacional via proxy

## Motivação
O fluxo de refresh já existia, mas ainda faltava uma revogação de sessão rastreável e verificável para permitir invalidação ativa da sessão atual antes do exp. Isso fecha a lacuna de segurança sem breaking change e prepara a base para cenários futuros como contenção de incidente e logout ampliado.

## Como validar
- `npm run test -- tests/unit/core/refresh-token.service.test.ts tests/integration/routes/auth.routes.test.ts` em `backend/`
- `npm run typecheck` e `npm run lint` em `backend/`
- `npm run test -- tests/unit/routes/auth-logout-route.test.ts tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-presence-token-route.test.ts tests/unit/routes/auth-refresh-route.test.ts` em `frontend/`
- `npm run typecheck` e `npm run lint` em `frontend/`
- `docker compose up -d --build`
- `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- via proxy: login `200`, logout `200`, refresh revogado `401`, `/api/auth/me` após revogação `401`, `/api/auth/presence-token` após revogação `401`

## Riscos e impactos
- a serialização de revogação/rotação continua local ao processo do backend; múltiplas réplicas exigirão coordenação distribuída em follow-up próprio
- o ajuste de estabilidade do frontend afeta apenas o runtime de desenvolvimento em container e não altera contrato HTTP nem build de produção

## Evidências
- validação operacional da revogação passou via proxy com os seguintes resultados: login `200`, logout `200`, refresh revogado `401`, `/api/auth/me` após revogação `401`, `/api/auth/presence-token` após revogação `401`
- o runtime do frontend no container deixou de registrar `ENOMEM` após o ajuste de polling restrito a desenvolvimento

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #161
