### PR TITLE
fix(auth): valide claims adicionais do JWT

### DIFF
--- a/backend/src/api/middlewares/authenticate.ts
+++ b/backend/src/api/middlewares/authenticate.ts
@@ -2,6 +2,8 @@ import { FastifyRequest, FastifyReply } from 'fastify';
 import jwt from 'jsonwebtoken';
 import {
   extractBearerToken,
+  JwtAudienceRejectedError,
+  JwtIssuerRejectedError,
   JwtKidRejectedError,
   type VerifiedJwtPayload,
 } from '../../config/jwt';
@@ -63,6 +65,30 @@ export async function authenticate(
       return reply.status(401).send({ message: 'Token inválido ou expirado.' });
     }
 
+    if (error instanceof JwtIssuerRejectedError) {
+      request.log.warn({
+        event: 'auth_jwt_issuer_rejected',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: error.reason,
+      }, 'JWT issuer rejected');
+      return reply.status(401).send({ message: 'Token inválido ou expirado.' });
+    }
+
+    if (error instanceof JwtAudienceRejectedError) {
+      request.log.warn({
+        event: 'auth_jwt_audience_rejected',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: error.reason,
+      }, 'JWT audience rejected');
+      return reply.status(401).send({ message: 'Token inválido ou expirado.' });
+    }
+
     if (error instanceof jwt.TokenExpiredError) {
       request.log.warn({
         event: 'auth_access_token_expired',
@@ -71,6 +97,15 @@ export async function authenticate(
         path: request.url,
         status: 401,
       }, 'Access token expired');
+    } else if (error instanceof jwt.NotBeforeError) {
+      request.log.warn({
+        event: 'auth_jwt_not_before_rejected',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        status: 401,
+        reason: 'not_before',
+      }, 'JWT rejected before not-before claim');
     } else {
       request.log.warn({
         event: 'auth_access_token_rejected',

--- a/backend/src/config/jwt.ts
+++ b/backend/src/config/jwt.ts
@@ -15,6 +15,9 @@ export interface VerifiedJwtPayload extends JwtPayload {
   keyId: string;
   tokenKeyId: string | null;
   legacyToken: boolean;
+  issuerPresent: boolean;
+  audiencePresent: boolean;
+  notBeforePresent: boolean;
 }
 
 export interface RefreshTokenPayload extends JwtPayload {
@@ -27,6 +30,9 @@ export interface VerifiedRefreshTokenPayload extends RefreshTokenPayload {
   keyId: string;
   tokenKeyId: string | null;
   legacyToken: boolean;
+  issuerPresent: boolean;
+  audiencePresent: boolean;
+  notBeforePresent: boolean;
 }
 
 export type JwtKeyRotationConfig = {
@@ -50,11 +56,20 @@ type JwtHeaderMetadata = {
   kid: string | null;
 };
 
+type JwtClaimConfig = {
+  issuer: string;
+  audience: string;
+};
+
 const JWT_ALGORITHM = 'HS256';
 const DEFAULT_DEVELOPMENT_JWT_SECRET = 'clutch-dev-secret-change-in-production';
 const DEFAULT_SINGLE_KEY_KID = 'legacy';
 const JWT_KEYRING_ENV = 'JWT_KEYS_JSON';
 const JWT_ACTIVE_KID_ENV = 'JWT_ACTIVE_KID';
+const JWT_ISSUER_ENV = 'JWT_ISSUER';
+const JWT_AUDIENCE_ENV = 'JWT_AUDIENCE';
+const DEFAULT_JWT_ISSUER = 'clutch.backend';
+const DEFAULT_JWT_AUDIENCE = 'clutch.auth';
 const BEARER_TOKEN_PATTERN = /^Bearer (?<token>[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)$/u;
 // 10 minutos reduz a janela de ataque sem forcar refresh excessivo em navegacao comum.
 const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 60 * 10;
@@ -80,6 +95,26 @@ export class JwtKidRejectedError extends Error {
   }
 }
 
+export class JwtIssuerRejectedError extends Error {
+  readonly reason: 'invalid_issuer';
+
+  constructor() {
+    super('JWT issuer invalido.');
+    this.name = 'JwtIssuerRejectedError';
+    this.reason = 'invalid_issuer';
+  }
+}
+
+export class JwtAudienceRejectedError extends Error {
+  readonly reason: 'invalid_audience';
+
+  constructor() {
+    super('JWT audience invalida.');
+    this.name = 'JwtAudienceRejectedError';
+    this.reason = 'invalid_audience';
+  }
+}
+
 function resolveJwtSecret(secret?: string): Secret {
   if (typeof secret === 'string' && secret.trim().length > 0) {
     return secret;
@@ -96,6 +131,37 @@ function resolveJwtSecret(secret?: string): Secret {
   }
 
   return DEFAULT_DEVELOPMENT_JWT_SECRET;
+}
+
+function resolveJwtClaimConfig(): JwtClaimConfig {
+  const configuredIssuer = process.env[JWT_ISSUER_ENV]?.trim();
+  const configuredAudience = process.env[JWT_AUDIENCE_ENV]?.trim();
+
+  if (process.env['NODE_ENV'] === 'production') {
+    if (!configuredIssuer || configuredIssuer.length === 0) {
+      throw new JwtRotationConfigError('JWT_ISSUER deve ser configurado em produção.');
+    }
+
+    if (!configuredAudience || configuredAudience.length === 0) {
+      throw new JwtRotationConfigError('JWT_AUDIENCE deve ser configurado em produção.');
+    }
+  }
+
+  const issuer = configuredIssuer && configuredIssuer.length > 0
+    ? configuredIssuer
+    : DEFAULT_JWT_ISSUER;
+  const audience = configuredAudience && configuredAudience.length > 0
+    ? configuredAudience
+    : DEFAULT_JWT_AUDIENCE;
+
+  if (issuer.length === 0 || audience.length === 0) {
+    throw new JwtRotationConfigError('JWT_ISSUER e JWT_AUDIENCE devem ser strings não vazias.');
+  }
+
+  return {
+    issuer,
+    audience,
+  };
 }
 
 function isJwtPayload(payload: string | JsonWebTokenPayload): payload is JsonWebTokenPayload {
@@ -348,6 +414,16 @@ function decodeJwtHeader(token: string): JwtHeaderMetadata {
   };
 }
 
+function decodeJwtPayload(token: string): JsonWebTokenPayload {
+  const decoded = jwt.decode(token);
+
+  if (!decoded || !isJwtPayload(decoded)) {
+    throw new Error('Token JWT invalido.');
+  }
+
+  return decoded;
+}
+
 function resolveVerificationCandidates(
   config: ResolvedJwtKeyRotationConfig,
   tokenKeyId: string | null,
@@ -376,13 +452,29 @@ function resolveVerificationCandidates(
 function verifyTokenAgainstCandidates<TPayload>(
   token: string,
   config: ResolvedJwtKeyRotationConfig,
+  claimConfig: JwtClaimConfig,
   // eslint-disable-next-line no-unused-vars
   assertPayload: (_payload: string | JsonWebTokenPayload) => TPayload,
-): TPayload & { keyId: string; tokenKeyId: string | null; legacyToken: boolean } {
+): TPayload & {
+  keyId: string;
+  tokenKeyId: string | null;
+  legacyToken: boolean;
+  issuerPresent: boolean;
+  audiencePresent: boolean;
+  notBeforePresent: boolean;
+} {
   const tokenHeader = decodeJwtHeader(token);
+  const decodedPayload = decodeJwtPayload(token);
+  const issuerPresent = typeof decodedPayload['iss'] === 'string' && decodedPayload['iss'].trim().length > 0;
+  const notBeforePresent = typeof decodedPayload['nbf'] === 'number';
+  const audienceClaim = decodedPayload['aud'];
+  const audiencePresent = typeof audienceClaim === 'string'
+    ? audienceClaim.trim().length > 0
+    : Array.isArray(audienceClaim) && audienceClaim.some((value) => typeof value === 'string' && value.trim().length > 0);
   const verifyOptions: VerifyOptions = {
     algorithms: [JWT_ALGORITHM],
     ignoreExpiration: false,
+    ignoreNotBefore: false,
   };
   const candidates = resolveVerificationCandidates(config, tokenHeader.kid);
   let lastError: unknown = new Error('Token JWT invalido.');
@@ -391,11 +483,26 @@ function verifyTokenAgainstCandidates<TPayload>(
     try {
       const payload = jwt.verify(token, candidate.secret, verifyOptions);
 
+      if (issuerPresent && decodedPayload['iss'] !== claimConfig.issuer) {
+        throw new JwtIssuerRejectedError();
+      }
+
+      const normalizedAudience = Array.isArray(audienceClaim) ? audienceClaim : [audienceClaim];
+      if (
+        audiencePresent &&
+        !normalizedAudience.some((value) => typeof value === 'string' && value === claimConfig.audience)
+      ) {
+        throw new JwtAudienceRejectedError();
+      }
+
       return {
         ...assertPayload(payload),
         keyId: candidate.keyId,
         tokenKeyId: tokenHeader.kid,
         legacyToken: candidate.legacyToken,
+        issuerPresent,
+        audiencePresent,
+        notBeforePresent,
       };
     } catch (error) {
       lastError = error;
@@ -407,11 +514,15 @@ function verifyTokenAgainstCandidates<TPayload>(
 
 export function createJwtSigner(input?: string | JwtKeyRotationConfig) {
   const resolvedConfig = resolveJwtKeyRotationConfig(input);
+  const claimConfig = resolveJwtClaimConfig();
 
   return (payload: JwtPayload): string => {
     const signOptions: SignOptions = {
       algorithm: JWT_ALGORITHM,
       expiresIn: `${getAccessTokenTtlSeconds()}s`,
+      issuer: claimConfig.issuer,
+      audience: claimConfig.audience,
+      notBefore: 0,
       header: {
         alg: JWT_ALGORITHM,
         kid: resolvedConfig.activeKid,
@@ -431,21 +542,27 @@ export function createJwtSigner(input?: string | JwtKeyRotationConfig) {
 
 export function createJwtVerifier(input?: string | JwtKeyRotationConfig) {
   const resolvedConfig = resolveJwtKeyRotationConfig(input);
+  const claimConfig = resolveJwtClaimConfig();
 
   return (token: string): VerifiedJwtPayload => verifyTokenAgainstCandidates(
     token,
     resolvedConfig,
+    claimConfig,
     assertJwtPayload,
   );
 }
 
 export function createRefreshTokenSigner(input?: string | JwtKeyRotationConfig) {
   const resolvedConfig = resolveJwtKeyRotationConfig(input);
+  const claimConfig = resolveJwtClaimConfig();
 
   return (payload: RefreshTokenPayload): string => {
     const signOptions: SignOptions = {
       algorithm: JWT_ALGORITHM,
       expiresIn: `${resolveRefreshTokenTtlSeconds()}s`,
+      issuer: claimConfig.issuer,
+      audience: claimConfig.audience,
+      notBefore: 0,
       header: {
         alg: JWT_ALGORITHM,
         kid: resolvedConfig.activeKid,
@@ -462,10 +579,12 @@ export function createRefreshTokenSigner(input?: string | JwtKeyRotationConfig) 
 
 export function createRefreshTokenVerifier(input?: string | JwtKeyRotationConfig) {
   const resolvedConfig = resolveJwtKeyRotationConfig(input);
+  const claimConfig = resolveJwtClaimConfig();
 
   return (token: string): VerifiedRefreshTokenPayload => verifyTokenAgainstCandidates(
     token,
     resolvedConfig,
+    claimConfig,
     assertRefreshTokenPayload,
   );
 }

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -191,7 +191,12 @@ describe('Auth Routes', () => {
         header: {
           kid: 'legacy',
         },
+        payload: {
+          iss: 'clutch.backend',
+          aud: 'clutch.auth',
+        },
       });
+      expect(typeof (jwt.decode(response.json().token as string) as jwt.JwtPayload | null)?.nbf).toBe('number');
       expect(String(response.headers['set-cookie'])).toContain(REFRESH_TOKEN_COOKIE_NAME);
       await app.close();
     });
@@ -378,6 +383,9 @@ describe('Auth Routes', () => {
         {
           algorithm: 'HS256',
           expiresIn: -1,
+          issuer: 'clutch.backend',
+          audience: 'clutch.auth',
+          notBefore: 0,
         },
       );
 
@@ -409,6 +417,9 @@ describe('Auth Routes', () => {
         {
           algorithm: 'HS384',
           expiresIn: '7d',
+          issuer: 'clutch.backend',
+          audience: 'clutch.auth',
+          notBefore: 0,
         },
       );
 
@@ -482,9 +493,105 @@ describe('Auth Routes', () => {
         {
           algorithm: 'HS256',
           expiresIn: '10m',
+          issuer: 'clutch.backend',
+          audience: 'clutch.auth',
+          notBefore: 0,
           header: {
             alg: 'HS256',
             kid: 'v2',
+          },
+        },
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('rejeita rota protegida com issuer invalido', async () => {
+      const app = await buildApp();
+      const token = jwt.sign(
+        {
+          id: 'user-id-1',
+          username: 'clutchplayer',
+        },
+        TEST_JWT_SECRET,
+        {
+          algorithm: 'HS256',
+          expiresIn: '10m',
+          issuer: 'external.backend',
+          audience: 'clutch.auth',
+          notBefore: 0,
+          header: {
+            alg: 'HS256',
+            kid: 'legacy',
+          },
+        },
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('rejeita rota protegida com audience invalida', async () => {
+      const app = await buildApp();
+      const token = jwt.sign(
+        {
+          id: 'user-id-1',
+          username: 'clutchplayer',
+        },
+        TEST_JWT_SECRET,
+        {
+          algorithm: 'HS256',
+          expiresIn: '10m',
+          issuer: 'clutch.backend',
+          audience: 'external-client',
+          notBefore: 0,
+          header: {
+            alg: 'HS256',
+            kid: 'legacy',
+          },
+        },
+      );
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await app.close();
+    });
+
+    it('rejeita rota protegida com nbf futuro', async () => {
+      const app = await buildApp();
+      const token = jwt.sign(
+        {
+          id: 'user-id-1',
+          username: 'clutchplayer',
+        },
+        TEST_JWT_SECRET,
+        {
+          algorithm: 'HS256',
+          expiresIn: '10m',
+          issuer: 'clutch.backend',
+          audience: 'clutch.auth',
+          notBefore: '30s',
+          header: {
+            alg: 'HS256',
+            kid: 'legacy',
           },
         },
       );

--- a/backend/tests/unit/config/jwt.test.ts
+++ b/backend/tests/unit/config/jwt.test.ts
@@ -74,6 +74,9 @@ describe('JWT config', () => {
       keyId: 'legacy',
       tokenKeyId: 'legacy',
       legacyToken: false,
+      issuerPresent: true,
+      audiencePresent: true,
+      notBeforePresent: true,
     });
   });
 
@@ -92,7 +95,13 @@ describe('JWT config', () => {
         kid: 'v2',
         typ: 'JWT',
       },
+      payload: {
+        iss: 'clutch.backend',
+        aud: 'clutch.auth',
+      },
     });
+    const payload = (decoded as jwt.Jwt | null)?.payload;
+    expect(payload && typeof payload !== 'string' ? typeof payload.nbf : 'undefined').toBe('number');
   });
 
   it('assina e valida refresh token com kid, sessionId e jti', () => {
@@ -116,6 +125,9 @@ describe('JWT config', () => {
       keyId: 'v2',
       tokenKeyId: 'v2',
       legacyToken: false,
+      issuerPresent: true,
+      audiencePresent: true,
+      notBeforePresent: true,
     });
   });
 
@@ -140,7 +152,112 @@ describe('JWT config', () => {
       keyId: 'v1',
       tokenKeyId: null,
       legacyToken: true,
+      issuerPresent: false,
+      audiencePresent: false,
+      notBeforePresent: false,
     });
+  });
+
+  it('aceita token com issuer valida', () => {
+    const verifyAccessToken = createJwtVerifier(secret);
+    const token = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+      },
+      secret,
+      {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+        issuer: 'clutch.backend',
+        audience: 'clutch.auth',
+        notBefore: 0,
+        header: {
+          alg: 'HS256',
+          kid: 'legacy',
+        },
+      },
+    );
+
+    expect(verifyAccessToken(token)).toMatchObject({
+      id: 'user-id-1',
+      username: 'clutchplayer',
+      issuerPresent: true,
+      audiencePresent: true,
+      notBeforePresent: true,
+    });
+  });
+
+  it('rejeita token com issuer invalida', () => {
+    const verifyAccessToken = createJwtVerifier(secret);
+    const token = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+      },
+      secret,
+      {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+        issuer: 'external.backend',
+        audience: 'clutch.auth',
+        notBefore: 0,
+        header: {
+          alg: 'HS256',
+          kid: 'legacy',
+        },
+      },
+    );
+
+    expect(() => verifyAccessToken(token)).toThrow('JWT issuer invalido.');
+  });
+
+  it('rejeita token com audience invalida', () => {
+    const verifyAccessToken = createJwtVerifier(secret);
+    const token = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+      },
+      secret,
+      {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+        issuer: 'clutch.backend',
+        audience: 'external-client',
+        notBefore: 0,
+        header: {
+          alg: 'HS256',
+          kid: 'legacy',
+        },
+      },
+    );
+
+    expect(() => verifyAccessToken(token)).toThrow('JWT audience invalida.');
+  });
+
+  it('rejeita token com nbf no futuro', () => {
+    const verifyAccessToken = createJwtVerifier(secret);
+    const token = jwt.sign(
+      {
+        id: 'user-id-1',
+        username: 'clutchplayer',
+      },
+      secret,
+      {
+        algorithm: 'HS256',
+        expiresIn: '10m',
+        issuer: 'clutch.backend',
+        audience: 'clutch.auth',
+        notBefore: '30s',
+        header: {
+          alg: 'HS256',
+          kid: 'legacy',
+        },
+      },
+    );
+
+    expect(() => verifyAccessToken(token)).toThrow();
   });
 
   it('rejeita token com kid desconhecido', () => {
@@ -303,11 +420,15 @@ describe('JWT config', () => {
     const previousSecret = process.env['JWT_SECRET'];
     const previousKeyring = process.env['JWT_KEYS_JSON'];
     const previousActiveKid = process.env['JWT_ACTIVE_KID'];
+    const previousIssuer = process.env['JWT_ISSUER'];
+    const previousAudience = process.env['JWT_AUDIENCE'];
 
     process.env['NODE_ENV'] = 'production';
     delete process.env['JWT_SECRET'];
     delete process.env['JWT_KEYS_JSON'];
     delete process.env['JWT_ACTIVE_KID'];
+    delete process.env['JWT_ISSUER'];
+    delete process.env['JWT_AUDIENCE'];
 
     try {
       expect(() => createJwtSigner()).toThrow('JWT_SECRET deve ser configurado em produção.');
@@ -335,6 +456,98 @@ describe('JWT config', () => {
         process.env['JWT_ACTIVE_KID'] = previousActiveKid;
       } else {
         delete process.env['JWT_ACTIVE_KID'];
+      }
+
+      if (typeof previousIssuer === 'string') {
+        process.env['JWT_ISSUER'] = previousIssuer;
+      } else {
+        delete process.env['JWT_ISSUER'];
+      }
+
+      if (typeof previousAudience === 'string') {
+        process.env['JWT_AUDIENCE'] = previousAudience;
+      } else {
+        delete process.env['JWT_AUDIENCE'];
+      }
+    }
+  });
+
+  it('falha em producao quando JWT_ISSUER nao esta configurado', () => {
+    const previousNodeEnv = process.env['NODE_ENV'];
+    const previousSecret = process.env['JWT_SECRET'];
+    const previousIssuer = process.env['JWT_ISSUER'];
+    const previousAudience = process.env['JWT_AUDIENCE'];
+
+    process.env['NODE_ENV'] = 'production';
+    process.env['JWT_SECRET'] = secret;
+    delete process.env['JWT_ISSUER'];
+    process.env['JWT_AUDIENCE'] = 'clutch.auth';
+
+    try {
+      expect(() => createJwtSigner()).toThrow('JWT_ISSUER deve ser configurado em produção.');
+    } finally {
+      if (typeof previousNodeEnv === 'string') {
+        process.env['NODE_ENV'] = previousNodeEnv;
+      } else {
+        delete process.env['NODE_ENV'];
+      }
+
+      if (typeof previousSecret === 'string') {
+        process.env['JWT_SECRET'] = previousSecret;
+      } else {
+        delete process.env['JWT_SECRET'];
+      }
+
+      if (typeof previousIssuer === 'string') {
+        process.env['JWT_ISSUER'] = previousIssuer;
+      } else {
+        delete process.env['JWT_ISSUER'];
+      }
+
+      if (typeof previousAudience === 'string') {
+        process.env['JWT_AUDIENCE'] = previousAudience;
+      } else {
+        delete process.env['JWT_AUDIENCE'];
+      }
+    }
+  });
+
+  it('falha em producao quando JWT_AUDIENCE nao esta configurado', () => {
+    const previousNodeEnv = process.env['NODE_ENV'];
+    const previousSecret = process.env['JWT_SECRET'];
+    const previousIssuer = process.env['JWT_ISSUER'];
+    const previousAudience = process.env['JWT_AUDIENCE'];
+
+    process.env['NODE_ENV'] = 'production';
+    process.env['JWT_SECRET'] = secret;
+    process.env['JWT_ISSUER'] = 'clutch.backend';
+    delete process.env['JWT_AUDIENCE'];
+
+    try {
+      expect(() => createJwtSigner()).toThrow('JWT_AUDIENCE deve ser configurado em produção.');
+    } finally {
+      if (typeof previousNodeEnv === 'string') {
+        process.env['NODE_ENV'] = previousNodeEnv;
+      } else {
+        delete process.env['NODE_ENV'];
+      }
+
+      if (typeof previousSecret === 'string') {
+        process.env['JWT_SECRET'] = previousSecret;
+      } else {
+        delete process.env['JWT_SECRET'];
+      }
+
+      if (typeof previousIssuer === 'string') {
+        process.env['JWT_ISSUER'] = previousIssuer;
+      } else {
+        delete process.env['JWT_ISSUER'];
+      }
+
+      if (typeof previousAudience === 'string') {
+        process.env['JWT_AUDIENCE'] = previousAudience;
+      } else {
+        delete process.env['JWT_AUDIENCE'];
       }
     }
   });


### PR DESCRIPTION
## Resumo
Adiciona validação explícita de `iss`, `aud` e `nbf` no fluxo JWT do backend, preservando o contrato HTTP atual e endurecendo a aceitação de tokens fora do contexto esperado.

## O que foi alterado
- Emissão de `iss`, `aud` e `nbf` em novos access tokens e refresh tokens.
- Verificação explícita de issuer, audience e not-before no núcleo JWT.
- Eventos estruturados para rejeição por issuer, audience e not-before no middleware de autenticação.
- Cobertura unitária e de integração para claims válidas, claims inválidas, configuração inconsistente e compatibilidade com tokens legados sem claims.

## Motivação
A assinatura e a expiração já estavam protegidas, mas ainda faltava validar o contexto do token. Sem `iss`, `aud` e `nbf`, um token válido criptograficamente ainda poderia ser aceito fora do ambiente ou propósito esperados.

## Como validar
- Executar `npm run test -- tests/unit/config/jwt.test.ts tests/unit/core/refresh-token.service.test.ts tests/integration/routes/auth.routes.test.ts` em `backend/`.
- Executar `npm run typecheck` em `backend/`.
- Executar `npm run lint` em `backend/`.
- Subir o stack com `docker compose up -d --build`.
- Executar `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`.
- Fazer login e verificar que o token emitido contém `kid`, `iss`, `aud` e `nbf`.
- Validar `GET /auth/me` com token válido retornando `200`.
- Validar `GET /auth/me` com tokens de `iss`, `aud` e `nbf` inválidos retornando `401`.
- Inspecionar `docker compose logs --no-color backend --since 2m` e verificar os eventos `auth_jwt_issuer_rejected`, `auth_jwt_audience_rejected` e `auth_jwt_not_before_rejected` sem dados sensíveis.

## Riscos e impactos
- Não há mudança de contrato HTTP, mas há endurecimento da verificação de tokens.
- A compatibilidade com tokens legados sem `iss`, `aud` e `nbf` foi mantida de forma transitória para evitar invalidação abrupta de sessões já emitidas.
- Essa janela de compatibilidade é temporária: esses tokens legados continuam válidos apenas até expirarem ou saírem de circulação. Um passo posterior pode remover essa compatibilidade quando a janela operacional terminar.
- `nbf` foi emitido com `notBefore: 0`. O ganho prático adicional é limitado, mas a presença explícita da claim permite validação consistente quando o token a carrega.
- Em produção, `JWT_ISSUER` e `JWT_AUDIENCE` passam a ser configuração obrigatória. Inicialização com configuração inconsistente falha cedo.

## Evidências
- Testes focados de JWT e auth passaram localmente.
- Validação operacional no backend containerizado confirmou:
  - login com token emitido contendo `kid`, `iss`, `aud` e `nbf`
  - rota protegida com token válido retornando `200`
  - rejeição com `401` para `iss`, `aud` e `nbf` inválidos
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #163