### PR TITLE
feat(auth): adiciona rotação de chave JWT com versionamento

### DIFF
--- a/backend/src/api/middlewares/authenticate.ts
+++ b/backend/src/api/middlewares/authenticate.ts
@@ -1,6 +1,10 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import jwt from 'jsonwebtoken';
-import { extractBearerToken, type JwtPayload } from '../../config/jwt';
+import {
+  extractBearerToken,
+  JwtKidRejectedError,
+  type VerifiedJwtPayload,
+} from '../../config/jwt';
 
 // ─────────────────────────────────────────────────────────────
 // Authenticate Middleware
@@ -33,10 +37,32 @@ export async function authenticate(
       return reply.status(401).send({ message: 'Token inválido ou expirado.' });
     }
 
-    const payload = request.server.verifyAccessToken(token) as JwtPayload;
+    const payload = request.server.verifyAccessToken(token) as VerifiedJwtPayload;
+    request.log.info({
+      event: 'auth_jwt_key_selected',
+      requestId: request.id,
+      method: request.method,
+      path: request.url,
+      kid: payload.keyId,
+      tokenKid: payload.tokenKeyId,
+      legacyToken: payload.legacyToken,
+    }, 'JWT key selected for access token verification');
     request.userId   = payload.id;
     request.username = payload.username;
   } catch (error) {
+    if (error instanceof JwtKidRejectedError) {
+      request.log.warn({
+        event: 'auth_jwt_kid_rejected',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        kid: error.kid,
+        reason: error.reason,
+      }, 'JWT kid rejected');
+      return reply.status(401).send({ message: 'Token inválido ou expirado.' });
+    }
+
     if (error instanceof jwt.TokenExpiredError) {
       request.log.warn({
         event: 'auth_access_token_expired',

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import {
 } from './config/logging';
 import {
   createJwtSigner,
+  type JwtKeyRotationConfig,
   createJwtVerifier,
 } from './config/jwt';
 import {
@@ -29,6 +30,7 @@ import { createRedisRefreshSessionStore } from './infra/cache/refresh-session.st
 
 export type BuildAppOptions = {
   jwtSecret?: string;
+  jwtKeyRotationConfig?: JwtKeyRotationConfig;
   logger?: boolean;
   readinessCheck?: () => Promise<ReadinessReport>;
   refreshSessionStore?: RefreshSessionStore;
@@ -43,10 +45,12 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     requestIdHeader: REQUEST_ID_HEADER,
     genReqId: (request) => resolveBackendRequestId(request.headers),
   });
-  const signAccessToken = createJwtSigner(options.jwtSecret);
-  const verifyAccessToken = createJwtVerifier(options.jwtSecret);
+  const jwtConfigInput = options.jwtKeyRotationConfig ?? options.jwtSecret;
+  const signAccessToken = createJwtSigner(jwtConfigInput);
+  const verifyAccessToken = createJwtVerifier(jwtConfigInput);
   const refreshTokenService = createRefreshTokenService({
     jwtSecret: options.jwtSecret,
+    jwtKeyRotationConfig: options.jwtKeyRotationConfig,
     refreshSessionStore: options.refreshSessionStore ?? createRedisRefreshSessionStore(),
   });
 

--- a/backend/src/config/jwt.ts
+++ b/backend/src/config/jwt.ts
@@ -4,10 +4,17 @@ import jwt, {
   type SignOptions,
   type VerifyOptions,
 } from 'jsonwebtoken';
+import { writeBackendRuntimeLog } from './logging';
 
 export interface JwtPayload {
   id: string;
   username: string;
+}
+
+export interface VerifiedJwtPayload extends JwtPayload {
+  keyId: string;
+  tokenKeyId: string | null;
+  legacyToken: boolean;
 }
 
 export interface RefreshTokenPayload extends JwtPayload {
@@ -16,12 +23,62 @@ export interface RefreshTokenPayload extends JwtPayload {
   jti: string;
 }
 
+export interface VerifiedRefreshTokenPayload extends RefreshTokenPayload {
+  keyId: string;
+  tokenKeyId: string | null;
+  legacyToken: boolean;
+}
+
+export type JwtKeyRotationConfig = {
+  activeKid: string;
+  keys: Record<string, string>;
+};
+
+type ResolvedJwtKeyRotationConfig = {
+  activeKid: string;
+  keys: Record<string, Secret>;
+  verificationOrder: string[];
+};
+
+type VerificationCandidate = {
+  keyId: string;
+  secret: Secret;
+  legacyToken: boolean;
+};
+
+type JwtHeaderMetadata = {
+  kid: string | null;
+};
+
 const JWT_ALGORITHM = 'HS256';
 const DEFAULT_DEVELOPMENT_JWT_SECRET = 'clutch-dev-secret-change-in-production';
+const DEFAULT_SINGLE_KEY_KID = 'legacy';
+const JWT_KEYRING_ENV = 'JWT_KEYS_JSON';
+const JWT_ACTIVE_KID_ENV = 'JWT_ACTIVE_KID';
 const BEARER_TOKEN_PATTERN = /^Bearer (?<token>[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)$/u;
 // 10 minutos reduz a janela de ataque sem forcar refresh excessivo em navegacao comum.
 const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60 * 10;
 const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7;
+const loggedKeyRotationConfigs = new Set<string>();
+
+export class JwtRotationConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JwtRotationConfigError';
+  }
+}
+
+export class JwtKidRejectedError extends Error {
+  readonly kid: string | null;
+  readonly reason: 'unknown_kid';
+
+  constructor(kid: string | null) {
+    super('JWT kid invalido ou desconhecido.');
+    this.name = 'JwtKidRejectedError';
+    this.kid = kid;
+    this.reason = 'unknown_kid';
+  }
+}
 
 function resolveJwtSecret(secret?: string): Secret {
   if (typeof secret === 'string' && secret.trim().length > 0) {
@@ -35,7 +92,7 @@ function resolveJwtSecret(secret?: string): Secret {
   }
 
   if (process.env['NODE_ENV'] === 'production') {
-    throw new Error('JWT_SECRET deve ser configurado em produção.');
+    throw new JwtRotationConfigError('JWT_SECRET deve ser configurado em produção.');
   }
 
   return DEFAULT_DEVELOPMENT_JWT_SECRET;
@@ -57,32 +114,6 @@ function assertJwtPayload(payload: string | JsonWebTokenPayload): JwtPayload {
   }
 
   return { id, username };
-}
-
-function resolveAccessTokenTtlSeconds(): number {
-  const rawValue = process.env['ACCESS_TOKEN_TTL_SECONDS'];
-  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
-
-  if (Number.isFinite(parsedValue) && parsedValue > 0) {
-    return Math.floor(parsedValue);
-  }
-
-  return DEFAULT_ACCESS_TOKEN_TTL_SECONDS;
-}
-
-export function getAccessTokenTtlSeconds(): number {
-  return resolveAccessTokenTtlSeconds();
-}
-
-function resolveRefreshTokenTtlSeconds(): number {
-  const rawValue = process.env['REFRESH_TOKEN_TTL_SECONDS'];
-  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
-
-  if (Number.isFinite(parsedValue) && parsedValue > 0) {
-    return Math.floor(parsedValue);
-  }
-
-  return DEFAULT_REFRESH_TOKEN_TTL_SECONDS;
 }
 
 function assertRefreshTokenPayload(payload: string | JsonWebTokenPayload): RefreshTokenPayload {
@@ -111,13 +142,280 @@ function assertRefreshTokenPayload(payload: string | JsonWebTokenPayload): Refre
   };
 }
 
-export function createJwtSigner(secret?: string) {
-  const resolvedSecret = resolveJwtSecret(secret);
+function resolveAccessTokenTtlSeconds(): number {
+  const rawValue = process.env['ACCESS_TOKEN_TTL_SECONDS'];
+  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
+
+  if (Number.isFinite(parsedValue) && parsedValue > 0) {
+    return Math.floor(parsedValue);
+  }
+
+  return DEFAULT_ACCESS_TOKEN_TTL_SECONDS;
+}
+
+export function getAccessTokenTtlSeconds(): number {
+  return resolveAccessTokenTtlSeconds();
+}
+
+function resolveRefreshTokenTtlSeconds(): number {
+  const rawValue = process.env['REFRESH_TOKEN_TTL_SECONDS'];
+  const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
+
+  if (Number.isFinite(parsedValue) && parsedValue > 0) {
+    return Math.floor(parsedValue);
+  }
+
+  return DEFAULT_REFRESH_TOKEN_TTL_SECONDS;
+}
+
+function resolveSingleKeyActiveKid(): string {
+  const configuredKid = process.env[JWT_ACTIVE_KID_ENV];
+
+  if (typeof configuredKid === 'string' && configuredKid.trim().length > 0) {
+    return configuredKid.trim();
+  }
+
+  return DEFAULT_SINGLE_KEY_KID;
+}
+
+function parseJwtKeysJson(rawValue: string): Record<string, string> {
+  let parsedValue: unknown;
+
+  try {
+    parsedValue = JSON.parse(rawValue) as unknown;
+  } catch {
+    throw new JwtRotationConfigError(`${JWT_KEYRING_ENV} deve conter JSON válido.`);
+  }
+
+  if (typeof parsedValue !== 'object' || parsedValue === null || Array.isArray(parsedValue)) {
+    throw new JwtRotationConfigError(`${JWT_KEYRING_ENV} deve conter um objeto de chaves nomeadas.`);
+  }
+
+  const entries = Object.entries(parsedValue);
+
+  if (entries.length === 0) {
+    throw new JwtRotationConfigError(`${JWT_KEYRING_ENV} deve conter pelo menos uma chave JWT.`);
+  }
+
+  const keys: Record<string, string> = {};
+
+  for (const [kid, secret] of entries) {
+    if (typeof kid !== 'string' || kid.trim().length === 0) {
+      throw new JwtRotationConfigError('Cada kid de JWT deve ser uma string não vazia.');
+    }
+
+    if (typeof secret !== 'string' || secret.trim().length === 0) {
+      throw new JwtRotationConfigError(`A chave JWT associada ao kid "${kid}" deve ser uma string não vazia.`);
+    }
+
+    keys[kid.trim()] = secret.trim();
+  }
+
+  return keys;
+}
+
+function normalizeExplicitKeyRotationConfig(config: JwtKeyRotationConfig): ResolvedJwtKeyRotationConfig {
+  const keys = Object.entries(config.keys).reduce<Record<string, Secret>>((accumulator, [kid, secret]) => {
+    if (typeof kid !== 'string' || kid.trim().length === 0) {
+      throw new JwtRotationConfigError('Cada kid de JWT deve ser uma string não vazia.');
+    }
+
+    if (typeof secret !== 'string' || secret.trim().length === 0) {
+      throw new JwtRotationConfigError(`A chave JWT associada ao kid "${kid}" deve ser uma string não vazia.`);
+    }
+
+    accumulator[kid.trim()] = secret.trim();
+    return accumulator;
+  }, {});
+
+  const verificationOrder = Object.keys(keys);
+
+  if (verificationOrder.length === 0) {
+    throw new JwtRotationConfigError('A configuração explícita de rotação JWT deve conter pelo menos uma chave.');
+  }
+
+  const activeKid = config.activeKid.trim();
+
+  if (activeKid.length === 0) {
+    throw new JwtRotationConfigError('A chave ativa JWT deve ser uma string não vazia.');
+  }
+
+  if (!Object.hasOwn(keys, activeKid)) {
+    throw new JwtRotationConfigError('A chave ativa JWT deve existir no conjunto de chaves válidas.');
+  }
+
+  return {
+    activeKid,
+    keys,
+    verificationOrder,
+  };
+}
+
+function resolveJwtKeyRotationConfig(input?: string | JwtKeyRotationConfig): ResolvedJwtKeyRotationConfig {
+  if (typeof input === 'object' && input !== null) {
+    const resolvedConfig = normalizeExplicitKeyRotationConfig(input);
+    logJwtRotationConfigLoaded(resolvedConfig);
+    return resolvedConfig;
+  }
+
+  if (typeof input === 'string' && input.trim().length > 0) {
+    const activeKid = resolveSingleKeyActiveKid();
+    const resolvedConfig = {
+      activeKid,
+      keys: { [activeKid]: input.trim() },
+      verificationOrder: [activeKid],
+    };
+    logJwtRotationConfigLoaded(resolvedConfig);
+    return resolvedConfig;
+  }
+
+  const rawKeyring = process.env[JWT_KEYRING_ENV];
+
+  if (typeof rawKeyring === 'string' && rawKeyring.trim().length > 0) {
+    const parsedKeys = parseJwtKeysJson(rawKeyring.trim());
+    const configuredActiveKid = process.env[JWT_ACTIVE_KID_ENV]?.trim();
+    const verificationOrder = Object.keys(parsedKeys);
+
+    if ((!configuredActiveKid || configuredActiveKid.length === 0) && verificationOrder.length > 1) {
+      throw new JwtRotationConfigError('JWT_ACTIVE_KID deve ser configurado quando múltiplas chaves JWT estiverem ativas.');
+    }
+
+    const activeKid = configuredActiveKid && configuredActiveKid.length > 0
+      ? configuredActiveKid
+      : verificationOrder[0];
+
+    if (typeof activeKid !== 'string' || activeKid.length === 0) {
+      throw new JwtRotationConfigError('JWT_ACTIVE_KID deve ser configurado quando múltiplas chaves JWT estiverem ativas.');
+    }
+
+    if (!Object.hasOwn(parsedKeys, activeKid)) {
+      throw new JwtRotationConfigError('JWT_ACTIVE_KID deve apontar para uma chave existente em JWT_KEYS_JSON.');
+    }
+
+    const resolvedConfig = {
+      activeKid,
+      keys: parsedKeys,
+      verificationOrder,
+    };
+    logJwtRotationConfigLoaded(resolvedConfig);
+    return resolvedConfig;
+  }
+
+  const resolvedSecret = resolveJwtSecret();
+  const activeKid = resolveSingleKeyActiveKid();
+  const resolvedConfig = {
+    activeKid,
+    keys: { [activeKid]: resolvedSecret },
+    verificationOrder: [activeKid],
+  };
+  logJwtRotationConfigLoaded(resolvedConfig);
+  return resolvedConfig;
+}
+
+function logJwtRotationConfigLoaded(config: ResolvedJwtKeyRotationConfig): void {
+  if (process.env['NODE_ENV'] === 'test') {
+    return;
+  }
+
+  const signature = JSON.stringify({
+    activeKid: config.activeKid,
+    kids: config.verificationOrder,
+  });
+
+  if (loggedKeyRotationConfigs.has(signature)) {
+    return;
+  }
+
+  loggedKeyRotationConfigs.add(signature);
+
+  writeBackendRuntimeLog('info', 'auth_jwt_rotation_config_loaded', 'JWT rotation config loaded', {
+    activeKid: config.activeKid,
+    configuredKeyCount: config.verificationOrder.length,
+  });
+}
+
+function decodeJwtHeader(token: string): JwtHeaderMetadata {
+  const decoded = jwt.decode(token, { complete: true });
+
+  if (!decoded || typeof decoded !== 'object' || !('header' in decoded)) {
+    throw new Error('Token JWT invalido.');
+  }
+
+  const rawKid = decoded.header['kid'];
+
+  return {
+    kid: typeof rawKid === 'string' && rawKid.trim().length > 0 ? rawKid.trim() : null,
+  };
+}
+
+function resolveVerificationCandidates(
+  config: ResolvedJwtKeyRotationConfig,
+  tokenKeyId: string | null,
+): VerificationCandidate[] {
+  if (typeof tokenKeyId === 'string') {
+    const secret = config.keys[tokenKeyId];
+
+    if (!secret) {
+      throw new JwtKidRejectedError(tokenKeyId);
+    }
+
+    return [{
+      keyId: tokenKeyId,
+      secret,
+      legacyToken: false,
+    }];
+  }
+
+  return config.verificationOrder.map((kid) => ({
+    keyId: kid,
+    secret: config.keys[kid] as Secret,
+    legacyToken: true,
+  }));
+}
+
+function verifyTokenAgainstCandidates<TPayload>(
+  token: string,
+  config: ResolvedJwtKeyRotationConfig,
+  // eslint-disable-next-line no-unused-vars
+  assertPayload: (_payload: string | JsonWebTokenPayload) => TPayload,
+): TPayload & { keyId: string; tokenKeyId: string | null; legacyToken: boolean } {
+  const tokenHeader = decodeJwtHeader(token);
+  const verifyOptions: VerifyOptions = {
+    algorithms: [JWT_ALGORITHM],
+    ignoreExpiration: false,
+  };
+  const candidates = resolveVerificationCandidates(config, tokenHeader.kid);
+  let lastError: unknown = new Error('Token JWT invalido.');
+
+  for (const candidate of candidates) {
+    try {
+      const payload = jwt.verify(token, candidate.secret, verifyOptions);
+
+      return {
+        ...assertPayload(payload),
+        keyId: candidate.keyId,
+        tokenKeyId: tokenHeader.kid,
+        legacyToken: candidate.legacyToken,
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
+export function createJwtSigner(input?: string | JwtKeyRotationConfig) {
+  const resolvedConfig = resolveJwtKeyRotationConfig(input);
 
   return (payload: JwtPayload): string => {
     const signOptions: SignOptions = {
       algorithm: JWT_ALGORITHM,
       expiresIn: `${getAccessTokenTtlSeconds()}s`,
+      header: {
+        alg: JWT_ALGORITHM,
+        kid: resolvedConfig.activeKid,
+      },
     };
 
     return jwt.sign(
@@ -125,53 +423,51 @@ export function createJwtSigner(secret?: string) {
         ...payload,
         tokenType: 'access',
       },
-      resolvedSecret,
+      resolvedConfig.keys[resolvedConfig.activeKid] as Secret,
       signOptions,
     );
   };
 }
 
-export function createJwtVerifier(secret?: string) {
-  const resolvedSecret = resolveJwtSecret(secret);
+export function createJwtVerifier(input?: string | JwtKeyRotationConfig) {
+  const resolvedConfig = resolveJwtKeyRotationConfig(input);
 
-  return (token: string): JwtPayload => {
-    const verifyOptions: VerifyOptions = {
-      algorithms: [JWT_ALGORITHM],
-      ignoreExpiration: false,
-    };
-
-    const payload = jwt.verify(token, resolvedSecret, verifyOptions);
-
-    return assertJwtPayload(payload);
-  };
+  return (token: string): VerifiedJwtPayload => verifyTokenAgainstCandidates(
+    token,
+    resolvedConfig,
+    assertJwtPayload,
+  );
 }
 
-export function createRefreshTokenSigner(secret?: string) {
-  const resolvedSecret = resolveJwtSecret(secret);
+export function createRefreshTokenSigner(input?: string | JwtKeyRotationConfig) {
+  const resolvedConfig = resolveJwtKeyRotationConfig(input);
 
   return (payload: RefreshTokenPayload): string => {
     const signOptions: SignOptions = {
       algorithm: JWT_ALGORITHM,
       expiresIn: `${resolveRefreshTokenTtlSeconds()}s`,
+      header: {
+        alg: JWT_ALGORITHM,
+        kid: resolvedConfig.activeKid,
+      },
     };
 
-    return jwt.sign(payload, resolvedSecret, signOptions);
+    return jwt.sign(
+      payload,
+      resolvedConfig.keys[resolvedConfig.activeKid] as Secret,
+      signOptions,
+    );
   };
 }
 
-export function createRefreshTokenVerifier(secret?: string) {
-  const resolvedSecret = resolveJwtSecret(secret);
+export function createRefreshTokenVerifier(input?: string | JwtKeyRotationConfig) {
+  const resolvedConfig = resolveJwtKeyRotationConfig(input);
 
-  return (token: string): RefreshTokenPayload => {
-    const verifyOptions: VerifyOptions = {
-      algorithms: [JWT_ALGORITHM],
-      ignoreExpiration: false,
-    };
-
-    const payload = jwt.verify(token, resolvedSecret, verifyOptions);
-
-    return assertRefreshTokenPayload(payload);
-  };
+  return (token: string): VerifiedRefreshTokenPayload => verifyTokenAgainstCandidates(
+    token,
+    resolvedConfig,
+    assertRefreshTokenPayload,
+  );
 }
 
 export function extractBearerToken(authorizationHeader?: string): string | null {

--- a/backend/src/core/services/refresh-token.service.ts
+++ b/backend/src/core/services/refresh-token.service.ts
@@ -2,10 +2,12 @@ import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
 import { getRefreshTokenCookieMaxAgeSeconds } from '../../config/auth-session';
 import {
   createJwtSigner,
+  type JwtKeyRotationConfig,
   createRefreshTokenSigner,
   createRefreshTokenVerifier,
   type JwtPayload,
   type RefreshTokenPayload,
+  type VerifiedRefreshTokenPayload,
 } from '../../config/jwt';
 
 export type RefreshSessionRecord = {
@@ -176,15 +178,17 @@ export type RefreshTokenService = {
 export type CreateRefreshTokenServiceOptions = {
   refreshSessionStore: RefreshSessionStore;
   jwtSecret?: string;
+  jwtKeyRotationConfig?: JwtKeyRotationConfig;
 };
 
 export function createRefreshTokenService(
   options: CreateRefreshTokenServiceOptions,
 ): RefreshTokenService {
   const refreshSessionStore = options.refreshSessionStore;
-  const signAccessToken = createJwtSigner(options.jwtSecret);
-  const signRefreshToken = createRefreshTokenSigner(options.jwtSecret);
-  const verifyRefreshToken = createRefreshTokenVerifier(options.jwtSecret);
+  const jwtConfigInput = options.jwtKeyRotationConfig ?? options.jwtSecret;
+  const signAccessToken = createJwtSigner(jwtConfigInput);
+  const signRefreshToken = createRefreshTokenSigner(jwtConfigInput);
+  const verifyRefreshToken = createRefreshTokenVerifier(jwtConfigInput);
   const refreshTokenTtlSeconds = getRefreshTokenCookieMaxAgeSeconds();
   const sessionLocks = new Map<string, { tail: Promise<void>; pending: number }>();
 
@@ -242,7 +246,7 @@ export function createRefreshTokenService(
     },
 
     async rotateSession(refreshToken: string): Promise<RefreshSessionResult> {
-      let payload: RefreshTokenPayload;
+      let payload: VerifiedRefreshTokenPayload;
 
       try {
         payload = verifyRefreshToken(refreshToken);
@@ -282,8 +286,10 @@ export function createRefreshTokenService(
         assertRefreshSessionPayload(payload, existingSession);
 
         const nextPayload: RefreshTokenPayload = {
-          ...payload,
+          id: payload.id,
+          username: payload.username,
           tokenType: 'refresh',
+          sessionId: payload.sessionId,
           jti: randomUUID(),
         };
 
@@ -306,7 +312,7 @@ export function createRefreshTokenService(
       refreshToken: string,
       reason: RefreshTokenRevokeReason = 'logout',
     ): Promise<RefreshSessionRevokeResult> {
-      let payload: RefreshTokenPayload;
+      let payload: VerifiedRefreshTokenPayload;
 
       try {
         payload = verifyRefreshToken(refreshToken);

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
 import { FastifyRequest, FastifyReply } from 'fastify';
-import type { JwtPayload } from '../config/jwt';
+import type { JwtPayload, VerifiedJwtPayload } from '../config/jwt';
 import type { RefreshTokenService } from '../core/services/refresh-token.service';
 
 // ─────────────────────────────────────────────────────────────
@@ -12,7 +12,7 @@ declare module 'fastify' {
   interface FastifyInstance {
     authenticate(request: FastifyRequest, reply: FastifyReply): Promise<void>;
     signAccessToken(payload: JwtPayload): string;
-    verifyAccessToken(token: string): JwtPayload;
+    verifyAccessToken(token: string): VerifiedJwtPayload;
     refreshTokenService: RefreshTokenService;
   }
 

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildApp, generateTestToken, TEST_JWT_SECRET } from '../../helpers/build-app';
 import jwt from 'jsonwebtoken';
 import { REFRESH_TOKEN_COOKIE_NAME } from '@/config/auth-session';
+import type { JwtKeyRotationConfig } from '@/config/jwt';
 
 vi.mock('@/core/repositories/user.repository', () => ({
   userRepository: {
@@ -31,6 +32,14 @@ const mockUser = {
   isActive:      true,
   createdAt:     new Date(),
   updatedAt:     new Date(),
+};
+
+const jwtKeyRotationConfig: JwtKeyRotationConfig = {
+  activeKid: 'v2',
+  keys: {
+    v1: 'clutch-legacy-secret',
+    v2: TEST_JWT_SECRET,
+  },
 };
 
 function extractCookieHeader(setCookieHeader: string | string[] | undefined): string {
@@ -148,6 +157,11 @@ describe('Auth Routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.json()).toHaveProperty('token');
+      expect(jwt.decode(response.json().token as string, { complete: true })).toMatchObject({
+        header: {
+          kid: 'legacy',
+        },
+      });
       expect(String(response.headers['set-cookie'])).toContain(REFRESH_TOKEN_COOKIE_NAME);
       await app.close();
     });
@@ -319,6 +333,83 @@ describe('Auth Routes', () => {
         {
           algorithm: 'HS384',
           expiresIn: '7d',
+        },
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('aceita rota protegida com token assinado por chave valida configurada', async () => {
+      vi.mocked(userRepository.findById).mockResolvedValue(mockUser);
+
+      const app = await buildApp({ jwtKeyRotationConfig });
+      const token = app.signAccessToken({
+        id: 'user-id-1',
+        username: 'clutchplayer',
+      });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      await app.close();
+    });
+
+    it('rejeita rota protegida com kid invalido', async () => {
+      const app = await buildApp({ jwtKeyRotationConfig });
+      const token = jwt.sign(
+        {
+          id: 'user-id-1',
+          username: 'clutchplayer',
+          tokenType: 'access',
+        },
+        'unknown-secret',
+        {
+          algorithm: 'HS256',
+          expiresIn: '10m',
+          header: {
+            alg: 'HS256',
+            kid: 'v999',
+          },
+        },
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('rejeita rota protegida com token assinado por chave nao reconhecida', async () => {
+      const app = await buildApp({ jwtKeyRotationConfig });
+      const token = jwt.sign(
+        {
+          id: 'user-id-1',
+          username: 'clutchplayer',
+          tokenType: 'access',
+        },
+        'wrong-key',
+        {
+          algorithm: 'HS256',
+          expiresIn: '10m',
+          header: {
+            alg: 'HS256',
+            kid: 'v2',
+          },
         },
       );
 

--- a/backend/tests/unit/config/jwt.test.ts
+++ b/backend/tests/unit/config/jwt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import jwt from 'jsonwebtoken';
 import {
   createRefreshTokenSigner,
@@ -7,10 +7,57 @@ import {
   createJwtSigner,
   createJwtVerifier,
   extractBearerToken,
+  JwtKidRejectedError,
+  JwtRotationConfigError,
+  type JwtKeyRotationConfig,
 } from '@/config/jwt';
+
+type JsonLogEntry = Record<string, unknown>;
+
+function captureJsonLogs() {
+  const entries: JsonLogEntry[] = [];
+
+  const collect = (chunk: string | Uint8Array): boolean => {
+    const serialized = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+
+    for (const line of serialized.split('\n')) {
+      const trimmed = line.trim();
+
+      if (!trimmed.startsWith('{')) {
+        continue;
+      }
+
+      try {
+        entries.push(JSON.parse(trimmed) as JsonLogEntry);
+      } catch {
+        // Ignora linhas nao-JSON emitidas por bibliotecas.
+      }
+    }
+
+    return true;
+  };
+
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string | Uint8Array) => collect(chunk)) as typeof process.stderr.write);
+
+  return {
+    entries,
+    restore() {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+}
 
 describe('JWT config', () => {
   const secret = 'clutch-test-secret';
+  const keyRotationConfig: JwtKeyRotationConfig = {
+    activeKid: 'v2',
+    keys: {
+      v1: 'clutch-legacy-secret',
+      v2: secret,
+    },
+  };
 
   it('assina e valida um token com payload esperado', () => {
     const signAccessToken = createJwtSigner(secret);
@@ -21,35 +68,17 @@ describe('JWT config', () => {
       username: 'clutchplayer',
     });
 
-    expect(verifyAccessToken(token)).toEqual({
+    expect(verifyAccessToken(token)).toMatchObject({
       id: 'user-id-1',
       username: 'clutchplayer',
+      keyId: 'legacy',
+      tokenKeyId: 'legacy',
+      legacyToken: false,
     });
   });
 
-  it('assina e valida refresh token com sessionId e jti', () => {
-    const signRefreshToken = createRefreshTokenSigner(secret);
-    const verifyRefreshToken = createRefreshTokenVerifier(secret);
-
-    const token = signRefreshToken({
-      id: 'user-id-1',
-      username: 'clutchplayer',
-      tokenType: 'refresh',
-      sessionId: 'session-1',
-      jti: 'refresh-1',
-    });
-
-    expect(verifyRefreshToken(token)).toEqual({
-      id: 'user-id-1',
-      username: 'clutchplayer',
-      tokenType: 'refresh',
-      sessionId: 'session-1',
-      jti: 'refresh-1',
-    });
-  });
-
-  it('fixa o algoritmo HS256 na assinatura', () => {
-    const signAccessToken = createJwtSigner(secret);
+  it('assina access token com kid da chave ativa', () => {
+    const signAccessToken = createJwtSigner(keyRotationConfig);
     const token = signAccessToken({
       id: 'user-id-1',
       username: 'clutchplayer',
@@ -60,9 +89,102 @@ describe('JWT config', () => {
     expect(decoded).toMatchObject({
       header: {
         alg: 'HS256',
+        kid: 'v2',
         typ: 'JWT',
       },
     });
+  });
+
+  it('assina e valida refresh token com kid, sessionId e jti', () => {
+    const signRefreshToken = createRefreshTokenSigner(keyRotationConfig);
+    const verifyRefreshToken = createRefreshTokenVerifier(keyRotationConfig);
+
+    const token = signRefreshToken({
+      id: 'user-id-1',
+      username: 'clutchplayer',
+      tokenType: 'refresh',
+      sessionId: 'session-1',
+      jti: 'refresh-1',
+    });
+
+    expect(verifyRefreshToken(token)).toMatchObject({
+      id: 'user-id-1',
+      username: 'clutchplayer',
+      tokenType: 'refresh',
+      sessionId: 'session-1',
+      jti: 'refresh-1',
+      keyId: 'v2',
+      tokenKeyId: 'v2',
+      legacyToken: false,
+    });
+  });
+
+  it('aceita token legado sem kid usando uma chave valida configurada', () => {
+    const verifyAccessToken = createJwtVerifier(keyRotationConfig);
+    const legacyToken = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+        tokenType: 'access',
+      },
+      keyRotationConfig.keys.v1!,
+      {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+      },
+    );
+
+    expect(verifyAccessToken(legacyToken)).toMatchObject({
+      id: 'user-id-1',
+      username: 'clutchplayer',
+      keyId: 'v1',
+      tokenKeyId: null,
+      legacyToken: true,
+    });
+  });
+
+  it('rejeita token com kid desconhecido', () => {
+    const verifyAccessToken = createJwtVerifier(keyRotationConfig);
+    const token = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+        tokenType: 'access',
+      },
+      'kid-unknown-secret',
+      {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+        header: {
+          alg: 'HS256',
+          kid: 'v999',
+        },
+      },
+    );
+
+    expect(() => verifyAccessToken(token)).toThrow(JwtKidRejectedError);
+  });
+
+  it('rejeita token com assinatura feita por chave nao reconhecida', () => {
+    const verifyAccessToken = createJwtVerifier(keyRotationConfig);
+    const token = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+        tokenType: 'access',
+      },
+      'wrong-active-secret',
+      {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+        header: {
+          alg: 'HS256',
+          kid: 'v2',
+        },
+      },
+    );
+
+    expect(() => verifyAccessToken(token)).toThrow();
   });
 
   it('usa um TTL curto de 10 minutos para o access token', () => {
@@ -97,6 +219,10 @@ describe('JWT config', () => {
       {
         algorithm: 'HS256',
         expiresIn: -1,
+        header: {
+          alg: 'HS256',
+          kid: 'legacy',
+        },
       },
     );
 
@@ -114,6 +240,10 @@ describe('JWT config', () => {
       {
         algorithm: 'HS384',
         expiresIn: '7d',
+        header: {
+          alg: 'HS384',
+          kid: 'legacy',
+        },
       },
     );
 
@@ -124,6 +254,10 @@ describe('JWT config', () => {
     const verifyAccessToken = createJwtVerifier(secret);
     const token = jwt.sign('plain-string-payload', secret, {
       algorithm: 'HS256',
+      header: {
+        alg: 'HS256',
+        kid: 'legacy',
+      },
     });
 
     expect(() => verifyAccessToken(token)).toThrow();
@@ -140,6 +274,10 @@ describe('JWT config', () => {
       {
         algorithm: 'HS256',
         expiresIn: '7d',
+        header: {
+          alg: 'HS256',
+          kid: 'legacy',
+        },
       },
     );
 
@@ -160,12 +298,16 @@ describe('JWT config', () => {
     expect(extractBearerToken(undefined)).toBeNull();
   });
 
-  it('falha em produção quando JWT_SECRET não está configurado', () => {
+  it('falha em producao quando JWT_SECRET nao esta configurado', () => {
     const previousNodeEnv = process.env['NODE_ENV'];
     const previousSecret = process.env['JWT_SECRET'];
+    const previousKeyring = process.env['JWT_KEYS_JSON'];
+    const previousActiveKid = process.env['JWT_ACTIVE_KID'];
 
     process.env['NODE_ENV'] = 'production';
     delete process.env['JWT_SECRET'];
+    delete process.env['JWT_KEYS_JSON'];
+    delete process.env['JWT_ACTIVE_KID'];
 
     try {
       expect(() => createJwtSigner()).toThrow('JWT_SECRET deve ser configurado em produção.');
@@ -182,6 +324,102 @@ describe('JWT config', () => {
       } else {
         delete process.env['JWT_SECRET'];
       }
+
+      if (typeof previousKeyring === 'string') {
+        process.env['JWT_KEYS_JSON'] = previousKeyring;
+      } else {
+        delete process.env['JWT_KEYS_JSON'];
+      }
+
+      if (typeof previousActiveKid === 'string') {
+        process.env['JWT_ACTIVE_KID'] = previousActiveKid;
+      } else {
+        delete process.env['JWT_ACTIVE_KID'];
+      }
     }
+  });
+
+  it('falha quando a configuracao de rotacao aponta para active kid inexistente', () => {
+    expect(() => createJwtSigner({
+      activeKid: 'v2',
+      keys: { v1: 'legacy-secret' },
+    })).toThrow(JwtRotationConfigError);
+  });
+
+  it('falha quando multiplas chaves existem em ambiente e JWT_ACTIVE_KID nao esta configurado', () => {
+    const previousNodeEnv = process.env['NODE_ENV'];
+    const previousSecret = process.env['JWT_SECRET'];
+    const previousKeyring = process.env['JWT_KEYS_JSON'];
+    const previousActiveKid = process.env['JWT_ACTIVE_KID'];
+
+    delete process.env['JWT_SECRET'];
+    process.env['JWT_KEYS_JSON'] = JSON.stringify({
+      v1: 'legacy-secret',
+      v2: 'active-secret',
+    });
+    delete process.env['JWT_ACTIVE_KID'];
+
+    try {
+      expect(() => createJwtSigner()).toThrow(JwtRotationConfigError);
+    } finally {
+      if (typeof previousNodeEnv === 'string') {
+        process.env['NODE_ENV'] = previousNodeEnv;
+      } else {
+        delete process.env['NODE_ENV'];
+      }
+
+      if (typeof previousSecret === 'string') {
+        process.env['JWT_SECRET'] = previousSecret;
+      } else {
+        delete process.env['JWT_SECRET'];
+      }
+
+      if (typeof previousKeyring === 'string') {
+        process.env['JWT_KEYS_JSON'] = previousKeyring;
+      } else {
+        delete process.env['JWT_KEYS_JSON'];
+      }
+
+      if (typeof previousActiveKid === 'string') {
+        process.env['JWT_ACTIVE_KID'] = previousActiveKid;
+      } else {
+        delete process.env['JWT_ACTIVE_KID'];
+      }
+    }
+  });
+
+  it('loga a configuracao de rotacao sem expor o keyring nem segredos', () => {
+    const previousNodeEnv = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'development';
+    const capturedLogs = captureJsonLogs();
+
+    try {
+      createJwtSigner({
+        activeKid: 'audit-v2',
+        keys: {
+          'audit-v1': 'legacy-secret-audit',
+          'audit-v2': 'active-secret-audit',
+        },
+      });
+    } finally {
+      capturedLogs.restore();
+
+      if (typeof previousNodeEnv === 'string') {
+        process.env['NODE_ENV'] = previousNodeEnv;
+      } else {
+        delete process.env['NODE_ENV'];
+      }
+    }
+
+    const logEntry = capturedLogs.entries.find((entry) => entry.event === 'auth_jwt_rotation_config_loaded');
+
+    expect(logEntry).toMatchObject({
+      event: 'auth_jwt_rotation_config_loaded',
+      activeKid: 'audit-v2',
+      configuredKeyCount: 2,
+    });
+    expect(logEntry).not.toHaveProperty('configuredKids');
+    expect(JSON.stringify(logEntry)).not.toContain('legacy-secret-audit');
+    expect(JSON.stringify(logEntry)).not.toContain('active-secret-audit');
   });
 });


### PR DESCRIPTION
﻿## Resumo
Adiciona rotação de chave JWT com versionamento no backend, mantendo HS256 e compatibilidade controlada com tokens legados sem `kid`. A mudança permite transição segura entre chaves válidas sem invalidar abruptamente tokens recentes.

## O que foi alterado
- Implementado keyring versionado em `backend/src/config/jwt.ts`, com chave ativa para assinatura e conjunto de chaves válidas para verificação.
- Adicionado `kid` no header de access token e refresh token emitidos pelo sistema.
- Atualizada a verificação para selecionar a chave pelo `kid` e rejeitar `kid` desconhecido com `401`.
- Mantido fallback legado controlado para tokens sem `kid`, limitado ao keyring configurado e em ordem determinística.
- Endurecida a configuração de produção para falhar cedo quando a configuração de rotação estiver inconsistente.
- Instrumentados logs estruturados de rotação e rejeição de `kid`, sem expor segredo, token ou keyring completo.
- Atualizados testes unitários e de integração para cobrir assinatura com `kid`, compatibilidade legado, `kid` inválido e chave não reconhecida.

## Motivação
A assinatura com chave única cria risco operacional e de segurança: a rotação passa a ser abrupta, sem janela de transição segura, e um comprometimento da chave ativa exige corte duro de sessão. A rotação com `kid` reduz esse risco e prepara o sistema para trocas controladas de chave sem breaking change no contrato atual.

## Como validar
- `cd backend`
- `npm run test -- tests/unit/config/jwt.test.ts tests/unit/core/refresh-token.service.test.ts tests/integration/routes/auth.routes.test.ts`
- `npm run typecheck`
- `npm run lint`
- `cd ..`
- `docker compose up -d --build`
- `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- Validar login no backend e confirmar que o token emitido contém `kid` no header.
- Validar `GET /auth/me` com token novo válido retornando `200`.
- Validar `GET /auth/me` com token assinado com `kid` inválido retornando `401`.
- Inspecionar `docker compose logs --no-color backend --since 2m` e confirmar eventos `auth_jwt_rotation_config_loaded`, `auth_jwt_key_selected` e `auth_jwt_kid_rejected` sem dados sensíveis.

## Riscos e impactos
- O runtime atual do compose usa uma única chave ativa por padrão; a compatibilidade com múltiplas chaves válidas ficou comprovada principalmente por testes focados.
- Tokens legados sem `kid` continuam aceitos apenas durante a janela de transição, limitados ao keyring configurado.
- Não há mudança de contrato HTTP nem de algoritmo de assinatura.

## Evidências
- Testes focados de JWT, refresh token e rotas de autenticação passaram localmente.
- Validação containerizada confirmou login `200`, token emitido com `kid`, rota protegida com token válido `200` e rejeição de `kid` inválido com `401`.
- Inspeção de logs do backend não encontrou `JWT_SECRET`, `Authorization`, `Bearer`, `clutch_refresh` ou `clutch_session`.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #160
