### PR TITLE
feat(security): adicione rate limit aos endpoints de autenticação

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fastify/cors": "^9.0.1",
+        "@fastify/rate-limit": "^10.3.0",
         "@fastify/websocket": "^10.0.1",
         "@prisma/client": "^5.22.0",
         "axios": "^1.7.7",
@@ -956,6 +957,43 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/websocket": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-10.0.1.tgz",
@@ -1090,6 +1128,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@noble/hashes": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/websocket": "^10.0.1",
     "@prisma/client": "^5.22.0",
     "axios": "^1.7.7",

--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -14,6 +14,7 @@ import {
   RefreshTokenRevokedError,
   RefreshTokenReuseError,
 } from '../../core/services/refresh-token.service';
+import { AUTH_RATE_LIMIT_POLICIES } from '../../config/rate-limit';
 
 // ─────────────────────────────────────────────────────────────
 // Auth Routes
@@ -57,7 +58,11 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   }
 
   // ── POST /auth/register ──────────────────────────────────
-  app.post('/register', async (request, reply) => {
+  app.post('/register', {
+    config: {
+      rateLimit: AUTH_RATE_LIMIT_POLICIES.register,
+    },
+  }, async (request, reply) => {
     const result = registerSchema.safeParse(request.body);
     if (!result.success) {
       return reply.status(400).send({
@@ -91,7 +96,11 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ── POST /auth/login ─────────────────────────────────────
-  app.post('/login', async (request, reply) => {
+  app.post('/login', {
+    config: {
+      rateLimit: AUTH_RATE_LIMIT_POLICIES.login,
+    },
+  }, async (request, reply) => {
     const result = loginSchema.safeParse(request.body);
     if (!result.success) {
       return reply.status(400).send({
@@ -149,7 +158,11 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // ── POST /auth/refresh ───────────────────────────────────
-  app.post('/refresh', async (request, reply) => {
+  app.post('/refresh', {
+    config: {
+      rateLimit: AUTH_RATE_LIMIT_POLICIES.refresh,
+    },
+  }, async (request, reply) => {
     const refreshToken = parseCookieValue(request.headers.cookie, REFRESH_TOKEN_COOKIE_NAME);
 
     if (!refreshToken) {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,5 @@
 import Fastify, { FastifyInstance } from 'fastify';
+import fastifyRateLimit from '@fastify/rate-limit';
 import { authRoutes } from './api/routes/auth.routes';
 import { profileRoutes } from './api/routes/profile.routes';
 import { friendRoutes } from './api/routes/friends.routes';
@@ -22,11 +23,14 @@ import {
   type JwtKeyRotationConfig,
   createJwtVerifier,
 } from './config/jwt';
+import { createAuthRateLimitPluginOptions } from './config/rate-limit';
 import {
   createRefreshTokenService,
   type RefreshSessionStore,
 } from './core/services/refresh-token.service';
 import { createRedisRefreshSessionStore } from './infra/cache/refresh-session.store';
+import { redis as runtimeRedis } from './infra/cache/redis';
+import type Redis from 'ioredis';
 
 export type BuildAppOptions = {
   jwtSecret?: string;
@@ -34,6 +38,7 @@ export type BuildAppOptions = {
   logger?: boolean;
   readinessCheck?: () => Promise<ReadinessReport>;
   refreshSessionStore?: RefreshSessionStore;
+  rateLimitRedis?: Redis | null;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -44,6 +49,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     disableRequestLogging: true,
     requestIdHeader: REQUEST_ID_HEADER,
     genReqId: (request) => resolveBackendRequestId(request.headers),
+    trustProxy: 'loopback, linklocal, uniquelocal',
   });
   const jwtConfigInput = options.jwtKeyRotationConfig ?? options.jwtSecret;
   const signAccessToken = createJwtSigner(jwtConfigInput);
@@ -58,6 +64,13 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   app.decorate('signAccessToken', signAccessToken);
   app.decorate('verifyAccessToken', verifyAccessToken);
   app.decorate('refreshTokenService', refreshTokenService);
+
+  await app.register(
+    fastifyRateLimit,
+    createAuthRateLimitPluginOptions(
+      options.rateLimitRedis ?? (process.env['NODE_ENV'] === 'test' ? null : runtimeRedis),
+    ),
+  );
 
   const readinessCheck = options.readinessCheck ?? runReadinessChecks;
 

--- a/backend/src/config/rate-limit.ts
+++ b/backend/src/config/rate-limit.ts
@@ -1,0 +1,64 @@
+import type Redis from 'ioredis';
+import type { FastifyRequest } from 'fastify';
+
+type AuthRateLimitRouteId = 'login' | 'register' | 'refresh';
+
+function createExceededLogger(
+  routeId: AuthRateLimitRouteId,
+  max: number,
+  timeWindow: string,
+) {
+  return (request: FastifyRequest): void => {
+    request.log.warn({
+      event: 'auth_rate_limit_exceeded',
+      requestId: request.id,
+      method: request.method,
+      path: request.url,
+      status: 429,
+      limiter: routeId,
+      max,
+      timeWindow,
+    }, 'Auth rate limit exceeded');
+  };
+}
+
+function buildPolicy(
+  routeId: AuthRateLimitRouteId,
+  max: number,
+  timeWindow: string,
+){
+  return {
+    routeId,
+    groupId: `auth-${routeId}`,
+    max,
+    timeWindow,
+    onExceeded: createExceededLogger(routeId, max, timeWindow),
+  };
+}
+
+export const AUTH_RATE_LIMIT_POLICIES = {
+  // 5 tentativas em 5 minutos cobre erro humano comum sem deixar brute force barato.
+  login: buildPolicy('login', 5, '5 minutes'),
+  // Cadastro legitimo é raro; 3 em 15 minutos reduz abuso automatizado sem bloquear onboarding normal.
+  register: buildPolicy('register', 3, '15 minutes'),
+  // Refresh precisa tolerar chamadas concorrentes do SSR sem virar vetor de flooding.
+  refresh: buildPolicy('refresh', 20, '1 minute'),
+} as const;
+
+export function createAuthRateLimitPluginOptions(
+  redisClient?: Redis | null,
+){
+  return {
+    global: false,
+    hook: 'onRequest' as const,
+    nameSpace: 'clutch-auth-rate-limit-',
+    keyGenerator: (request: FastifyRequest): string => request.ip,
+    skipOnError: true,
+    redis: redisClient ?? undefined,
+    errorResponseBuilder: () => ({
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: 'Muitas tentativas. Tente novamente em instantes.',
+    }),
+  };
+}

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -141,6 +141,36 @@ describe('Auth Routes', () => {
       expect(response.statusCode).toBe(400);
       await app.close();
     });
+
+    it('bloqueia cadastro acima do limite com 429', async () => {
+      vi.mocked(userRepository.existsByEmailOrUsername).mockResolvedValue(true);
+
+      const app = await buildApp();
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/auth/register',
+          payload: { username: `clutchplayer${attempt}`, email: `player${attempt}@clutch.gg`, password: 'password123' },
+        });
+
+        expect(response.statusCode).toBe(409);
+      }
+
+      const blockedResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/register',
+        payload: { username: 'clutchplayer-overflow', email: 'overflow@clutch.gg', password: 'password123' },
+      });
+
+      expect(blockedResponse.statusCode).toBe(429);
+      expect(blockedResponse.json()).toMatchObject({
+        error: 'Too Many Requests',
+        message: 'Muitas tentativas. Tente novamente em instantes.',
+        statusCode: 429,
+      });
+      await app.close();
+    });
   });
 
   describe('POST /auth/login', () => {
@@ -246,6 +276,52 @@ describe('Auth Routes', () => {
         reason: 'invalid_credentials',
       });
       expect(JSON.stringify(capturedLogs.entries)).not.toContain('password123');
+      await app.close();
+    });
+
+    it('bloqueia login acima do limite com 429 e log estruturado seguro', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(null);
+      const capturedLogs = captureJsonLogs();
+
+      const app = await buildApp({ logger: true });
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/auth/login',
+          headers: { 'x-request-id': `req-login-limit-${attempt}` },
+          payload: { email: 'player@clutch.gg', password: 'wrong-password' },
+        });
+
+        expect(response.statusCode).toBe(401);
+      }
+
+      const blockedResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        headers: { 'x-request-id': 'req-login-limit-blocked' },
+        payload: { email: 'player@clutch.gg', password: 'wrong-password' },
+      });
+
+      capturedLogs.restore();
+
+      expect(blockedResponse.statusCode).toBe(429);
+      expect(blockedResponse.json()).toMatchObject({
+        error: 'Too Many Requests',
+        message: 'Muitas tentativas. Tente novamente em instantes.',
+        statusCode: 429,
+      });
+      const logEntry = capturedLogs.entries.find((entry) => entry.event === 'auth_rate_limit_exceeded');
+      expect(logEntry).toMatchObject({
+        event: 'auth_rate_limit_exceeded',
+        requestId: 'req-login-limit-blocked',
+        method: 'POST',
+        path: '/auth/login',
+        status: 429,
+        limiter: 'login',
+      });
+      expect(JSON.stringify(logEntry)).not.toContain('wrong-password');
+      expect(JSON.stringify(logEntry)).not.toContain('Authorization');
       await app.close();
     });
   });
@@ -569,6 +645,62 @@ describe('Auth Routes', () => {
         reason: 'logout',
       });
       expect(JSON.stringify(capturedLogs.entries)).not.toContain('clutch_refresh=');
+      await app.close();
+    });
+
+    it('bloqueia refresh acima do limite com 429', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(mockUser);
+      vi.mocked(bcrypt.compare).mockResolvedValue(true as never);
+
+      const app = await buildApp();
+      const loginResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        payload: { email: 'player@clutch.gg', password: 'password123' },
+      });
+
+      const refreshCookie = extractCookieHeader(loginResponse.headers['set-cookie']);
+
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const response = await app.inject({
+          method: 'POST',
+          url: '/auth/refresh',
+          headers: { cookie: refreshCookie },
+        });
+
+        expect([200, 401]).toContain(response.statusCode);
+      }
+
+      const blockedResponse = await app.inject({
+        method: 'POST',
+        url: '/auth/refresh',
+        headers: { cookie: refreshCookie },
+      });
+
+      expect(blockedResponse.statusCode).toBe(429);
+      await app.close();
+    });
+
+    it('nao afeta rota fora do auth path apos exceder o limite de login', async () => {
+      vi.mocked(userRepository.findByEmail).mockResolvedValue(null);
+
+      const app = await buildApp();
+
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        await app.inject({
+          method: 'POST',
+          url: '/auth/login',
+          payload: { email: 'player@clutch.gg', password: 'wrong-password' },
+        });
+      }
+
+      const healthResponse = await app.inject({
+        method: 'GET',
+        url: '/health',
+      });
+
+      expect(healthResponse.statusCode).toBe(200);
+      expect(healthResponse.json()).toMatchObject({ status: 'ok' });
       await app.close();
     });
   });


### PR DESCRIPTION
﻿## Resumo
Adiciona rate limit por rota no auth path para reduzir brute force e flooding em `login`, `register` e `refresh`, sem alterar o contrato HTTP existente. A mudança mantém o fluxo normal abaixo do limite e endurece o backend com resposta previsível e observabilidade estruturada.

## O que foi alterado
- Registrado `@fastify/rate-limit` no backend com configuração centralizada para o auth path.
- Aplicados limites específicos em `POST /auth/login`, `POST /auth/register` e `POST /auth/refresh`.
- Definida chave do limiter com `request.ip`, usando `trustProxy` restrito a redes privadas para alinhar com Traefik sem aceitar `x-forwarded-for` bruto.
- Adicionado evento estruturado `auth_rate_limit_exceeded` sem IP, headers, cookies ou credenciais.
- Atualizados testes de integração para bloqueio por rota, rota fora do auth path e logging seguro.

## Motivação
O auth path ainda não tinha proteção específica contra brute force e abuso. O objetivo é reduzir custo de ataque e flooding sem criar regressão para usuários legítimos nem introduzir bloqueio global fora do escopo da autenticação.

## Como validar
- `cd backend`
- `npm run test -- tests/integration/routes/auth.routes.test.ts tests/unit/core/refresh-token.service.test.ts`
- `npm run typecheck`
- `npm run lint`
- `cd ..`
- `docker compose up -d --build`
- `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- Validar via proxy:
  - `POST /api/auth/login` normal retorna `200`
  - `POST /api/auth/register` normal retorna `201`
  - `POST /api/auth/refresh` abaixo do limite continua funcional
  - tentativas repetidas de `POST /api/auth/login` retornam `429` ao exceder a janela
  - abuso de `POST /api/auth/refresh` retorna `429` ao exceder a janela
- Inspecionar `docker compose logs --no-color backend --since 2m` e confirmar eventos `auth_rate_limit_exceeded` sem dados sensíveis.

## Riscos e impactos
- `skipOnError: true` foi mantido de forma deliberada para preservar disponibilidade do auth path se o store do limiter falhar. O sistema passa a operar temporariamente em modo aberto para rate limit, com menos proteção momentânea contra abuso, mas sem derrubar autenticação.
- O limiter usa Redis no runtime principal e fallback controlado nos testes; isso mantém previsibilidade no stack atual sem acoplar a suíte local à disponibilidade do Redis.
- Não há mudança de contrato HTTP de sucesso nem impacto em rotas fora do auth path.

## Evidências
- Testes focados de integração e serviço de refresh passaram localmente.
- Validação containerizada confirmou backend saudável e fluxo normal de `login`, `register` e `refresh` abaixo do limite.
- Validação operacional confirmou `429` nos excessos e logs estruturados com `auth_rate_limit_exceeded` sem `Authorization`, cookies ou credenciais.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #165
