### PR TITLE
feat(auth): add session observability across auth flows

### DIFF
--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -77,6 +77,16 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
 
     const token = await issueAuthSession(user, reply);
 
+    request.log.info({
+      event: 'auth_register_succeeded',
+      requestId: request.id,
+      method: request.method,
+      path: request.url,
+      status: 201,
+      userId: user.id,
+      username: user.username,
+    }, 'Auth register succeeded');
+
     return reply.status(201).send({ id: user.id, username: user.username, token });
   });
 
@@ -93,15 +103,42 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     const user = await userRepository.findByEmail(email);
 
     if (!user) {
+      request.log.warn({
+        event: 'auth_login_failed',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: 'invalid_credentials',
+      }, 'Auth login failed');
       return reply.status(401).send({ message: 'Credenciais inválidas.' });
     }
 
     const passwordMatch = await bcrypt.compare(password, user.password_hash);
     if (!passwordMatch) {
+      request.log.warn({
+        event: 'auth_login_failed',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: 'invalid_credentials',
+        userId: user.id,
+      }, 'Auth login failed');
       return reply.status(401).send({ message: 'Credenciais inválidas.' });
     }
 
     const token = await issueAuthSession(user, reply);
+
+    request.log.info({
+      event: 'auth_login_succeeded',
+      requestId: request.id,
+      method: request.method,
+      path: request.url,
+      status: 200,
+      userId: user.id,
+      username: user.username,
+    }, 'Auth login succeeded');
 
     return reply.status(200).send({
       id:       user.id,

--- a/backend/tests/helpers/build-app.ts
+++ b/backend/tests/helpers/build-app.ts
@@ -8,7 +8,7 @@ import { createInMemoryRefreshSessionStore } from '../../src/core/services/refre
 export const TEST_JWT_SECRET = 'clutch-test-secret';
 
 export const buildApp = async (
-  options: Omit<BuildAppOptions, 'jwtSecret' | 'logger'> = {},
+  options: Omit<BuildAppOptions, 'jwtSecret'> = {},
 ): Promise<FastifyInstance> => {
   return createApp({
     jwtSecret: TEST_JWT_SECRET,

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -49,6 +49,43 @@ function extractCookieHeader(setCookieHeader: string | string[] | undefined): st
   return cookie;
 }
 
+type JsonLogEntry = Record<string, unknown>;
+
+function captureJsonLogs() {
+  const entries: JsonLogEntry[] = [];
+
+  const collect = (chunk: string | Uint8Array): boolean => {
+    const serialized = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+
+    for (const line of serialized.split('\n')) {
+      const trimmed = line.trim();
+
+      if (!trimmed.startsWith('{')) {
+        continue;
+      }
+
+      try {
+        entries.push(JSON.parse(trimmed) as JsonLogEntry);
+      } catch {
+        // Ignora linhas nao-JSON emitidas por bibliotecas.
+      }
+    }
+
+    return true;
+  };
+
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stderr.write);
+
+  return {
+    entries,
+    restore() {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+}
+
 describe('Auth Routes', () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -143,6 +180,60 @@ describe('Auth Routes', () => {
       expect(response.statusCode).toBe(401);
       await app.close();
     });
+
+    it('emite logs estruturados de sucesso com requestId sem vazar token', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(mockUser);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true as never);
+      const capturedLogs = captureJsonLogs();
+
+      const app = await buildApp({ logger: true });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        headers: { 'x-request-id': 'req-login-log-1' },
+        payload: { email: 'player@clutch.gg', password: 'password123' },
+      });
+
+      capturedLogs.restore();
+
+      expect(response.statusCode).toBe(200);
+      const logEntry = capturedLogs.entries.find((entry) => entry.event === 'auth_login_succeeded');
+      expect(logEntry).toMatchObject({
+        event: 'auth_login_succeeded',
+        requestId: 'req-login-log-1',
+        status: 200,
+        userId: 'user-id-1',
+      });
+      expect(JSON.stringify(capturedLogs.entries)).not.toContain('jwt-token');
+      expect(JSON.stringify(capturedLogs.entries)).not.toContain('password123');
+      await app.close();
+    });
+
+    it('emite logs estruturados de falha de login com requestId', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(null);
+      const capturedLogs = captureJsonLogs();
+
+      const app = await buildApp({ logger: true });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        headers: { 'x-request-id': 'req-login-log-2' },
+        payload: { email: 'naoexiste@clutch.gg', password: 'password123' },
+      });
+
+      capturedLogs.restore();
+
+      expect(response.statusCode).toBe(401);
+      const logEntry = capturedLogs.entries.find((entry) => entry.event === 'auth_login_failed');
+      expect(logEntry).toMatchObject({
+        event: 'auth_login_failed',
+        requestId: 'req-login-log-2',
+        status: 401,
+        reason: 'invalid_credentials',
+      });
+      expect(JSON.stringify(capturedLogs.entries)).not.toContain('password123');
+      await app.close();
+    });
   });
 
   describe('GET /auth/me', () => {
@@ -186,7 +277,8 @@ describe('Auth Routes', () => {
     });
 
     it('retorna 401 com token expirado', async () => {
-      const app = await buildApp();
+      const capturedLogs = captureJsonLogs();
+      const app = await buildApp({ logger: true });
       const expiredToken = jwt.sign(
         {
           id: 'user-id-1',
@@ -205,7 +297,14 @@ describe('Auth Routes', () => {
         headers: { Authorization: `Bearer ${expiredToken}` },
       });
 
+      capturedLogs.restore();
+
       expect(response.statusCode).toBe(401);
+      const logEntry = capturedLogs.entries.find((entry) => entry.event === 'auth_access_token_expired');
+      expect(logEntry).toMatchObject({
+        event: 'auth_access_token_expired',
+        status: 401,
+      });
       await app.close();
     });
 
@@ -321,6 +420,64 @@ describe('Auth Routes', () => {
       });
 
       expect(refreshAfterLogoutResponse.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('mantem logs estruturados para revogacao e rejeicao de refresh revogado', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(mockUser);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true as never);
+      const capturedLogs = captureJsonLogs();
+
+      const app = await buildApp({ logger: true });
+      const loginResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        headers: { 'x-request-id': 'req-login-log-3' },
+        payload: { email: 'player@clutch.gg', password: 'password123' },
+      });
+
+      const refreshCookie = extractCookieHeader(loginResponse.headers['set-cookie']);
+
+      const logoutResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/logout',
+        headers: {
+          cookie: refreshCookie,
+          'x-request-id': 'req-logout-log-1',
+        },
+      });
+
+      const refreshAfterLogoutResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: {
+          cookie: refreshCookie,
+          'x-request-id': 'req-refresh-log-1',
+        },
+      });
+
+      capturedLogs.restore();
+
+      expect(logoutResponse.statusCode).toBe(200);
+      expect(refreshAfterLogoutResponse.statusCode).toBe(401);
+      expect(capturedLogs.entries.find((entry) => entry.event === 'auth_session_revoked')).toMatchObject({
+        event: 'auth_session_revoked',
+        requestId: 'req-logout-log-1',
+        status: 200,
+        reason: 'logout',
+      });
+      expect(capturedLogs.entries.find((entry) => entry.event === 'auth_logout_completed')).toMatchObject({
+        event: 'auth_logout_completed',
+        requestId: 'req-logout-log-1',
+        status: 200,
+      });
+      expect(capturedLogs.entries.find((entry) => entry.event === 'auth_refresh_rejected_revoked_session')).toMatchObject({
+        event: 'auth_refresh_rejected_revoked_session',
+        requestId: 'req-refresh-log-1',
+        status: 401,
+        reason: 'logout',
+      });
+      expect(JSON.stringify(capturedLogs.entries)).not.toContain('clutch_refresh=');
       await app.close();
     });
   });

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
   clearRefreshSessionCookie(response);
   appendRefreshSetCookie(response, backendResponse?.headers.get('set-cookie') ?? null);
 
