### PR TITLE
fix(frontend): parametrize a URL pública do proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ cd clutch
 cp .env.example .env
 ```
 
+Se o host público do proxy não for `http://localhost`, defina `NEXT_PUBLIC_APP_URL` com a origem pública correta antes de subir o stack. Exemplos: túnel HTTPS, máquina remota ou cloud dev.
+
 ### 3. Subir todo o ambiente
 ```bash
 docker compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
       WATCHPACK_POLLING_INTERVAL: "1000"
       CHOKIDAR_USEPOLLING: "true"
       INTERNAL_API_URL: http://backend:3344
-      NEXT_PUBLIC_API_URL: http://localhost/api
-      NEXT_PUBLIC_WS_URL: ws://localhost
+      NEXT_PUBLIC_APP_URL: http://localhost
+      NEXT_PUBLIC_API_URL: /api
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
 INTERNAL_API_URL=http://backend:3344
-NEXT_PUBLIC_API_URL=http://localhost/api
-NEXT_PUBLIC_WS_URL=ws://localhost
+NEXT_PUBLIC_APP_URL=http://localhost
+NEXT_PUBLIC_API_URL=/api

--- a/frontend/src/lib/config/env.ts
+++ b/frontend/src/lib/config/env.ts
@@ -1,3 +1,5 @@
+import { resolvePublicApiBaseUrl, resolvePublicWsBaseUrl } from '@/services/http/client';
+
 type ClientEnv = {
   apiUrl: string;
   wsUrl: string;
@@ -5,7 +7,7 @@ type ClientEnv = {
 
 export function getClientEnv(): ClientEnv {
   return {
-    apiUrl: process.env.NEXT_PUBLIC_API_URL ?? '',
-    wsUrl: process.env.NEXT_PUBLIC_WS_URL ?? '',
+    apiUrl: resolvePublicApiBaseUrl(),
+    wsUrl: resolvePublicWsBaseUrl(),
   };
 }

--- a/frontend/src/services/http/client.ts
+++ b/frontend/src/services/http/client.ts
@@ -1,18 +1,4 @@
-function resolveApiBaseUrl(): string {
-  const internalApiUrl = process.env.INTERNAL_API_URL?.trim();
-
-  if (internalApiUrl) {
-    return internalApiUrl;
-  }
-
-  const publicApiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
-
-  if (publicApiUrl) {
-    return publicApiUrl;
-  }
-
-  throw new Error('API URL is not configured.');
-}
+const DEFAULT_LOCAL_PUBLIC_APP_ORIGIN = 'http://localhost';
 
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
@@ -20,6 +6,81 @@ function normalizeBaseUrl(baseUrl: string): string {
 
 function normalizePathname(pathname: string): string {
   return pathname.replace(/^\/+/, '');
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'ws:' || url.protocol === 'wss:';
+  } catch {
+    return false;
+  }
+}
+
+function resolvePublicAppOrigin(): string {
+  const explicitPublicOrigin =
+    process.env.PUBLIC_APP_URL?.trim() ||
+    process.env.NEXT_PUBLIC_APP_URL?.trim();
+
+  if (explicitPublicOrigin) {
+    return explicitPublicOrigin;
+  }
+
+  const publicApiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+  if (publicApiUrl && isAbsoluteUrl(publicApiUrl)) {
+    return new URL(publicApiUrl).origin;
+  }
+
+  const publicWsUrl = process.env.NEXT_PUBLIC_WS_URL?.trim();
+
+  if (publicWsUrl && isAbsoluteUrl(publicWsUrl)) {
+    const wsOrigin = new URL(publicWsUrl);
+    const httpProtocol = wsOrigin.protocol === 'wss:' ? 'https:' : 'http:';
+    return `${httpProtocol}//${wsOrigin.host}`;
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return DEFAULT_LOCAL_PUBLIC_APP_ORIGIN;
+  }
+
+  throw new Error('Public app origin is not configured.');
+}
+
+export function resolvePublicApiBaseUrl(): string {
+  const publicApiUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
+
+  if (publicApiUrl) {
+    if (isAbsoluteUrl(publicApiUrl)) {
+      return publicApiUrl;
+    }
+
+    return new URL(normalizePathname(publicApiUrl), normalizeBaseUrl(resolvePublicAppOrigin())).toString();
+  }
+
+  return new URL('api/', normalizeBaseUrl(resolvePublicAppOrigin())).toString();
+}
+
+export function resolvePublicWsBaseUrl(): string {
+  const explicitPublicWsUrl = process.env.NEXT_PUBLIC_WS_URL?.trim();
+
+  if (explicitPublicWsUrl) {
+    return explicitPublicWsUrl;
+  }
+
+  const publicOrigin = new URL(resolvePublicAppOrigin());
+  const wsProtocol = publicOrigin.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${wsProtocol}//${publicOrigin.host}`;
+}
+
+function resolveApiBaseUrl(): string {
+  const internalApiUrl = process.env.INTERNAL_API_URL?.trim();
+
+  if (internalApiUrl) {
+    return internalApiUrl;
+  }
+
+  return resolvePublicApiBaseUrl();
 }
 
 export function buildApiUrl(pathname: string): string {

--- a/frontend/tests/unit/routes/api-proxy-route.test.ts
+++ b/frontend/tests/unit/routes/api-proxy-route.test.ts
@@ -4,11 +4,13 @@ import { GET } from '@/app/api/[...path]/route';
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
 
 describe('api proxy route', () => {
   beforeEach(() => {
     process.env.INTERNAL_API_URL = 'http://backend.test';
     process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost';
     vi.restoreAllMocks();
   });
 
@@ -80,6 +82,40 @@ describe('api proxy route', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.headers.get('set-cookie')).toContain('clutch_session=');
   });
+
+  it('uses the configured public app origin when only a relative public API path is available', async () => {
+    delete process.env.INTERNAL_API_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://preview.clutch.gg';
+    process.env.NEXT_PUBLIC_API_URL = '/api';
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe('https://preview.clutch.gg/api/profiles/clutchplayer');
+      const headers = new Headers(init?.headers);
+      expect(headers.get('authorization')).toBe('Bearer jwt-token');
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const request = new NextRequest('https://preview.clutch.gg/api/profiles/clutchplayer', {
+      headers: {
+        cookie: 'clutch_session=jwt-token',
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ path: ['profiles', 'clutchplayer'] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 afterAll(() => {
@@ -91,8 +127,14 @@ afterAll(() => {
 
   if (typeof originalApiUrl === 'undefined') {
     delete process.env.NEXT_PUBLIC_API_URL;
+  } else {
+    process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+  }
+
+  if (typeof originalAppUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_APP_URL;
     return;
   }
 
-  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+  process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
 });

--- a/frontend/tests/unit/routes/auth-login-route.test.ts
+++ b/frontend/tests/unit/routes/auth-login-route.test.ts
@@ -4,6 +4,7 @@ import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
 
 function captureServerLogs() {
   const entries: Array<Record<string, unknown>> = [];
@@ -40,6 +41,7 @@ describe('auth login route', () => {
   beforeEach(() => {
     process.env.INTERNAL_API_URL = 'http://backend.test';
     process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost';
     vi.restoreAllMocks();
   });
 
@@ -49,9 +51,10 @@ describe('auth login route', () => {
 
   it('sets an httpOnly access cookie and forwards the refresh cookie when login succeeds', async () => {
     const capturedLogs = captureServerLogs();
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
 
+      expect(String(input)).toBe('http://backend.test/auth/login');
       expect(headers.get('x-request-id')).toBe('req-login-123');
 
       return new Response(
@@ -111,6 +114,49 @@ describe('auth login route', () => {
     expect(JSON.stringify(capturedLogs.entries)).not.toContain('refresh-token');
   });
 
+  it('uses the configured public app origin when only a relative public API path is available', async () => {
+    delete process.env.INTERNAL_API_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://preview.clutch.gg';
+    process.env.NEXT_PUBLIC_API_URL = '/api';
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe('https://preview.clutch.gg/api/auth/login');
+
+      return new Response(
+        JSON.stringify({
+          id: 'user-1',
+          username: 'clutchplayer',
+          token: 'jwt-token',
+          message: 'Acesso autorizado.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const response = await POST(
+      new Request('https://preview.clutch.gg/api/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'clutchplayer@clutch.gg',
+          password: 'clutch123',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('propagates invalid credentials without setting a session cookie', async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
@@ -158,8 +204,14 @@ afterAll(() => {
 
   if (typeof originalApiUrl === 'undefined') {
     delete process.env.NEXT_PUBLIC_API_URL;
+  } else {
+    process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+  }
+
+  if (typeof originalAppUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_APP_URL;
     return;
   }
 
-  process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+  process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
 });

--- a/frontend/tests/unit/services/http-client.test.ts
+++ b/frontend/tests/unit/services/http-client.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildApiUrl } from '@/services/http/client';
+import {
+  buildApiUrl,
+  resolvePublicApiBaseUrl,
+  resolvePublicWsBaseUrl,
+} from '@/services/http/client';
 
 const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
 const originalInternalApiUrl = process.env.INTERNAL_API_URL;
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+const originalPublicAppUrl = process.env.PUBLIC_APP_URL;
+const originalWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+const originalNodeEnv = process.env.NODE_ENV;
+const mutableEnv = process.env as Record<string, string | undefined>;
 
 describe('buildApiUrl', () => {
   afterEach(() => {
@@ -19,6 +28,30 @@ describe('buildApiUrl', () => {
     } else {
       process.env.INTERNAL_API_URL = originalInternalApiUrl;
     }
+
+    if (typeof originalAppUrl === 'undefined') {
+      delete process.env.NEXT_PUBLIC_APP_URL;
+    } else {
+      process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+    }
+
+    if (typeof originalPublicAppUrl === 'undefined') {
+      delete process.env.PUBLIC_APP_URL;
+    } else {
+      process.env.PUBLIC_APP_URL = originalPublicAppUrl;
+    }
+
+    if (typeof originalWsUrl === 'undefined') {
+      delete process.env.NEXT_PUBLIC_WS_URL;
+    } else {
+      process.env.NEXT_PUBLIC_WS_URL = originalWsUrl;
+    }
+
+    if (typeof originalNodeEnv === 'undefined') {
+      delete mutableEnv.NODE_ENV;
+    } else {
+      mutableEnv.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it('prefers the internal API URL on the server', () => {
@@ -30,8 +63,45 @@ describe('buildApiUrl', () => {
 
   it('preserves the /api prefix when the public URL uses path routing', () => {
     delete process.env.INTERNAL_API_URL;
-    process.env.NEXT_PUBLIC_API_URL = 'http://localhost/api';
+    process.env.NEXT_PUBLIC_API_URL = 'https://clutch.example/api';
 
-    expect(buildApiUrl('/auth/login')).toBe('http://localhost/api/auth/login');
+    expect(buildApiUrl('/auth/login')).toBe('https://clutch.example/api/auth/login');
+  });
+
+  it('builds the public API URL from NEXT_PUBLIC_APP_URL when NEXT_PUBLIC_API_URL is relative', () => {
+    delete process.env.INTERNAL_API_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://preview.clutch.gg';
+    process.env.NEXT_PUBLIC_API_URL = '/api';
+
+    expect(resolvePublicApiBaseUrl()).toBe('https://preview.clutch.gg/api');
+    expect(buildApiUrl('/auth/login')).toBe('https://preview.clutch.gg/api/auth/login');
+  });
+
+  it('prefers PUBLIC_APP_URL over NEXT_PUBLIC_APP_URL when both are configured', () => {
+    delete process.env.INTERNAL_API_URL;
+    process.env.PUBLIC_APP_URL = 'https://edge.clutch.gg';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://preview.clutch.gg';
+    process.env.NEXT_PUBLIC_API_URL = '/api';
+
+    expect(resolvePublicApiBaseUrl()).toBe('https://edge.clutch.gg/api');
+  });
+
+  it('falls back to localhost only outside production when no public origin is configured', () => {
+    delete process.env.INTERNAL_API_URL;
+    delete process.env.PUBLIC_APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    delete process.env.NEXT_PUBLIC_WS_URL;
+    delete process.env.NEXT_PUBLIC_API_URL;
+    mutableEnv.NODE_ENV = 'development';
+
+    expect(resolvePublicApiBaseUrl()).toBe('http://localhost/api/');
+    expect(resolvePublicWsBaseUrl()).toBe('ws://localhost');
+  });
+
+  it('derives the websocket base URL from the configured public app origin', () => {
+    delete process.env.NEXT_PUBLIC_WS_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://preview.clutch.gg';
+
+    expect(resolvePublicWsBaseUrl()).toBe('wss://preview.clutch.gg');
   });
 });


### PR DESCRIPTION
## Resumo
Remove a dependência fixa de `localhost` da resolução da URL pública usada pelo frontend/proxy. A mudança preserva o fluxo atual de autenticação e mantém a separação entre comunicação interna com o backend e origem pública do app.

## O que foi alterado
- Centralização da resolução da URL pública do proxy em `frontend/src/services/http/client.ts`.
- Prioridade explícita para `INTERNAL_API_URL` no server-side e para `PUBLIC_APP_URL`/`NEXT_PUBLIC_APP_URL` na origem pública.
- Suporte a `NEXT_PUBLIC_API_URL` relativo (`/api`) como padrão recomendado.
- Derivação da base pública de WebSocket a partir da origem pública do app quando não houver override explícito.
- Atualização de `docker-compose.yml`, `frontend/.env.example` e `README.md` para refletir o padrão novo.
- Atualização de testes focados para helper de URL pública e rotas server-side que dependem do proxy.

## Motivação
O uso fixo de `localhost` no caminho público do proxy reduz portabilidade e quebra cenários como túnel, máquina remota ou cloud dev. A mudança torna a origem pública configurável sem alterar o contrato HTTP existente nem o fluxo principal de auth.

## Como validar
- Executar `npm run test -- tests/unit/services/http-client.test.ts tests/unit/routes/auth-login-route.test.ts tests/unit/routes/api-proxy-route.test.ts tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-presence-token-route.test.ts tests/unit/routes/auth-logout-route.test.ts` em `frontend/`.
- Executar `npm run typecheck` em `frontend/`.
- Executar `npm run lint` em `frontend/`.
- Subir o stack com `docker compose up -d --build`.
- Executar `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`.
- Validar via proxy:
  - `GET /login`
  - `POST /api/auth/login`
  - `GET /api/auth/me`
  - `GET /api/auth/presence-token`
  - `POST /api/auth/logout`
- Validar cenário com host público explícito no frontend:
  - `NEXT_PUBLIC_APP_URL=https://preview.clutch.gg`
  - `NEXT_PUBLIC_API_URL=/api`
  - helper deve resolver `https://preview.clutch.gg/api` e `wss://preview.clutch.gg`

## Riscos e impactos
- Não há breaking change de contrato HTTP.
- A configuração antiga com `NEXT_PUBLIC_API_URL` absoluta continua compatível por transição, o que evita corte abrupto em ambientes já configurados.
- A coexistência entre configuração antiga e nova mantém duas formas válidas de setup temporariamente; o padrão recomendado passa a ser `NEXT_PUBLIC_APP_URL` + `NEXT_PUBLIC_API_URL=/api`.
- O ambiente local continua usando `http://localhost` como fallback controlado apenas para desenvolvimento.

## Evidências
- Testes focados do frontend passaram localmente.
- Validação operacional via proxy confirmou:
  - `GET /login` → `200`
  - `POST /api/auth/login` → `200`
  - `GET /api/auth/me` → `200`
  - `GET /api/auth/presence-token` → `200`
  - `POST /api/auth/logout` → `200`
- Validação de origem pública explícita confirmou:
  - `api=https://preview.clutch.gg/api`
  - `ws=wss://preview.clutch.gg`
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #145