### PR TITLE
feat(dx): adiciona comandos de bootstrap, reset e validacao do ambiente

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ npm run env:reset
 - `env:validate` — verifica serviços em execução, health endpoints e um fluxo mínimo de auth via proxy
 - `env:reset` — derruba o stack e remove volumes nomeados do compose para recomeço limpo
 
-Use `env:reset` quando houver drift local relevante de banco, Redis ou caches de containers. Para o fluxo normal, prefira `env:bootstrap` seguido de `env:validate`.
+`env:reset` e destrutivo para o estado local: ele apaga os volumes nomeados do compose, incluindo banco e Redis. Use esse comando quando quiser recomeçar o ambiente do zero ou eliminar drift local relevante. Para o fluxo normal, prefira `env:bootstrap` seguido de `env:validate`.
 
 ### 6. Conta demo
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ Esse comando:
 
 Você pode reexecutá-lo quando quiser restaurar a base demo sem depender do restart do container.
 
+### Comandos operacionais recomendados
+
+O repositório agora expõe uma interface mínima na raiz para operar o ambiente local:
+
+```bash
+npm run env:bootstrap
+npm run env:validate
+npm run env:reset
+```
+
+- `env:bootstrap` — sobe o stack com build e executa o bootstrap do backend
+- `env:validate` — verifica serviços em execução, health endpoints e um fluxo mínimo de auth via proxy
+- `env:reset` — derruba o stack e remove volumes nomeados do compose para recomeço limpo
+
+Use `env:reset` quando houver drift local relevante de banco, Redis ou caches de containers. Para o fluxo normal, prefira `env:bootstrap` seguido de `env:validate`.
+
 ### 6. Conta demo
 
 O seed é determinístico e pode ser reexecutado sem depender de Steam, IGDB, Epic ou Discord.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "clutch-dev-tools",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Comandos operacionais locais para o ambiente container-first do CLUTCH.",
+  "scripts": {
+    "env:bootstrap": "node ./scripts/dev/bootstrap.mjs",
+    "env:reset": "node ./scripts/dev/reset.mjs",
+    "env:validate": "node ./scripts/dev/validate.mjs"
+  }
+}

--- a/scripts/dev/bootstrap.mjs
+++ b/scripts/dev/bootstrap.mjs
@@ -1,0 +1,16 @@
+import { logStep, runCompose } from './helpers.mjs';
+
+async function main() {
+  logStep('Subindo o stack container-first com build');
+  runCompose(['up', '-d', '--build']);
+
+  logStep('Aplicando bootstrap do backend');
+  runCompose(['exec', '-T', 'backend', 'sh', './scripts/container-bootstrap.sh']);
+
+  logStep('Bootstrap concluído');
+}
+
+main().catch((error) => {
+  process.stderr.write(`[clutch-dev] bootstrap falhou: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/scripts/dev/helpers.mjs
+++ b/scripts/dev/helpers.mjs
@@ -1,0 +1,115 @@
+import { spawnSync } from 'node:child_process';
+
+const composeBaseArgs = ['compose'];
+const defaultServices = ['frontend', 'backend', 'presence', 'postgres', 'redis', 'traefik'];
+
+function formatCommand(command, args) {
+  return [command, ...args].join(' ');
+}
+
+export function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: false,
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    throw new Error(`Command failed: ${formatCommand(command, args)} (exit ${result.status})`);
+  }
+}
+
+export function captureCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    shell: false,
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+    const message = stderr.length > 0
+      ? stderr
+      : `Command failed: ${formatCommand(command, args)} (exit ${result.status})`;
+    throw new Error(message);
+  }
+
+  return typeof result.stdout === 'string' ? result.stdout : '';
+}
+
+export function runCompose(args, options = {}) {
+  runCommand('docker', [...composeBaseArgs, ...args], options);
+}
+
+export function captureCompose(args, options = {}) {
+  return captureCommand('docker', [...composeBaseArgs, ...args], options);
+}
+
+export function logStep(message) {
+  process.stdout.write(`[clutch-dev] ${message}\n`);
+}
+
+export function assertServicesRunning(expectedServices = defaultServices) {
+  const output = captureCompose(['ps', '--services', '--status', 'running']);
+  const runningServices = new Set(
+    output
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+
+  const missingServices = expectedServices.filter((service) => !runningServices.has(service));
+
+  if (missingServices.length > 0) {
+    throw new Error(`Serviços não estão em execução: ${missingServices.join(', ')}`);
+  }
+}
+
+export async function waitForHealthyHttp(url, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  const intervalMs = options.intervalMs ?? 2_000;
+  const deadline = Date.now() + timeoutMs;
+  let lastError = new Error(`Timeout aguardando ${url}`);
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { method: 'GET', cache: 'no-store' });
+
+      if (response.ok) {
+        return response;
+      }
+
+      lastError = new Error(`Healthcheck falhou em ${url} com status ${response.status}`);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw lastError;
+}
+
+export function parseSetCookie(setCookieHeaders) {
+  const headers = Array.isArray(setCookieHeaders)
+    ? setCookieHeaders
+    : setCookieHeaders
+      ? [setCookieHeaders]
+      : [];
+
+  return headers
+    .map((header) => header.split(';', 1)[0]?.trim())
+    .filter((value) => typeof value === 'string' && value.length > 0);
+}
+
+export function buildCookieHeader(cookies) {
+  return cookies.join('; ');
+}

--- a/scripts/dev/reset.mjs
+++ b/scripts/dev/reset.mjs
@@ -1,0 +1,13 @@
+import { logStep, runCompose } from './helpers.mjs';
+
+async function main() {
+  logStep('Derrubando o stack e removendo volumes nomeados do compose');
+  runCompose(['down', '-v', '--remove-orphans']);
+
+  logStep('Reset concluído');
+}
+
+main().catch((error) => {
+  process.stderr.write(`[clutch-dev] reset falhou: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/scripts/dev/validate.mjs
+++ b/scripts/dev/validate.mjs
@@ -1,0 +1,88 @@
+import {
+  assertServicesRunning,
+  buildCookieHeader,
+  logStep,
+  parseSetCookie,
+  waitForHealthyHttp,
+} from './helpers.mjs';
+
+async function validateLoginFlow() {
+  const loginResponse = await fetch('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: 'clutchplayer@clutch.gg',
+      password: 'clutch123',
+    }),
+  });
+
+  if (!loginResponse.ok) {
+    throw new Error(`Login falhou com status ${loginResponse.status}`);
+  }
+
+  const cookies = parseSetCookie(
+    typeof loginResponse.headers.getSetCookie === 'function'
+      ? loginResponse.headers.getSetCookie()
+      : loginResponse.headers.get('set-cookie'),
+  );
+
+  if (cookies.length === 0) {
+    throw new Error('Login não retornou cookies de sessão.');
+  }
+
+  const cookieHeader = buildCookieHeader(cookies);
+
+  const meResponse = await fetch('http://localhost/api/auth/me', {
+    headers: {
+      cookie: cookieHeader,
+    },
+  });
+
+  if (!meResponse.ok) {
+    throw new Error(`/api/auth/me falhou com status ${meResponse.status}`);
+  }
+
+  const presenceResponse = await fetch('http://localhost/api/auth/presence-token', {
+    headers: {
+      cookie: cookieHeader,
+    },
+  });
+
+  if (!presenceResponse.ok) {
+    throw new Error(`/api/auth/presence-token falhou com status ${presenceResponse.status}`);
+  }
+
+  const logoutResponse = await fetch('http://localhost/api/auth/logout', {
+    method: 'POST',
+    headers: {
+      cookie: cookieHeader,
+    },
+  });
+
+  if (!logoutResponse.ok) {
+    throw new Error(`/api/auth/logout falhou com status ${logoutResponse.status}`);
+  }
+}
+
+async function main() {
+  logStep('Verificando serviços principais em execução');
+  assertServicesRunning();
+
+  logStep('Validando health do backend via proxy');
+  await waitForHealthyHttp('http://localhost/api/health');
+
+  logStep('Validando health do presence via proxy');
+  await waitForHealthyHttp('http://localhost/presence/health');
+
+  logStep('Validando fluxo mínimo de autenticação via proxy');
+  await validateLoginFlow();
+
+  logStep('Validação concluída');
+}
+
+main().catch((error) => {
+  process.stderr.write(`[clutch-dev] validação falhou: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Resumo
Consolida a operação local do projeto em três comandos previsíveis para bootstrap, reset e validação do stack container-first. A mudança reduz troubleshooting manual e padroniza a preparação do ambiente sem alterar contratos HTTP nem a arquitetura atual.

## O que foi alterado
- Adiciona um `package.json` na raiz com os comandos `env:bootstrap`, `env:reset` e `env:validate`.
- Cria scripts dedicados em `scripts/dev` para orquestrar subida do stack, reset controlado e validação operacional mínima via proxy.
- Reutiliza o bootstrap já existente do backend dentro do fluxo novo, evitando duplicação de lógica entre serviços.
- Atualiza a documentação operacional do ambiente local no `README`.

## Motivação
O projeto já possui um stack local funcional, mas os passos operacionais ainda estavam espalhados e dependiam de sequência manual. Esta PR cria uma interface mínima e rastreável para preparar, reiniciar e validar o ambiente com menos drift operacional.

## Como validar
- Executar `npm run env:reset` para limpar o ambiente local.
- Executar `npm run env:bootstrap` para subir o stack e preparar o backend.
- Executar `npm run env:validate` para validar serviços críticos, health endpoints e um fluxo mínimo de autenticação via proxy.
- Confirmar que o validate falha claramente quando um serviço essencial do stack não está em execução.

## Riscos e impactos
- `env:reset` é destrutivo para o estado local: remove volumes nomeados do compose e apaga o estado de banco e Redis do ambiente de desenvolvimento. Use quando quiser recomeçar o ambiente do zero ou eliminar drift local relevante.
- O primeiro `env:bootstrap` pode levar alguns minutos por depender de build e sincronização de dependências nos containers.
- O impacto é restrito à DX local; não há mudança de contrato HTTP nem de comportamento funcional do produto.

## Evidências
- `npm run env:validate` falhou claramente com stack incompleto: `Serviços não estão em execução: presence`.
- `npm run env:validate` concluiu com sucesso após `env:bootstrap`, validando `/api/health`, `/presence/health`, login, `/api/auth/me`, `/api/auth/presence-token` e logout.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #147