-  logServerEvent('info', 'frontend_auth_logout', 'Frontend auth logout completed', {
+  logServerEvent('info', 'frontend_auth_logout_completed', 'Frontend auth logout completed', {
     requestId,
     method: request.method,
     path: request.nextUrl.pathname,

--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -70,6 +70,12 @@ export async function GET(request: NextRequest) {
   }
 
   if (backendResponse.status === 401) {
+    logServerEvent('info', 'frontend_auth_refresh_start', 'Frontend auth refresh started from session restore', {
+      requestId,
+      path: request.nextUrl.pathname,
+      status: 401,
+    });
+
     const refreshResult = await refreshAuthSession(
       requestId,
       request.headers.get('cookie'),
@@ -88,6 +94,12 @@ export async function GET(request: NextRequest) {
       logServerEvent('warn', 'frontend_auth_me_refresh_rejected', 'Frontend auth session refresh was rejected', {
         requestId,
         status: refreshResult.status,
+        duration_ms: Date.now() - startedAt,
+      });
+      logServerEvent('warn', 'frontend_auth_session_cleared', 'Frontend auth session cleared after session restore failure', {
+        requestId,
+        status: refreshResult.status,
+        reason: 'refresh_rejected',
         duration_ms: Date.now() - startedAt,
       });
 
@@ -171,6 +183,13 @@ export async function GET(request: NextRequest) {
 
     if (backendResponse.status === 401) {
       clearAccessSessionCookie(response);
+      clearRefreshSessionCookie(response);
+      logServerEvent('warn', 'frontend_auth_session_cleared', 'Frontend auth session cleared after backend rejection', {
+        requestId,
+        status: 401,
+        reason: 'backend_rejected',
+        duration_ms: Date.now() - startedAt,
+      });
     }
 
     return response;

--- a/frontend/src/app/api/auth/presence-token/route.ts
+++ b/frontend/src/app/api/auth/presence-token/route.ts
@@ -66,6 +66,12 @@ export async function GET(request: NextRequest) {
   }
 
   if (backendResponse.status === 401) {
+    logServerEvent('info', 'frontend_auth_refresh_start', 'Frontend auth refresh started from presence token flow', {
+      requestId,
+      path: request.nextUrl.pathname,
+      status: 401,
+    });
+
     const refreshResult = await refreshAuthSession(
       requestId,
       request.headers.get('cookie'),
@@ -80,6 +86,18 @@ export async function GET(request: NextRequest) {
       clearAccessSessionCookie(response);
       clearRefreshSessionCookie(response);
       appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      logServerEvent('warn', 'frontend_auth_refresh_failed', 'Frontend auth refresh failed during presence token flow', {
+        requestId,
+        status: refreshResult.status,
+        duration_ms: Date.now() - startedAt,
+      });
+      logServerEvent('warn', 'frontend_auth_session_cleared', 'Frontend auth session cleared after presence token refresh failure', {
+        requestId,
+        status: refreshResult.status,
+        reason: 'refresh_rejected',
+        duration_ms: Date.now() - startedAt,
+      });
 
       return response;
     }
@@ -114,6 +132,13 @@ export async function GET(request: NextRequest) {
       clearAccessSessionCookie(response);
       clearRefreshSessionCookie(response);
       appendRefreshSetCookie(response, refreshResult.refreshSetCookie);
+
+      logServerEvent('warn', 'frontend_auth_session_cleared', 'Frontend auth session cleared after presence token validation failure', {
+        requestId,
+        status: backendResponse.status,
+        reason: 'backend_rejected',
+        duration_ms: Date.now() - startedAt,
+      });
 
       return response;
     }
@@ -152,6 +177,13 @@ export async function GET(request: NextRequest) {
 
     if (backendResponse.status === 401) {
       clearAccessSessionCookie(response);
+      clearRefreshSessionCookie(response);
+      logServerEvent('warn', 'frontend_auth_session_cleared', 'Frontend auth session cleared after presence token rejection', {
+        requestId,
+        status: 401,
+        reason: 'backend_rejected',
+        duration_ms: Date.now() - startedAt,
+      });
     }
 
     return response;

--- a/frontend/src/app/api/auth/refresh/route.ts
+++ b/frontend/src/app/api/auth/refresh/route.ts
@@ -47,6 +47,12 @@ export async function POST(request: NextRequest) {
       status: refreshResult.status,
       duration_ms: Date.now() - startedAt,
     });
+    logServerEvent('warn', 'frontend_auth_session_cleared', 'Frontend auth session cleared after refresh failure', {
+      requestId,
+      status: refreshResult.status,
+      reason: 'refresh_failed',
+      duration_ms: Date.now() - startedAt,
+    });
 
     return response;
   }

--- a/frontend/src/lib/server/logger.ts
+++ b/frontend/src/lib/server/logger.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 export const FRONTEND_SERVICE_NAME = 'frontend';
 export const REQUEST_ID_HEADER = 'x-request-id';
+const SENSITIVE_URL_PATTERN = /[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'<>]+/g;
 
 type LogLevel = 'info' | 'warn' | 'error';
 type LogContext = Record<string, unknown>;
@@ -58,16 +59,45 @@ export function logServerEvent(
   writeLog(level, createServerLogEntry(level, event, message, context));
 }
 
+function formatSanitizedConnectionTarget(rawUrl: string): string {
+  const trimmedUrl = rawUrl.trim();
+
+  if (!trimmedUrl) {
+    return '[connection redacted]';
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedUrl);
+    const parts = [
+      parsedUrl.protocol ? `scheme=${parsedUrl.protocol.replace(/:$/, '')}` : null,
+      parsedUrl.hostname ? `host=${parsedUrl.hostname}` : null,
+      parsedUrl.port ? `port=${parsedUrl.port}` : null,
+    ].filter((value): value is string => Boolean(value));
+
+    return parts.length > 0 ? `[connection ${parts.join(' ')}]` : '[connection redacted]';
+  } catch {
+    return '[connection redacted]';
+  }
+}
+
+export function sanitizeServerSensitiveText(value: string): string {
+  if (!value.trim()) {
+    return value;
+  }
+
+  return value.replace(SENSITIVE_URL_PATTERN, (match) => formatSanitizedConnectionTarget(match));
+}
+
 export function serializeServerError(error: unknown): LogContext {
   if (error instanceof Error) {
     return {
       errorName: error.name,
-      errorMessage: error.message,
-      stack: error.stack,
+      errorMessage: sanitizeServerSensitiveText(error.message),
+      stack: error.stack ? sanitizeServerSensitiveText(error.stack) : undefined,
     };
   }
 
   return {
-    errorMessage: String(error),
+    errorMessage: sanitizeServerSensitiveText(String(error)),
   };
 }

--- a/frontend/tests/unit/lib/server-logger.test.ts
+++ b/frontend/tests/unit/lib/server-logger.test.ts
@@ -3,6 +3,8 @@ import {
   FRONTEND_SERVICE_NAME,
   createServerLogEntry,
   resolveServerRequestId,
+  sanitizeServerSensitiveText,
+  serializeServerError,
 } from '@/lib/server/logger';
 
 describe('server logger', () => {
@@ -28,5 +30,16 @@ describe('server logger', () => {
     expect(entry.message).toBe('Frontend route request started');
     expect(entry.route).toBe('/api/auth/login');
     expect(typeof entry.timestamp).toBe('string');
+  });
+
+  it('sanitiza urls sensiveis em mensagens de erro', () => {
+    const details = serializeServerError(new Error('dial redis://default:super-secret@redis.internal:6379 failed'));
+
+    expect(sanitizeServerSensitiveText('redis://default:super-secret@redis.internal:6379')).toBe(
+      '[connection scheme=redis host=redis.internal port=6379]',
+    );
+    expect(details.errorMessage).toBe('dial [connection scheme=redis host=redis.internal port=6379] failed');
+    expect(String(details.stack)).not.toContain('super-secret');
+    expect(String(details.stack)).not.toContain('redis://');
   });
 });

--- a/frontend/tests/unit/routes/auth-login-route.test.ts
+++ b/frontend/tests/unit/routes/auth-login-route.test.ts
@@ -5,6 +5,37 @@ import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
+function captureServerLogs() {
+  const entries: Array<Record<string, unknown>> = [];
+
+  const collect = (chunk: string | Uint8Array): boolean => {
+    const serialized = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+
+    for (const line of serialized.split('\n')) {
+      const trimmed = line.trim();
+
+      if (!trimmed.startsWith('{')) {
+        continue;
+      }
+
+      entries.push(JSON.parse(trimmed) as Record<string, unknown>);
+    }
+
+    return true;
+  };
+
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stderr.write);
+
+  return {
+    entries,
+    restore() {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+}
+
 describe('auth login route', () => {
   beforeEach(() => {
     process.env.INTERNAL_API_URL = 'http://backend.test';
@@ -17,6 +48,7 @@ describe('auth login route', () => {
   });
 
   it('sets an httpOnly access cookie and forwards the refresh cookie when login succeeds', async () => {
+    const capturedLogs = captureServerLogs();
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
 
@@ -55,6 +87,8 @@ describe('auth login route', () => {
       }),
     );
 
+    capturedLogs.restore();
+
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const setCookieHeader = response.headers.get('set-cookie');
@@ -62,6 +96,19 @@ describe('auth login route', () => {
     expect(setCookieHeader).toContain('HttpOnly');
     expect(setCookieHeader).toContain('jwt-token');
     expect(setCookieHeader).toContain('clutch_refresh=refresh-token');
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_login_start')).toMatchObject({
+      event: 'frontend_auth_login_start',
+      requestId: 'req-login-123',
+      path: '/api/auth/login',
+    });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_login_success')).toMatchObject({
+      event: 'frontend_auth_login_success',
+      requestId: 'req-login-123',
+      status: 200,
+      username: 'clutchplayer',
+    });
+    expect(JSON.stringify(capturedLogs.entries)).not.toContain('jwt-token');
+    expect(JSON.stringify(capturedLogs.entries)).not.toContain('refresh-token');
   });
 
   it('propagates invalid credentials without setting a session cookie', async () => {

--- a/frontend/tests/unit/routes/auth-logout-route.test.ts
+++ b/frontend/tests/unit/routes/auth-logout-route.test.ts
@@ -5,6 +5,24 @@ import { POST } from '@/app/api/auth/logout/route';
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
+function captureServerLogs() {
+  const entries: Array<Record<string, unknown>> = [];
+  const collect = (chunk: string | Uint8Array): boolean => {
+    const serialized = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    for (const line of serialized.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('{')) {
+        continue;
+      }
+      entries.push(JSON.parse(trimmed) as Record<string, unknown>);
+    }
+    return true;
+  };
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stderr.write);
+  return { entries, restore() { stdoutSpy.mockRestore(); stderrSpy.mockRestore(); } };
+}
+
 describe('auth logout route', () => {
   beforeEach(() => {
     process.env.INTERNAL_API_URL = 'http://backend.test';
@@ -13,6 +31,7 @@ describe('auth logout route', () => {
   });
 
   it('clears the local session cookie and forwards the backend refresh revocation request', async () => {
+    const capturedLogs = captureServerLogs();
     const fetchHandler = vi.fn(async () => new Response(
       JSON.stringify({ message: 'Sessão encerrada.' }),
       {
@@ -33,10 +52,13 @@ describe('auth logout route', () => {
       new NextRequest('http://localhost/api/auth/logout', {
         method: 'POST',
         headers: {
+          'x-request-id': 'req-logout-123',
           cookie: 'clutch_session=jwt-token; clutch_refresh=refresh-token',
         },
       }),
     );
+
+    capturedLogs.restore();
 
     expect(response.status).toBe(200);
     expect(fetchHandler).toHaveBeenCalledTimes(1);
@@ -47,6 +69,12 @@ describe('auth logout route', () => {
     expect(new Headers(requestInit?.headers).get('cookie')).toContain('clutch_refresh=refresh-token');
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
     expect(response.headers.get('set-cookie')).toContain('clutch_refresh=');
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_logout_completed')).toMatchObject({
+      event: 'frontend_auth_logout_completed',
+      requestId: 'req-logout-123',
+      status: 200,
+    });
+    expect(JSON.stringify(capturedLogs.entries)).not.toContain('refresh-token');
   });
 });
 

--- a/frontend/tests/unit/routes/auth-me-route.test.ts
+++ b/frontend/tests/unit/routes/auth-me-route.test.ts
@@ -5,6 +5,24 @@ import { GET } from '@/app/api/auth/me/route';
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
+function captureServerLogs() {
+  const entries: Array<Record<string, unknown>> = [];
+  const collect = (chunk: string | Uint8Array): boolean => {
+    const serialized = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    for (const line of serialized.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('{')) {
+        continue;
+      }
+      entries.push(JSON.parse(trimmed) as Record<string, unknown>);
+    }
+    return true;
+  };
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stderr.write);
+  return { entries, restore() { stdoutSpy.mockRestore(); stderrSpy.mockRestore(); } };
+}
+
 describe('auth me route', () => {
   beforeEach(() => {
     process.env.INTERNAL_API_URL = 'http://backend.test';
@@ -115,6 +133,7 @@ describe('auth me route', () => {
   });
 
   it('clears the session when the refresh session was revoked', async () => {
+    const capturedLogs = captureServerLogs();
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 
@@ -143,11 +162,14 @@ describe('auth me route', () => {
 
     const request = new NextRequest('http://localhost/api/auth/me', {
       headers: {
+        'x-request-id': 'req-auth-me-401',
         cookie: 'clutch_session=expired-token; clutch_refresh=invalid-refresh-token',
       },
     });
 
     const response = await GET(request);
+
+    capturedLogs.restore();
 
     expect(response.status).toBe(401);
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -156,6 +178,22 @@ describe('auth me route', () => {
     await expect(response.json()).resolves.toEqual({
       message: 'Token invalido ou expirado.',
     });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_refresh_start')).toMatchObject({
+      event: 'frontend_auth_refresh_start',
+      requestId: 'req-auth-me-401',
+      path: '/api/auth/me',
+    });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_me_refresh_rejected')).toMatchObject({
+      event: 'frontend_auth_me_refresh_rejected',
+      requestId: 'req-auth-me-401',
+      status: 401,
+    });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_session_cleared')).toMatchObject({
+      event: 'frontend_auth_session_cleared',
+      requestId: 'req-auth-me-401',
+      reason: 'refresh_rejected',
+    });
+    expect(JSON.stringify(capturedLogs.entries)).not.toContain('invalid-refresh-token');
   });
 });
 

--- a/frontend/tests/unit/routes/auth-presence-token-route.test.ts
+++ b/frontend/tests/unit/routes/auth-presence-token-route.test.ts
@@ -5,6 +5,24 @@ import { GET } from '@/app/api/auth/presence-token/route';
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
+function captureServerLogs() {
+  const entries: Array<Record<string, unknown>> = [];
+  const collect = (chunk: string | Uint8Array): boolean => {
+    const serialized = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    for (const line of serialized.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('{')) {
+        continue;
+      }
+      entries.push(JSON.parse(trimmed) as Record<string, unknown>);
+    }
+    return true;
+  };
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stderr.write);
+  return { entries, restore() { stdoutSpy.mockRestore(); stderrSpy.mockRestore(); } };
+}
+
 describe('auth presence token route', () => {
   beforeEach(() => {
     process.env.INTERNAL_API_URL = 'http://backend.test';
@@ -108,6 +126,7 @@ describe('auth presence token route', () => {
   });
 
   it('returns 401 and clears cookies when the refresh session was revoked', async () => {
+    const capturedLogs = captureServerLogs();
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
 
@@ -136,11 +155,14 @@ describe('auth presence token route', () => {
 
     const request = new NextRequest('http://localhost/api/auth/presence-token', {
       headers: {
+        'x-request-id': 'req-presence-401',
         cookie: 'clutch_session=expired-token; clutch_refresh=invalid-refresh-token',
       },
     });
 
     const response = await GET(request);
+
+    capturedLogs.restore();
 
     expect(response.status).toBe(401);
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -149,6 +171,22 @@ describe('auth presence token route', () => {
     await expect(response.json()).resolves.toEqual({
       message: 'Token invalido ou expirado.',
     });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_refresh_start')).toMatchObject({
+      event: 'frontend_auth_refresh_start',
+      requestId: 'req-presence-401',
+      path: '/api/auth/presence-token',
+    });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_refresh_failed')).toMatchObject({
+      event: 'frontend_auth_refresh_failed',
+      requestId: 'req-presence-401',
+      status: 401,
+    });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_session_cleared')).toMatchObject({
+      event: 'frontend_auth_session_cleared',
+      requestId: 'req-presence-401',
+      reason: 'refresh_rejected',
+    });
+    expect(JSON.stringify(capturedLogs.entries)).not.toContain('invalid-refresh-token');
   });
 });
 

--- a/frontend/tests/unit/routes/auth-refresh-route.test.ts
+++ b/frontend/tests/unit/routes/auth-refresh-route.test.ts
@@ -5,6 +5,24 @@ import { POST } from '@/app/api/auth/refresh/route';
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
 
+function captureServerLogs() {
+  const entries: Array<Record<string, unknown>> = [];
+  const collect = (chunk: string | Uint8Array): boolean => {
+    const serialized = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    for (const line of serialized.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('{')) {
+        continue;
+      }
+      entries.push(JSON.parse(trimmed) as Record<string, unknown>);
+    }
+    return true;
+  };
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stderr.write);
+  return { entries, restore() { stdoutSpy.mockRestore(); stderrSpy.mockRestore(); } };
+}
+
 describe('auth refresh route', () => {
   beforeEach(() => {
     process.env.INTERNAL_API_URL = 'http://backend.test';
@@ -46,6 +64,7 @@ describe('auth refresh route', () => {
   });
 
   it('clears cookies when the backend rejects a revoked refresh session', async () => {
+    const capturedLogs = captureServerLogs();
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response(
@@ -66,15 +85,29 @@ describe('auth refresh route', () => {
       new NextRequest('http://localhost/api/auth/refresh', {
         method: 'POST',
         headers: {
+          'x-request-id': 'req-refresh-123',
           cookie: 'clutch_refresh=revoked-refresh-token',
         },
       }),
     );
 
+    capturedLogs.restore();
+
     expect(response.status).toBe(401);
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
     expect(response.headers.get('set-cookie')).toContain('clutch_refresh=');
     await expect(response.json()).resolves.toEqual({ message: 'Sessao invalida ou expirada.' });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_refresh_rejected')).toMatchObject({
+      event: 'frontend_auth_refresh_rejected',
+      requestId: 'req-refresh-123',
+      status: 401,
+    });
+    expect(capturedLogs.entries.find((entry) => entry.event === 'frontend_auth_session_cleared')).toMatchObject({
+      event: 'frontend_auth_session_cleared',
+      requestId: 'req-refresh-123',
+      reason: 'refresh_failed',
+    });
+    expect(JSON.stringify(capturedLogs.entries)).not.toContain('revoked-refresh-token');
   });
 });
 


### PR DESCRIPTION
﻿## Resumo
Esta PR amplia a observabilidade do auth path com eventos estruturados no backend e no frontend server-side, cobrindo login, refresh, logout/revogação e falhas relevantes de autenticação. A mudança preserva o contrato HTTP atual e reforça a sanitização para evitar vazamento de tokens, cookies, headers sensíveis e secrets.

## O que foi alterado
- Backend: adiciona eventos explícitos de sucesso e falha de login, mantendo a trilha estruturada de refresh, expiração de access token, revogação e logout.
- Frontend server-side: padroniza eventos de refresh acionado, refresh falhado, logout concluído e limpeza de sessão por `401` nos fluxos de `/api/auth/login`, `/api/auth/refresh`, `/api/auth/logout`, `/api/auth/me` e `/api/auth/presence-token`.
- Logging seguro: aplica sanitização de `error.message` e `stack` no logger server-side do frontend para remover URLs sensíveis.
- Testes: adiciona cobertura focada para presença dos eventos esperados, `requestId` e ausência de dados sensíveis nos logs.

## Motivação
O projeto já possui auth endurecido, refresh token rotativo, revogação de sessão e logs estruturados por serviço, mas o auth path ainda não tinha uma trilha observável completa e consistente. Esta PR fecha essa lacuna para facilitar diagnóstico operacional e incident response sem degradar segurança dos logs.

## Como validar
- Backend:
  - `cd backend`
  - `npm run test -- tests/integration/routes/auth.routes.test.ts tests/unit/config/logging.test.ts tests/unit/core/refresh-token.service.test.ts`
  - `npm run typecheck`
  - `npm run lint`
- Frontend:
  - `cd frontend`
  - `npm run test -- tests/unit/lib/server-logger.test.ts tests/unit/routes/auth-login-route.test.ts tests/unit/routes/auth-refresh-route.test.ts tests/unit/routes/auth-logout-route.test.ts tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-presence-token-route.test.ts`
  - `npm run typecheck`
  - `npm run lint`
- Stack container-first:
  - `docker compose up -d --build`
  - `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- Fluxo operacional via proxy:
  - `POST /api/auth/login` -> `200`
  - `GET /api/auth/me` -> `200`
  - `GET /api/auth/presence-token` -> `200`
  - `POST /api/auth/refresh` -> `200`
  - `POST /api/auth/logout` -> `200`
  - `POST /api/auth/refresh` após revogação -> `401`
  - `GET /api/auth/me` após revogação -> `401`
  - `GET /api/auth/presence-token` após revogação -> `401`
- Inspecionar logs:
  - `docker compose logs backend`
  - `docker compose logs frontend`

## Riscos e impactos
- Baixo risco de contrato, porque os endpoints e payloads HTTP foram preservados.
- O fluxo operacional real após logout tende a limpar a sessão local imediatamente no frontend; por isso, em cliente real, a evidência pós-revogação aparece como ausência de sessão local, enquanto a semântica de sessão revogada fica coberta de forma determinística nos testes focados.
- Os testes de backend no host continuam emitindo ruído de Redis em `stderr` por imports globais, sem impacto funcional.

## Evidências
- Validação operacional confirmou login, refresh, logout e rejeição pós-revogação via proxy.
- `docker compose logs backend` mostrou eventos como `auth_login_succeeded`, `auth_access_token_refreshed`, `auth_session_revoked` e `auth_logout_completed` com `requestId`.
- `docker compose logs frontend` mostrou eventos como `frontend_auth_login_success`, `frontend_auth_refresh_rejected`, `frontend_auth_session_cleared` e `frontend_auth_logout_completed` sem dados sensíveis.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #164
