### PR TITLE
fix(integrations): alinhe o contrato real de Epic e IGDB

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,10 +40,11 @@ DISCORD_CLIENT_SECRET=
 IGDB_CLIENT_ID=
 IGDB_CLIENT_SECRET=
 
-# ── Epic Games (Python Service) ──────────────────────────────
-# URL do serviço Python rodando localmente
-# Opcional em desenvolvimento
-EPIC_SERVICE_URL="http://python-service:8000"
+# ── Epic Games (adapter externo opcional) ────────────────────
+# A integração Epic depende de um adapter externo funcional.
+# O repositório atual não sobe esse adapter no docker-compose.
+# Deixe vazio quando a integração Epic não estiver disponível.
+EPIC_SERVICE_URL=
 
 # ── JWT (preencher antes do deploy) ──────────────────────────
 # Gerar com: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"

--- a/backend/src/api/routes/integrations.routes.ts
+++ b/backend/src/api/routes/integrations.routes.ts
@@ -1,9 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
-import { steamService } from '../../infra/integrations/steam/steam.service';
-import { igdbService } from '../../infra/integrations/igdb/igdb.service';
-import { epicService } from '../../infra/integrations/epic/epic.service';
-import { prisma } from '../../infra/database/client';
+import { isIntegrationError } from '../../core/services/integrations.service';
 
 const steamConnectSchema = z.object({
   steamId: z.string().min(1, 'SteamID é obrigatório'),
@@ -12,6 +9,32 @@ const steamConnectSchema = z.object({
 const epicConnectSchema = z.object({
   authToken: z.string().min(1, 'Token Epic é obrigatório'),
 });
+
+function replyWithIntegrationError(
+  request: { id: string; method: string; url: string; log: FastifyInstance['log'] },
+  error: unknown,
+): { statusCode: number; payload: { message: string } } {
+  if (isIntegrationError(error)) {
+    request.log.warn({
+      event: 'integration_request_failed',
+      requestId: request.id,
+      method: request.method,
+      path: request.url,
+      provider: error.integration,
+      reason: error.reason,
+      status: error.statusCode,
+    }, 'Integration request failed');
+
+    return {
+      statusCode: error.statusCode,
+      payload: {
+        message: error.clientMessage,
+      },
+    };
+  }
+
+  throw error;
+}
 
 export async function integrationRoutes(app: FastifyInstance): Promise<void> {
 
@@ -23,30 +46,17 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       const result = steamConnectSchema.safeParse(request.body);
       if (!result.success) return reply.status(400).send({ message: result.error.errors[0]?.message });
 
-      const { steamId } = result.data;
-      const isValid = await steamService.validateSteamId(steamId);
-      if (!isValid) return reply.status(400).send({ message: 'SteamID inválido ou perfil privado.' });
+      try {
+        const resultPayload = await app.integrationsService.connectSteam(
+          request.userId,
+          result.data.steamId,
+        );
 
-      await prisma.platformIntegration.upsert({
-        where:  { userId_platform: { userId: request.userId, platform: 'STEAM' } },
-        create: { userId: request.userId, platform: 'STEAM', externalId: steamId },
-        update: { externalId: steamId, isActive: true },
-      });
-
-      const games = await steamService.getOwnedGames(steamId);
-      let imported = 0;
-
-      for (const game of games) {
-        const igdbData = await igdbService.searchGame(game.name).catch(() => null);
-        await prisma.userGameLibrary.upsert({
-          where:  { userId_gameId_platform: { userId: request.userId, gameId: String(game.appid), platform: 'STEAM' } },
-          create: { userId: request.userId, gameId: String(game.appid), gameName: game.name, coverUrl: igdbData?.coverUrl ?? null, platform: 'STEAM', hoursPlayed: game.playtime_forever / 60 },
-          update: { hoursPlayed: game.playtime_forever / 60, coverUrl: igdbData?.coverUrl ?? null },
-        });
-        imported++;
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error);
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
       }
-
-      return reply.status(200).send({ message: `Steam conectado. ${imported} jogos importados.`, imported });
     },
   );
 
@@ -55,25 +65,13 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     '/steam/sync',
     { preHandler: [app.authenticate] },
     async (request, reply) => {
-      const integration = await prisma.platformIntegration.findUnique({
-        where: { userId_platform: { userId: request.userId, platform: 'STEAM' } },
-      });
-
-      if (!integration) return reply.status(404).send({ message: 'Steam não conectado.' });
-
-      const games  = await steamService.getOwnedGames(integration.externalId);
-      let synced   = 0;
-
-      for (const game of games) {
-        await prisma.userGameLibrary.upsert({
-          where:  { userId_gameId_platform: { userId: request.userId, gameId: String(game.appid), platform: 'STEAM' } },
-          create: { userId: request.userId, gameId: String(game.appid), gameName: game.name, platform: 'STEAM', hoursPlayed: game.playtime_forever / 60 },
-          update: { hoursPlayed: game.playtime_forever / 60 },
-        });
-        synced++;
+      try {
+        const resultPayload = await app.integrationsService.syncSteamLibrary(request.userId);
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error);
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
       }
-
-      return reply.status(200).send({ message: `${synced} jogos sincronizados.`, synced });
     },
   );
 
@@ -84,10 +82,15 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       const { q } = request.query;
       if (!q || q.trim().length < 2) return reply.status(400).send({ message: 'Query deve ter pelo menos 2 caracteres.' });
 
-      const game = await igdbService.searchGame(q.trim());
-      if (!game) return reply.status(404).send({ message: 'Jogo não encontrado.' });
+      try {
+        const game = await app.integrationsService.searchIgdbGame(q.trim());
+        if (!game) return reply.status(404).send({ message: 'Jogo não encontrado.' });
 
-      return reply.status(200).send(game);
+        return reply.status(200).send(game);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error);
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
+      }
     },
   );
 
@@ -99,31 +102,17 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       const result = epicConnectSchema.safeParse(request.body);
       if (!result.success) return reply.status(400).send({ message: result.error.errors[0]?.message });
 
-      const { authToken } = result.data;
-      const isValid = await epicService.validateToken(authToken);
-      if (!isValid) return reply.status(400).send({ message: 'Token Epic inválido ou expirado.' });
+      try {
+        const resultPayload = await app.integrationsService.connectEpic(
+          request.userId,
+          result.data.authToken,
+        );
 
-      const games = await epicService.getLibrary(authToken).catch(() => {
-        throw { statusCode: 503, message: 'Serviço Epic indisponível. Tente novamente.' };
-      });
-
-      await prisma.platformIntegration.upsert({
-        where:  { userId_platform: { userId: request.userId, platform: 'EPIC' } },
-        create: { userId: request.userId, platform: 'EPIC', externalId: 'epic', accessToken: authToken },
-        update: { accessToken: authToken, isActive: true },
-      });
-
-      let imported = 0;
-      for (const game of games) {
-        await prisma.userGameLibrary.upsert({
-          where:  { userId_gameId_platform: { userId: request.userId, gameId: game.id, platform: 'EPIC' } },
-          create: { userId: request.userId, gameId: game.id, gameName: game.title, coverUrl: game.coverUrl, platform: 'EPIC' },
-          update: { gameName: game.title, coverUrl: game.coverUrl },
-        });
-        imported++;
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error);
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
       }
-
-      return reply.status(200).send({ message: `Epic conectado. ${imported} jogos importados.`, imported });
     },
   );
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -28,6 +28,10 @@ import {
   createRefreshTokenService,
   type RefreshSessionStore,
 } from './core/services/refresh-token.service';
+import {
+  createIntegrationsService,
+  type IntegrationsService,
+} from './core/services/integrations.service';
 import { createRedisRefreshSessionStore } from './infra/cache/refresh-session.store';
 import { redis as runtimeRedis } from './infra/cache/redis';
 import type Redis from 'ioredis';
@@ -39,6 +43,7 @@ export type BuildAppOptions = {
   readinessCheck?: () => Promise<ReadinessReport>;
   refreshSessionStore?: RefreshSessionStore;
   rateLimitRedis?: Redis | null;
+  integrationsService?: IntegrationsService;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -59,11 +64,13 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     jwtKeyRotationConfig: options.jwtKeyRotationConfig,
     refreshSessionStore: options.refreshSessionStore ?? createRedisRefreshSessionStore(),
   });
+  const integrationsService = options.integrationsService ?? createIntegrationsService();
 
   app.decorate('authenticate', authenticate);
   app.decorate('signAccessToken', signAccessToken);
   app.decorate('verifyAccessToken', verifyAccessToken);
   app.decorate('refreshTokenService', refreshTokenService);
+  app.decorate('integrationsService', integrationsService);
 
   await app.register(
     fastifyRateLimit,

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -1,0 +1,277 @@
+/* eslint-disable no-unused-vars */
+import { prisma } from '../../infra/database/client';
+import {
+  createIntegrationError,
+  type IntegrationError,
+  translateUpstreamError,
+} from '../../infra/integrations/integration.errors';
+import { epicService, type EpicGame } from '../../infra/integrations/epic/epic.service';
+import { igdbService, type IgdbGame } from '../../infra/integrations/igdb/igdb.service';
+import { steamService, type SteamGame } from '../../infra/integrations/steam/steam.service';
+import { writeBackendRuntimeLog } from '../../config/logging';
+
+type PlatformIntegrationPlatform = 'STEAM' | 'EPIC';
+
+type PersistedIntegration = {
+  externalId: string;
+  accessToken?: string | null;
+};
+
+type PersistIntegrationInput = {
+  externalId: string;
+  accessToken?: string | null;
+};
+
+type SteamIntegrationClient = Pick<typeof steamService, 'validateSteamId' | 'getOwnedGames'>;
+type IgdbIntegrationClient = Pick<typeof igdbService, 'searchGame'>;
+type EpicIntegrationClient = Pick<typeof epicService, 'validateToken' | 'getLibrary'>;
+
+type IntegrationsPersistence = {
+  upsertPlatformIntegration(
+    userId: string,
+    platform: PlatformIntegrationPlatform,
+    data: PersistIntegrationInput,
+  ): Promise<void>;
+  findPlatformIntegration(
+    userId: string,
+    platform: PlatformIntegrationPlatform,
+  ): Promise<PersistedIntegration | null>;
+  upsertSteamLibraryGame(
+    userId: string,
+    game: SteamGame,
+    coverUrl: string | null,
+  ): Promise<void>;
+  upsertEpicLibraryGame(
+    userId: string,
+    game: EpicGame,
+  ): Promise<void>;
+};
+
+export type IntegrationsService = ReturnType<typeof createIntegrationsService>;
+
+function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
+  return {
+    async upsertPlatformIntegration(userId, platform, data): Promise<void> {
+      await prisma.platformIntegration.upsert({
+        where: {
+          userId_platform: {
+            userId,
+            platform,
+          },
+        },
+        create: {
+          userId,
+          platform,
+          externalId: data.externalId,
+          ...(typeof data.accessToken === 'string'
+            ? { accessToken: data.accessToken }
+            : {}),
+        },
+        update: {
+          externalId: data.externalId,
+          isActive: true,
+          ...(typeof data.accessToken === 'string'
+            ? { accessToken: data.accessToken }
+            : {}),
+        },
+      });
+    },
+    async findPlatformIntegration(userId, platform): Promise<PersistedIntegration | null> {
+      const integration = await prisma.platformIntegration.findUnique({
+        where: {
+          userId_platform: {
+            userId,
+            platform,
+          },
+        },
+      });
+
+      if (!integration) {
+        return null;
+      }
+
+      return {
+        externalId: integration.externalId,
+        accessToken: integration.accessToken,
+      };
+    },
+    async upsertSteamLibraryGame(userId, game, coverUrl): Promise<void> {
+      await prisma.userGameLibrary.upsert({
+        where: {
+          userId_gameId_platform: {
+            userId,
+            gameId: String(game.appid),
+            platform: 'STEAM',
+          },
+        },
+        create: {
+          userId,
+          gameId: String(game.appid),
+          gameName: game.name,
+          coverUrl,
+          platform: 'STEAM',
+          hoursPlayed: game.playtime_forever / 60,
+        },
+        update: {
+          hoursPlayed: game.playtime_forever / 60,
+          coverUrl,
+        },
+      });
+    },
+    async upsertEpicLibraryGame(userId, game): Promise<void> {
+      await prisma.userGameLibrary.upsert({
+        where: {
+          userId_gameId_platform: {
+            userId,
+            gameId: game.id,
+            platform: 'EPIC',
+          },
+        },
+        create: {
+          userId,
+          gameId: game.id,
+          gameName: game.title,
+          coverUrl: game.coverUrl,
+          platform: 'EPIC',
+        },
+        update: {
+          gameName: game.title,
+          coverUrl: game.coverUrl,
+        },
+      });
+    },
+  };
+}
+
+async function resolveIgdbCover(gameName: string, client: IgdbIntegrationClient): Promise<string | null> {
+  try {
+    const game = await client.searchGame(gameName);
+    return game?.coverUrl ?? null;
+  } catch (error) {
+    const translatedError = translateUpstreamError(
+      'igdb',
+      error,
+      'Busca IGDB indisponível.',
+    );
+
+    writeBackendRuntimeLog(
+      'warn',
+      'integration_igdb_enrichment_failed',
+      'IGDB enrichment failed during Steam import',
+      {
+        integration: translatedError.integration,
+        reason: translatedError.reason,
+        status: translatedError.statusCode,
+      },
+    );
+
+    return null;
+  }
+}
+
+export function createIntegrationsService(dependencies?: {
+  steamClient?: SteamIntegrationClient;
+  igdbClient?: IgdbIntegrationClient;
+  epicClient?: EpicIntegrationClient;
+  persistence?: IntegrationsPersistence;
+}): {
+  connectSteam: (userId: string, steamId: string) => Promise<{ imported: number; message: string }>;
+  syncSteamLibrary: (userId: string) => Promise<{ synced: number; message: string }>;
+  searchIgdbGame: (query: string) => Promise<IgdbGame | null>;
+  connectEpic: (userId: string, authToken: string) => Promise<{ imported: number; message: string }>;
+} {
+  const steamClient = dependencies?.steamClient ?? steamService;
+  const igdbClient = dependencies?.igdbClient ?? igdbService;
+  const epicClient = dependencies?.epicClient ?? epicService;
+  const persistence = dependencies?.persistence ?? createPrismaIntegrationsPersistence();
+
+  return {
+    async connectSteam(userId: string, steamId: string): Promise<{ imported: number; message: string }> {
+      const isValidSteamId = await steamClient.validateSteamId(steamId);
+
+      if (!isValidSteamId) {
+        throw createIntegrationError(
+          'steam',
+          400,
+          'invalid_request',
+          'SteamID inválido ou perfil privado.',
+        );
+      }
+
+      await persistence.upsertPlatformIntegration(userId, 'STEAM', { externalId: steamId });
+
+      const games = await steamClient.getOwnedGames(steamId);
+
+      for (const game of games) {
+        const coverUrl = await resolveIgdbCover(game.name, igdbClient);
+        await persistence.upsertSteamLibraryGame(userId, game, coverUrl);
+      }
+
+      return {
+        imported: games.length,
+        message: `Steam conectado. ${games.length} jogos importados.`,
+      };
+    },
+
+    async syncSteamLibrary(userId: string): Promise<{ synced: number; message: string }> {
+      const integration = await persistence.findPlatformIntegration(userId, 'STEAM');
+
+      if (!integration) {
+        throw createIntegrationError(
+          'steam',
+          404,
+          'not_connected',
+          'Steam não conectado.',
+        );
+      }
+
+      const games = await steamClient.getOwnedGames(integration.externalId);
+
+      for (const game of games) {
+        await persistence.upsertSteamLibraryGame(userId, game, null);
+      }
+
+      return {
+        synced: games.length,
+        message: `${games.length} jogos sincronizados.`,
+      };
+    },
+
+    async searchIgdbGame(query: string): Promise<IgdbGame | null> {
+      return igdbClient.searchGame(query);
+    },
+
+    async connectEpic(userId: string, authToken: string): Promise<{ imported: number; message: string }> {
+      const isValidToken = await epicClient.validateToken(authToken);
+
+      if (!isValidToken) {
+        throw createIntegrationError(
+          'epic',
+          400,
+          'invalid_credentials',
+          'Token Epic inválido ou expirado.',
+        );
+      }
+
+      const games = await epicClient.getLibrary(authToken);
+
+      await persistence.upsertPlatformIntegration(userId, 'EPIC', {
+        externalId: 'epic',
+        accessToken: authToken,
+      });
+
+      for (const game of games) {
+        await persistence.upsertEpicLibraryGame(userId, game);
+      }
+
+      return {
+        imported: games.length,
+        message: `Epic conectado. ${games.length} jogos importados.`,
+      };
+    },
+  };
+}
+
+export function isIntegrationError(error: unknown): error is IntegrationError {
+  return error instanceof Error && error.name === 'IntegrationError';
+}

--- a/backend/src/infra/integrations/epic/epic.service.ts
+++ b/backend/src/infra/integrations/epic/epic.service.ts
@@ -1,11 +1,103 @@
 import axios from 'axios';
+import {
+  createIntegrationError,
+  logIntegrationProviderEvent,
+  translateUpstreamError,
+} from '../integration.errors';
 
 // ─────────────────────────────────────────────────────────────
 // Epic Games Service — proxy para o Python service
 // ─────────────────────────────────────────────────────────────
 
-const EPIC_SERVICE_URL = process.env['EPIC_SERVICE_URL'] ?? 'http://localhost:8000';
-const EPIC_TIMEOUT     = 30_000;
+const EPIC_TIMEOUT = 30_000;
+const EPIC_VALIDATE_TIMEOUT = 5_000;
+const UNSUPPORTED_EPIC_ADAPTER_URLS = new Set([
+  'http://localhost:8000',
+  'http://127.0.0.1:8000',
+  'http://python-service:8000',
+]);
+
+function normalizeBaseUrl(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function resolveEpicServiceUrl(): string {
+  const configuredUrl = process.env['EPIC_SERVICE_URL']?.trim().replace(/^"(.*)"$/, '$1');
+
+  if (!configuredUrl) {
+    logIntegrationProviderEvent(
+      'epic',
+      'integration_epic_unavailable',
+      'unsupported',
+      'Epic adapter is not configured in the current runtime.',
+    );
+
+    throw createIntegrationError(
+      'epic',
+      503,
+      'unsupported',
+      'Integração Epic indisponível no runtime atual.',
+    );
+  }
+
+  const normalizedUrl = normalizeBaseUrl(configuredUrl);
+
+  if (UNSUPPORTED_EPIC_ADAPTER_URLS.has(normalizedUrl)) {
+    logIntegrationProviderEvent(
+      'epic',
+      'integration_epic_unavailable',
+      'unsupported',
+      'Epic adapter URL points to an unsupported legacy runtime target.',
+      { targetUrl: normalizedUrl },
+    );
+
+    throw createIntegrationError(
+      'epic',
+      503,
+      'unsupported',
+      'Integração Epic indisponível no runtime atual.',
+    );
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(normalizedUrl);
+  } catch {
+    logIntegrationProviderEvent(
+      'epic',
+      'integration_epic_unavailable',
+      'misconfigured',
+      'Epic adapter URL is invalid.',
+    );
+
+    throw createIntegrationError(
+      'epic',
+      503,
+      'misconfigured',
+      'Integração Epic indisponível no runtime atual.',
+    );
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol) || parsedUrl.username || parsedUrl.password) {
+    logIntegrationProviderEvent(
+      'epic',
+      'integration_epic_unavailable',
+      'misconfigured',
+      'Epic adapter URL uses an unsupported scheme or embedded credentials.',
+      { targetUrl: normalizedUrl },
+    );
+
+    throw createIntegrationError(
+      'epic',
+      503,
+      'misconfigured',
+      'Integração Epic indisponível no runtime atual.',
+    );
+  }
+
+  return normalizedUrl;
+}
 
 export interface EpicGame {
   id:        string;
@@ -17,23 +109,60 @@ export interface EpicGame {
 export const epicService = {
 
   async getLibrary(authToken: string): Promise<EpicGame[]> {
-    const response = await axios.get<{ games: EpicGame[] }>(
-      `${EPIC_SERVICE_URL}/library`,
-      {
-        headers: { Authorization: `Bearer ${authToken}` },
-        timeout: EPIC_TIMEOUT,
-      },
-    );
+    const baseUrl = resolveEpicServiceUrl();
 
-    return response.data.games ?? [];
+    try {
+      const response = await axios.get<{ games: EpicGame[] }>(
+        `${baseUrl}/library`,
+        {
+          headers: { Authorization: `Bearer ${authToken}` },
+          timeout: EPIC_TIMEOUT,
+        },
+      );
+
+      return response.data.games ?? [];
+    } catch (error) {
+      throw translateUpstreamError(
+        'epic',
+        error,
+        'Integração Epic indisponível no momento.',
+        { targetUrl: baseUrl },
+      );
+    }
   },
 
   async validateToken(authToken: string): Promise<boolean> {
+    const baseUrl = resolveEpicServiceUrl();
+
     try {
-      await axios.get(`${EPIC_SERVICE_URL}/validate`, {
+      await axios.get(`${baseUrl}/validate`, {
         headers: { Authorization: `Bearer ${authToken}` },
-        timeout: 5_000,
+        timeout: EPIC_VALIDATE_TIMEOUT,
       });
+      return true;
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        typeof (error as { response?: { status?: number } }).response?.status === 'number' &&
+        [400, 401, 403].includes((error as { response?: { status?: number } }).response?.status as number)
+      ) {
+        return false;
+      }
+
+      throw translateUpstreamError(
+        'epic',
+        error,
+        'Integração Epic indisponível no momento.',
+        { targetUrl: baseUrl },
+      );
+    }
+  },
+
+  isConfigured(): boolean {
+    try {
+      resolveEpicServiceUrl();
       return true;
     } catch {
       return false;

--- a/backend/src/infra/integrations/igdb/igdb.service.ts
+++ b/backend/src/infra/integrations/igdb/igdb.service.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
 import { redis } from '../../cache/redis';
+import {
+  createIntegrationError,
+  translateUpstreamError,
+} from '../integration.errors';
 
 // ─────────────────────────────────────────────────────────────
 // IGDB Service — Twitch OAuth + game metadata
@@ -8,6 +12,26 @@ import { redis } from '../../cache/redis';
 const IGDB_BASE_URL  = 'https://api.igdb.com/v4';
 const TWITCH_TOKEN_URL = 'https://id.twitch.tv/oauth2/token';
 const TOKEN_REDIS_KEY  = 'igdb:token';
+const IGDB_TIMEOUT_MS = 10_000;
+
+function resolveIgdbCredentials(): { clientId: string; clientSecret: string } {
+  const clientId = process.env['IGDB_CLIENT_ID']?.trim();
+  const clientSecret = process.env['IGDB_CLIENT_SECRET']?.trim();
+
+  if (!clientId || !clientSecret) {
+    throw createIntegrationError(
+      'igdb',
+      503,
+      'misconfigured',
+      'Integração IGDB indisponível no runtime atual.',
+    );
+  }
+
+  return {
+    clientId,
+    clientSecret,
+  };
+}
 
 interface TwitchTokenResponse {
   access_token: string;
@@ -27,13 +51,27 @@ async function getAccessToken(): Promise<string> {
   const cached = await redis.get(TOKEN_REDIS_KEY);
   if (cached) return cached;
 
-  const response = await axios.post<TwitchTokenResponse>(TWITCH_TOKEN_URL, null, {
-    params: {
-      client_id:     process.env['IGDB_CLIENT_ID'],
-      client_secret: process.env['IGDB_CLIENT_SECRET'],
-      grant_type:    'client_credentials',
-    },
-  });
+  const credentials = resolveIgdbCredentials();
+
+  let response: { data: TwitchTokenResponse };
+
+  try {
+    response = await axios.post<TwitchTokenResponse>(TWITCH_TOKEN_URL, null, {
+      params: {
+        client_id: credentials.clientId,
+        client_secret: credentials.clientSecret,
+        grant_type: 'client_credentials',
+      },
+      timeout: IGDB_TIMEOUT_MS,
+    });
+  } catch (error) {
+    throw translateUpstreamError(
+      'igdb',
+      error,
+      'Integração IGDB indisponível no momento.',
+      { targetUrl: TWITCH_TOKEN_URL },
+    );
+  }
 
   const { access_token, expires_in } = response.data;
   await redis.setex(TOKEN_REDIS_KEY, expires_in - 60, access_token);
@@ -45,24 +83,43 @@ export const igdbService = {
 
   async searchGame(name: string): Promise<IgdbGame | null> {
     const token = await getAccessToken();
+    const credentials = resolveIgdbCredentials();
 
-    const response = await axios.post<Array<{
+    let response: { data: Array<{
       id: number;
       name: string;
       cover?: { id: number; url: string };
       platforms?: Array<{ name: string }>;
       summary?: string;
-    }>>(
-      `${IGDB_BASE_URL}/games`,
-      `search "${name}"; fields name,cover.url,platforms.name,summary; limit 1;`,
-      {
-        headers: {
-          'Client-ID':     process.env['IGDB_CLIENT_ID'] ?? '',
-          'Authorization': `Bearer ${token}`,
-          'Content-Type':  'text/plain',
+    }> };
+
+    try {
+      response = await axios.post<Array<{
+        id: number;
+        name: string;
+        cover?: { id: number; url: string };
+        platforms?: Array<{ name: string }>;
+        summary?: string;
+      }>>(
+        `${IGDB_BASE_URL}/games`,
+        `search "${name}"; fields name,cover.url,platforms.name,summary; limit 1;`,
+        {
+          headers: {
+            'Client-ID': credentials.clientId,
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'text/plain',
+          },
+          timeout: IGDB_TIMEOUT_MS,
         },
-      },
-    );
+      );
+    } catch (error) {
+      throw translateUpstreamError(
+        'igdb',
+        error,
+        'Integração IGDB indisponível no momento.',
+        { targetUrl: `${IGDB_BASE_URL}/games` },
+      );
+    }
 
     const game = response.data[0];
     if (!game) return null;
@@ -80,24 +137,43 @@ export const igdbService = {
 
   async getGameById(igdbId: number): Promise<IgdbGame | null> {
     const token = await getAccessToken();
+    const credentials = resolveIgdbCredentials();
 
-    const response = await axios.post<Array<{
+    let response: { data: Array<{
       id: number;
       name: string;
       cover?: { id: number; url: string };
       platforms?: Array<{ name: string }>;
       summary?: string;
-    }>>(
-      `${IGDB_BASE_URL}/games`,
-      `where id = ${igdbId}; fields name,cover.url,platforms.name,summary; limit 1;`,
-      {
-        headers: {
-          'Client-ID':     process.env['IGDB_CLIENT_ID'] ?? '',
-          'Authorization': `Bearer ${token}`,
-          'Content-Type':  'text/plain',
+    }> };
+
+    try {
+      response = await axios.post<Array<{
+        id: number;
+        name: string;
+        cover?: { id: number; url: string };
+        platforms?: Array<{ name: string }>;
+        summary?: string;
+      }>>(
+        `${IGDB_BASE_URL}/games`,
+        `where id = ${igdbId}; fields name,cover.url,platforms.name,summary; limit 1;`,
+        {
+          headers: {
+            'Client-ID': credentials.clientId,
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'text/plain',
+          },
+          timeout: IGDB_TIMEOUT_MS,
         },
-      },
-    );
+      );
+    } catch (error) {
+      throw translateUpstreamError(
+        'igdb',
+        error,
+        'Integração IGDB indisponível no momento.',
+        { targetUrl: `${IGDB_BASE_URL}/games` },
+      );
+    }
 
     const game = response.data[0];
     if (!game) return null;

--- a/backend/src/infra/integrations/integration.errors.ts
+++ b/backend/src/infra/integrations/integration.errors.ts
@@ -1,0 +1,164 @@
+import {
+  sanitizeConnectionUrl,
+  writeBackendRuntimeLog,
+} from '../../config/logging';
+
+export type IntegrationName = 'steam' | 'igdb' | 'epic';
+
+export type IntegrationErrorReason =
+  | 'invalid_request'
+  | 'invalid_credentials'
+  | 'not_found'
+  | 'not_connected'
+  | 'timeout'
+  | 'upstream_unavailable'
+  | 'unsupported'
+  | 'misconfigured';
+
+type AxiosErrorLike = {
+  code?: string;
+  message?: string;
+  response?: {
+    status?: number;
+  };
+};
+
+function isAxiosErrorLike(error: unknown): error is AxiosErrorLike {
+  return typeof error === 'object' && error !== null;
+}
+
+export class IntegrationError extends Error {
+  readonly integration: IntegrationName;
+  readonly statusCode: number;
+  readonly reason: IntegrationErrorReason;
+  readonly clientMessage: string;
+
+  constructor(
+    integration: IntegrationName,
+    statusCode: number,
+    reason: IntegrationErrorReason,
+    clientMessage: string,
+    message = clientMessage,
+  ) {
+    super(message);
+    this.name = 'IntegrationError';
+    this.integration = integration;
+    this.statusCode = statusCode;
+    this.reason = reason;
+    this.clientMessage = clientMessage;
+  }
+}
+
+export function createIntegrationError(
+  integration: IntegrationName,
+  statusCode: number,
+  reason: IntegrationErrorReason,
+  clientMessage: string,
+  message = clientMessage,
+): IntegrationError {
+  return new IntegrationError(integration, statusCode, reason, clientMessage, message);
+}
+
+type UpstreamErrorOptions = {
+  targetUrl?: string;
+};
+
+function buildSanitizedTargetContext(targetUrl?: string): Record<string, string> {
+  if (!targetUrl) {
+    return {};
+  }
+
+  const sanitizedTarget = sanitizeConnectionUrl(targetUrl);
+
+  return {
+    ...(sanitizedTarget.host ? { upstreamHost: sanitizedTarget.host } : {}),
+    ...(sanitizedTarget.port ? { upstreamPort: sanitizedTarget.port } : {}),
+    ...(sanitizedTarget.scheme ? { upstreamScheme: sanitizedTarget.scheme } : {}),
+  };
+}
+
+export function logIntegrationProviderEvent(
+  integration: IntegrationName,
+  event: string,
+  reason: IntegrationErrorReason,
+  message: string,
+  options: UpstreamErrorOptions = {},
+): void {
+  writeBackendRuntimeLog(
+    'warn',
+    event,
+    message,
+    {
+      provider: integration,
+      reason,
+      ...buildSanitizedTargetContext(options.targetUrl),
+    },
+  );
+}
+
+export function translateUpstreamError(
+  integration: IntegrationName,
+  error: unknown,
+  fallbackMessage: string,
+  options: UpstreamErrorOptions = {},
+): IntegrationError {
+  if (error instanceof IntegrationError) {
+    return error;
+  }
+
+  if (isAxiosErrorLike(error)) {
+    if (error.code === 'ECONNABORTED') {
+      logIntegrationProviderEvent(
+        integration,
+        `integration_${integration}_timeout`,
+        'timeout',
+        `${integration} upstream request timed out.`,
+        options,
+      );
+
+      return createIntegrationError(
+        integration,
+        504,
+        'timeout',
+        fallbackMessage,
+        `${integration} upstream request timed out.`,
+      );
+    }
+
+    const responseStatus = error.response?.status;
+
+    if (typeof responseStatus === 'number' && responseStatus >= 500) {
+      logIntegrationProviderEvent(
+        integration,
+        `integration_${integration}_unavailable`,
+        'upstream_unavailable',
+        `${integration} upstream returned an unavailable status.`,
+        options,
+      );
+
+      return createIntegrationError(
+        integration,
+        503,
+        'upstream_unavailable',
+        fallbackMessage,
+        `${integration} upstream returned an unavailable status.`,
+      );
+    }
+  }
+
+  logIntegrationProviderEvent(
+    integration,
+    `integration_${integration}_unavailable`,
+    'upstream_unavailable',
+    `${integration} upstream request failed.`,
+    options,
+  );
+
+  return createIntegrationError(
+    integration,
+    503,
+    'upstream_unavailable',
+    fallbackMessage,
+    `${integration} upstream request failed.`,
+  );
+}

--- a/backend/src/infra/integrations/steam/steam.service.ts
+++ b/backend/src/infra/integrations/steam/steam.service.ts
@@ -1,10 +1,30 @@
 import axios from 'axios';
+import {
+  createIntegrationError,
+  translateUpstreamError,
+} from '../integration.errors';
 
 // ─────────────────────────────────────────────────────────────
 // Steam Service — biblioteca e horas jogadas
 // ─────────────────────────────────────────────────────────────
 
 const STEAM_BASE_URL = 'https://api.steampowered.com';
+const STEAM_TIMEOUT_MS = 10_000;
+
+function resolveSteamApiKey(): string {
+  const apiKey = process.env['STEAM_API_KEY']?.trim();
+
+  if (!apiKey) {
+    throw createIntegrationError(
+      'steam',
+      503,
+      'misconfigured',
+      'Integração Steam indisponível no runtime atual.',
+    );
+  }
+
+  return apiKey;
+}
 
 export interface SteamGame {
   appid:            number;
@@ -26,42 +46,60 @@ export interface SteamPlayerSummary {
 export const steamService = {
 
   async getOwnedGames(steamId: string): Promise<SteamGame[]> {
-    const response = await axios.get<{
-      response: {
-        game_count: number;
-        games:      SteamGame[];
-      };
-    }>(
-      `${STEAM_BASE_URL}/IPlayerService/GetOwnedGames/v1/`,
-      {
-        params: {
-          key:                  process.env['STEAM_API_KEY'],
-          steamid:              steamId,
-          include_appinfo:      true,
-          include_played_free_games: true,
+    try {
+      const response = await axios.get<{
+        response: {
+          game_count: number;
+          games:      SteamGame[];
+        };
+      }>(
+        `${STEAM_BASE_URL}/IPlayerService/GetOwnedGames/v1/`,
+        {
+          params: {
+            key: resolveSteamApiKey(),
+            steamid: steamId,
+            include_appinfo: true,
+            include_played_free_games: true,
+          },
+          timeout: STEAM_TIMEOUT_MS,
         },
-        timeout: 10_000,
-      },
-    );
+      );
 
-    return response.data.response.games ?? [];
+      return response.data.response.games ?? [];
+    } catch (error) {
+      throw translateUpstreamError(
+        'steam',
+        error,
+        'Integração Steam indisponível no momento.',
+        { targetUrl: STEAM_BASE_URL },
+      );
+    }
   },
 
   async getPlayerSummary(steamId: string): Promise<SteamPlayerSummary | null> {
-    const response = await axios.get<{
-      response: { players: SteamPlayerSummary[] };
-    }>(
-      `${STEAM_BASE_URL}/ISteamUser/GetPlayerSummaries/v2/`,
-      {
-        params: {
-          key:      process.env['STEAM_API_KEY'],
-          steamids: steamId,
+    try {
+      const response = await axios.get<{
+        response: { players: SteamPlayerSummary[] };
+      }>(
+        `${STEAM_BASE_URL}/ISteamUser/GetPlayerSummaries/v2/`,
+        {
+          params: {
+            key: resolveSteamApiKey(),
+            steamids: steamId,
+          },
+          timeout: STEAM_TIMEOUT_MS,
         },
-        timeout: 10_000,
-      },
-    );
+      );
 
-    return response.data.response.players[0] ?? null;
+      return response.data.response.players[0] ?? null;
+    } catch (error) {
+      throw translateUpstreamError(
+        'steam',
+        error,
+        'Integração Steam indisponível no momento.',
+        { targetUrl: STEAM_BASE_URL },
+      );
+    }
   },
 
   async validateSteamId(steamId: string): Promise<boolean> {

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
 import { FastifyRequest, FastifyReply } from 'fastify';
 import type { JwtPayload, VerifiedJwtPayload } from '../config/jwt';
+import type { IntegrationsService } from '../core/services/integrations.service';
 import type { RefreshTokenService } from '../core/services/refresh-token.service';
 
 // ─────────────────────────────────────────────────────────────
@@ -14,6 +15,7 @@ declare module 'fastify' {
     signAccessToken(payload: JwtPayload): string;
     verifyAccessToken(token: string): VerifiedJwtPayload;
     refreshTokenService: RefreshTokenService;
+    integrationsService: IntegrationsService;
   }
 
   interface FastifyRequest {

--- a/backend/tests/integration/routes/integrations.routes.test.ts
+++ b/backend/tests/integration/routes/integrations.routes.test.ts
@@ -1,123 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildApp, generateTestToken } from '../../helpers/build-app';
+import {
+  createIntegrationError,
+  type IntegrationError,
+} from '@/infra/integrations/integration.errors';
 
-vi.mock('@/core/repositories/user.repository', () => ({
-  userRepository: {
-    findById: vi.fn(),
-    findByEmail: vi.fn(),
-    findByUsername: vi.fn(),
-    existsByEmailOrUsername: vi.fn(),
-    create: vi.fn(),
-  },
-}));
-
-vi.mock('@/core/repositories/profile.repository', () => ({
-  profileRepository: {
-    findFullProfileByUsername: vi.fn(),
-    updateByUserId: vi.fn(),
-  },
-}));
-
-vi.mock('@/core/repositories/friend.repository', () => ({
-  friendRepository: {
-    createRequest: vi.fn(),
-    findRequestById: vi.fn(),
-    existsRequest: vi.fn(),
-    existsFriendship: vi.fn(),
-    acceptRequest: vi.fn(),
-    removeFriendship: vi.fn(),
-    findFriendsByUserId: vi.fn(),
-    findPendingRequests: vi.fn(),
-    findFriendIdsByUserId: vi.fn(),
-  },
-}));
-
-vi.mock('@/core/repositories/presence.repository', () => ({
-  presenceRepository: {
-    set: vi.fn(),
-    get: vi.fn(),
-    setOffline: vi.fn(),
-    publishScopedUpdate: vi.fn(),
-  },
-}));
-
-vi.mock('@/core/repositories/post.repository', () => ({
-  postRepository: {
-    create: vi.fn(),
-    findById: vi.fn(),
-    deleteById: vi.fn(),
-    findFeedByUserId: vi.fn(),
-    toggleInteraction: vi.fn(),
-    createComment: vi.fn(),
-    findCommentsByPostId: vi.fn(),
-    findCommentById: vi.fn(),
-  },
-}));
-
-vi.mock('@/core/repositories/notification.repository', () => ({
-  notificationRepository: {
-    findByUserId: vi.fn(),
-    findById: vi.fn(),
-    markAsRead: vi.fn(),
-    markAllAsRead: vi.fn(),
-    create: vi.fn(),
-  },
-}));
-
-vi.mock('@/core/services/notification.service', () => ({
-  notificationService: {
-    create: vi.fn(),
-  },
-}));
-
-vi.mock('@/infra/database/client', () => ({
-  prisma: {
-    platformIntegration: {
-      findUnique: vi.fn(),
-      upsert: vi.fn(),
-    },
-    userGameLibrary: {
-      upsert: vi.fn(),
-    },
-  },
-}));
-
-vi.mock('@/infra/integrations/steam/steam.service', () => ({
-  steamService: {
-    validateSteamId: vi.fn(),
-    getOwnedGames: vi.fn(),
-  },
-}));
-
-vi.mock('@/infra/integrations/igdb/igdb.service', () => ({
-  igdbService: {
-    searchGame: vi.fn(),
-  },
-}));
-
-vi.mock('@/infra/integrations/epic/epic.service', () => ({
-  epicService: {
-    validateToken: vi.fn(),
-    getLibrary: vi.fn(),
-  },
-}));
-
-import { prisma } from '@/infra/database/client';
-import { epicService } from '@/infra/integrations/epic/epic.service';
-import { igdbService } from '@/infra/integrations/igdb/igdb.service';
-import { steamService } from '@/infra/integrations/steam/steam.service';
-
-const mockSteamGames = [
-  { appid: 730, name: 'Counter-Strike 2', playtime_forever: 6000, img_icon_url: '' },
-  { appid: 570, name: 'Dota 2', playtime_forever: 1200, img_icon_url: '' },
-];
-
-const mockEpicGames = [
-  { id: 'fortnite', title: 'Fortnite', namespace: 'fn', coverUrl: null },
-  { id: 'rocket-league', title: 'Rocket League', namespace: 'rl', coverUrl: 'https://cdn.clutch.gg/rocket.jpg' },
-];
-
-const mockSteamGame = mockSteamGames[0]!;
+const createMockIntegrationsService = () => ({
+  connectSteam: vi.fn(),
+  syncSteamLibrary: vi.fn(),
+  searchIgdbGame: vi.fn(),
+  connectEpic: vi.fn(),
+});
 
 describe('Integrations Routes', () => {
   beforeEach(() => {
@@ -126,7 +19,8 @@ describe('Integrations Routes', () => {
 
   describe('POST /integrations/steam/connect', () => {
     it('retorna 401 sem token', async () => {
-      const app = await buildApp();
+      const integrationsService = createMockIntegrationsService();
+      const app = await buildApp({ integrationsService });
 
       const response = await app.inject({
         method: 'POST',
@@ -135,12 +29,13 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(401);
-      expect(vi.mocked(steamService.validateSteamId)).not.toHaveBeenCalled();
+      expect(integrationsService.connectSteam).not.toHaveBeenCalled();
       await app.close();
     });
 
     it('retorna 400 com body invalido', async () => {
-      const app = await buildApp();
+      const integrationsService = createMockIntegrationsService();
+      const app = await buildApp({ integrationsService });
       const token = generateTestToken(app);
 
       const response = await app.inject({
@@ -151,39 +46,18 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(response.json()).toMatchObject({ message: expect.any(String) });
-      expect(vi.mocked(prisma.platformIntegration.upsert)).not.toHaveBeenCalled();
+      expect(integrationsService.connectSteam).not.toHaveBeenCalled();
       await app.close();
     });
 
-    it('retorna 400 com SteamID invalido', async () => {
-      vi.mocked(steamService.validateSteamId).mockResolvedValue(false);
-
-      const app = await buildApp();
-      const token = generateTestToken(app);
-
-      const response = await app.inject({
-        method: 'POST',
-        url: '/integrations/steam/connect',
-        headers: { Authorization: `Bearer ${token}` },
-        payload: { steamId: 'private-profile' },
+    it('retorna 200 quando o service conecta a Steam', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.connectSteam.mockResolvedValue({
+        imported: 2,
+        message: 'Steam conectado. 2 jogos importados.',
       });
 
-      expect(response.statusCode).toBe(400);
-      expect(vi.mocked(prisma.platformIntegration.upsert)).not.toHaveBeenCalled();
-      await app.close();
-    });
-
-    it('retorna 200 e importa jogos da Steam', async () => {
-      vi.mocked(steamService.validateSteamId).mockResolvedValue(true);
-      vi.mocked(steamService.getOwnedGames).mockResolvedValue(mockSteamGames);
-      vi.mocked(igdbService.searchGame)
-        .mockResolvedValueOnce({ id: 730, name: 'Counter-Strike 2', coverUrl: 'https://images.ct2.jpg', platforms: ['PC'], summary: null })
-        .mockResolvedValueOnce(null);
-      vi.mocked(prisma.platformIntegration.upsert).mockResolvedValue({ id: 'integration-id-1' } as never);
-      vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({ id: 'library-id-1' } as never);
-
-      const app = await buildApp();
+      const app = await buildApp({ integrationsService });
       const token = generateTestToken(app, 'user-id-1');
 
       const response = await app.inject({
@@ -194,21 +68,25 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
+      expect(integrationsService.connectSteam).toHaveBeenCalledWith(
+        'user-id-1',
+        '76561198000000000',
+      );
       expect(response.json()).toMatchObject({
         imported: 2,
-        message: 'Steam conectado. 2 jogos importados.',
       });
-      expect(vi.mocked(prisma.platformIntegration.upsert)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(prisma.userGameLibrary.upsert)).toHaveBeenCalledTimes(2);
       await app.close();
     });
   });
 
   describe('POST /integrations/steam/sync', () => {
     it('retorna 404 quando Steam nao esta conectada', async () => {
-      vi.mocked(prisma.platformIntegration.findUnique).mockResolvedValue(null);
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.syncSteamLibrary.mockRejectedValue(
+        createIntegrationError('steam', 404, 'not_connected', 'Steam não conectado.'),
+      );
 
-      const app = await buildApp();
+      const app = await buildApp({ integrationsService });
       const token = generateTestToken(app, 'user-id-1');
 
       const response = await app.inject({
@@ -218,42 +96,15 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
-      expect(vi.mocked(steamService.getOwnedGames)).not.toHaveBeenCalled();
-      await app.close();
-    });
-
-    it('retorna 200 e sincroniza biblioteca existente', async () => {
-      vi.mocked(prisma.platformIntegration.findUnique).mockResolvedValue({
-        userId: 'user-id-1',
-        platform: 'STEAM',
-        externalId: '76561198000000000',
-      } as never);
-      vi.mocked(steamService.getOwnedGames).mockResolvedValue([mockSteamGame]);
-      vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({ id: 'library-id-1' } as never);
-
-      const app = await buildApp();
-      const token = generateTestToken(app, 'user-id-1');
-
-      const response = await app.inject({
-        method: 'POST',
-        url: '/integrations/steam/sync',
-        headers: { Authorization: `Bearer ${token}` },
-      });
-
-      expect(response.statusCode).toBe(200);
-      expect(response.json()).toMatchObject({
-        synced: 1,
-        message: '1 jogos sincronizados.',
-      });
-      expect(vi.mocked(steamService.getOwnedGames)).toHaveBeenCalledWith('76561198000000000');
-      expect(vi.mocked(prisma.userGameLibrary.upsert)).toHaveBeenCalledTimes(1);
+      expect(integrationsService.syncSteamLibrary).toHaveBeenCalledWith('user-id-1');
       await app.close();
     });
   });
 
   describe('GET /integrations/igdb/search', () => {
     it('retorna 400 com query curta', async () => {
-      const app = await buildApp();
+      const integrationsService = createMockIntegrationsService();
+      const app = await buildApp({ integrationsService });
 
       const response = await app.inject({
         method: 'GET',
@@ -261,14 +112,14 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(vi.mocked(igdbService.searchGame)).not.toHaveBeenCalled();
+      expect(integrationsService.searchIgdbGame).not.toHaveBeenCalled();
       await app.close();
     });
 
     it('retorna 404 quando jogo nao e encontrado', async () => {
-      vi.mocked(igdbService.searchGame).mockResolvedValue(null);
-
-      const app = await buildApp();
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.searchIgdbGame.mockResolvedValue(null);
+      const app = await buildApp({ integrationsService });
 
       const response = await app.inject({
         method: 'GET',
@@ -276,29 +127,25 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+      expect(integrationsService.searchIgdbGame).toHaveBeenCalledWith('unknown-game');
       await app.close();
     });
 
-    it('retorna 200 com metadados do jogo', async () => {
-      vi.mocked(igdbService.searchGame).mockResolvedValue({
-        id: 730,
-        name: 'Counter-Strike 2',
-        coverUrl: 'https://images.ct2.jpg',
-        platforms: ['PC'],
-        summary: 'Competitive FPS',
-      });
-
-      const app = await buildApp();
+    it('traduz timeout de IGDB para 504', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.searchIgdbGame.mockRejectedValue(
+        createIntegrationError('igdb', 504, 'timeout', 'Integração IGDB indisponível no momento.'),
+      );
+      const app = await buildApp({ integrationsService });
 
       const response = await app.inject({
         method: 'GET',
-        url: '/integrations/igdb/search?q=Counter-Strike 2',
+        url: '/integrations/igdb/search?q=Hades',
       });
 
-      expect(response.statusCode).toBe(200);
+      expect(response.statusCode).toBe(504);
       expect(response.json()).toMatchObject({
-        id: 730,
-        name: 'Counter-Strike 2',
+        message: 'Integração IGDB indisponível no momento.',
       });
       await app.close();
     });
@@ -306,7 +153,8 @@ describe('Integrations Routes', () => {
 
   describe('POST /integrations/epic/connect', () => {
     it('retorna 400 com body invalido', async () => {
-      const app = await buildApp();
+      const integrationsService = createMockIntegrationsService();
+      const app = await buildApp({ integrationsService });
       const token = generateTestToken(app, 'user-id-1');
 
       const response = await app.inject({
@@ -317,33 +165,16 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(vi.mocked(epicService.validateToken)).not.toHaveBeenCalled();
+      expect(integrationsService.connectEpic).not.toHaveBeenCalled();
       await app.close();
     });
 
-    it('retorna 400 com token Epic invalido', async () => {
-      vi.mocked(epicService.validateToken).mockResolvedValue(false);
-
-      const app = await buildApp();
-      const token = generateTestToken(app, 'user-id-1');
-
-      const response = await app.inject({
-        method: 'POST',
-        url: '/integrations/epic/connect',
-        headers: { Authorization: `Bearer ${token}` },
-        payload: { authToken: 'expired-token' },
-      });
-
-      expect(response.statusCode).toBe(400);
-      expect(vi.mocked(epicService.getLibrary)).not.toHaveBeenCalled();
-      await app.close();
-    });
-
-    it('retorna 503 quando o adapter Epic falha', async () => {
-      vi.mocked(epicService.validateToken).mockResolvedValue(true);
-      vi.mocked(epicService.getLibrary).mockRejectedValue(new Error('Python service offline'));
-
-      const app = await buildApp();
+    it('retorna 503 quando a integracao Epic esta indisponivel', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.connectEpic.mockRejectedValue(
+        createIntegrationError('epic', 503, 'unsupported', 'Integração Epic indisponível no runtime atual.'),
+      );
+      const app = await buildApp({ integrationsService });
       const token = generateTestToken(app, 'user-id-1');
 
       const response = await app.inject({
@@ -354,17 +185,42 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(503);
-      expect(vi.mocked(prisma.platformIntegration.upsert)).not.toHaveBeenCalled();
+      expect(response.json()).toMatchObject({
+        message: 'Integração Epic indisponível no runtime atual.',
+      });
       await app.close();
     });
 
-    it('retorna 200 e importa jogos da Epic', async () => {
-      vi.mocked(epicService.validateToken).mockResolvedValue(true);
-      vi.mocked(epicService.getLibrary).mockResolvedValue(mockEpicGames);
-      vi.mocked(prisma.platformIntegration.upsert).mockResolvedValue({ id: 'integration-id-1' } as never);
-      vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({ id: 'library-id-1' } as never);
+    it('retorna 504 quando o adapter Epic configurado nao responde a tempo', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.connectEpic.mockRejectedValue(
+        createIntegrationError('epic', 504, 'timeout', 'Integração Epic indisponível no momento.'),
+      );
+      const app = await buildApp({ integrationsService });
+      const token = generateTestToken(app, 'user-id-1');
 
-      const app = await buildApp();
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/epic/connect',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { authToken: 'valid-token' },
+      });
+
+      expect(response.statusCode).toBe(504);
+      expect(response.json()).toMatchObject({
+        message: 'Integração Epic indisponível no momento.',
+      });
+      await app.close();
+    });
+
+    it('retorna 200 quando o service conecta a Epic', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.connectEpic.mockResolvedValue({
+        imported: 1,
+        message: 'Epic conectado. 1 jogos importados.',
+      });
+
+      const app = await buildApp({ integrationsService });
       const token = generateTestToken(app, 'user-id-1');
 
       const response = await app.inject({
@@ -375,12 +231,7 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(response.json()).toMatchObject({
-        imported: 2,
-        message: 'Epic conectado. 2 jogos importados.',
-      });
-      expect(vi.mocked(prisma.platformIntegration.upsert)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(prisma.userGameLibrary.upsert)).toHaveBeenCalledTimes(2);
+      expect(integrationsService.connectEpic).toHaveBeenCalledWith('user-id-1', 'valid-token');
       await app.close();
     });
   });

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('axios');
 vi.mock('@/infra/cache/redis', () => ({
@@ -10,235 +10,373 @@ vi.mock('@/infra/cache/redis', () => ({
 
 import axios from 'axios';
 import { redis } from '@/infra/cache/redis';
+import {
+  createIntegrationsService,
+} from '@/core/services/integrations.service';
+import { IntegrationError } from '@/infra/integrations/integration.errors';
 import { epicService } from '@/infra/integrations/epic/epic.service';
 import { igdbService } from '@/infra/integrations/igdb/igdb.service';
 import { steamService } from '@/infra/integrations/steam/steam.service';
 
-describe('igdbService', () => {
-  beforeEach(() => vi.clearAllMocks());
+const originalEnv = { ...process.env };
 
-  describe('searchGame', () => {
-    it('renova token quando Redis miss e retorna jogo', async () => {
-      vi.mocked(redis.get).mockResolvedValue(null);
-      vi.mocked(redis.setex).mockResolvedValue('OK');
+const mockSteamGames = [
+  { appid: 730, name: 'Counter-Strike 2', playtime_forever: 6000, img_icon_url: '' },
+  { appid: 570, name: 'Dota 2', playtime_forever: 1200, img_icon_url: '' },
+];
 
-      vi.mocked(axios.post)
-        .mockResolvedValueOnce({
-          data: { access_token: 'test-token', expires_in: 3600, token_type: 'bearer' },
-        })
-        .mockResolvedValueOnce({
-          data: [{
-            id: 1234,
-            name: 'Valorant',
-            cover: { id: 1, url: '//images.igdb.com/igdb/image/upload/t_thumb/test.jpg' },
-            platforms: [{ name: 'PC (Microsoft Windows)' }],
-            summary: 'Tactical shooter',
-          }],
-        });
+const mockEpicGames = [
+  { id: 'fortnite', title: 'Fortnite', namespace: 'fn', coverUrl: null },
+];
 
-      const result = await igdbService.searchGame('Valorant');
+describe('integrations service layer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-      expect(result).not.toBeNull();
-      expect(result?.name).toBe('Valorant');
-      expect(result?.coverUrl).toContain('t_cover_big');
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('importa biblioteca Steam e tolera falha do IGDB como enriquecimento opcional', async () => {
+    const persistence = {
+      upsertPlatformIntegration: vi.fn().mockResolvedValue(undefined),
+      findPlatformIntegration: vi.fn(),
+      upsertSteamLibraryGame: vi.fn().mockResolvedValue(undefined),
+      upsertEpicLibraryGame: vi.fn(),
+    };
+
+    const service = createIntegrationsService({
+      steamClient: {
+        validateSteamId: vi.fn().mockResolvedValue(true),
+        getOwnedGames: vi.fn().mockResolvedValue(mockSteamGames),
+      },
+      igdbClient: {
+        searchGame: vi.fn()
+          .mockResolvedValueOnce({
+            id: 730,
+            name: 'Counter-Strike 2',
+            coverUrl: 'https://cdn.example/cs2.jpg',
+            platforms: ['PC'],
+            summary: null,
+          })
+          .mockRejectedValueOnce(new Error('IGDB offline')),
+      },
+      epicClient: {
+        validateToken: vi.fn(),
+        getLibrary: vi.fn(),
+      },
+      persistence,
     });
 
-    it('usa token do cache Redis quando disponivel', async () => {
-      vi.mocked(redis.get).mockResolvedValue('cached-token');
-      vi.mocked(axios.post).mockResolvedValueOnce({
-        data: [{ id: 1, name: 'CS2', platforms: [], summary: null }],
-      });
+    const result = await service.connectSteam('user-id-1', '76561198000000000');
 
-      await igdbService.searchGame('CS2');
+    expect(result).toMatchObject({
+      imported: 2,
+      message: 'Steam conectado. 2 jogos importados.',
+    });
+    expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
+      'user-id-1',
+      'STEAM',
+      { externalId: '76561198000000000' },
+    );
+    expect(persistence.upsertSteamLibraryGame).toHaveBeenNthCalledWith(
+      1,
+      'user-id-1',
+      mockSteamGames[0],
+      'https://cdn.example/cs2.jpg',
+    );
+    expect(persistence.upsertSteamLibraryGame).toHaveBeenNthCalledWith(
+      2,
+      'user-id-1',
+      mockSteamGames[1],
+      null,
+    );
+  });
 
-      expect(axios.post).toHaveBeenCalledTimes(1);
+  it('traduz Steam nao conectado na sincronizacao', async () => {
+    const service = createIntegrationsService({
+      steamClient: {
+        validateSteamId: vi.fn(),
+        getOwnedGames: vi.fn(),
+      },
+      igdbClient: {
+        searchGame: vi.fn(),
+      },
+      epicClient: {
+        validateToken: vi.fn(),
+        getLibrary: vi.fn(),
+      },
+      persistence: {
+        upsertPlatformIntegration: vi.fn(),
+        findPlatformIntegration: vi.fn().mockResolvedValue(null),
+        upsertSteamLibraryGame: vi.fn(),
+        upsertEpicLibraryGame: vi.fn(),
+      },
     });
 
-    it('retorna null quando jogo nao encontrado', async () => {
-      vi.mocked(redis.get).mockResolvedValue('cached-token');
-      vi.mocked(axios.post).mockResolvedValueOnce({ data: [] });
-
-      const result = await igdbService.searchGame('jogo-inexistente-xyz');
-
-      expect(result).toBeNull();
-    });
-
-    it('envia headers esperados para a busca no IGDB', async () => {
-      vi.mocked(redis.get).mockResolvedValue('cached-token');
-      vi.mocked(axios.post).mockResolvedValueOnce({
-        data: [{ id: 1, name: 'Hades', platforms: [], summary: null }],
-      });
-
-      await igdbService.searchGame('Hades');
-
-      expect(axios.post).toHaveBeenCalledWith(
-        'https://api.igdb.com/v4/games',
-        'search "Hades"; fields name,cover.url,platforms.name,summary; limit 1;',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer cached-token',
-            'Content-Type': 'text/plain',
-          }),
-        }),
-      );
+    await expect(service.syncSteamLibrary('user-id-1')).rejects.toMatchObject({
+      statusCode: 404,
+      reason: 'not_connected',
     });
   });
 
-  describe('getGameById', () => {
-    it('retorna jogo quando o id existe', async () => {
-      vi.mocked(redis.get).mockResolvedValue('cached-token');
-      vi.mocked(axios.post).mockResolvedValueOnce({
+  it('marca Epic como indisponivel quando o adapter nao existe no runtime atual', async () => {
+    const service = createIntegrationsService({
+      steamClient: {
+        validateSteamId: vi.fn(),
+        getOwnedGames: vi.fn(),
+      },
+      igdbClient: {
+        searchGame: vi.fn(),
+      },
+      epicClient: {
+        validateToken: vi.fn().mockRejectedValue(
+          new IntegrationError(
+            'epic',
+            503,
+            'unsupported',
+            'Integração Epic indisponível no runtime atual.',
+          ),
+        ),
+        getLibrary: vi.fn(),
+      },
+      persistence: {
+        upsertPlatformIntegration: vi.fn(),
+        findPlatformIntegration: vi.fn(),
+        upsertSteamLibraryGame: vi.fn(),
+        upsertEpicLibraryGame: vi.fn(),
+      },
+    });
+
+    await expect(service.connectEpic('user-id-1', 'epic-token')).rejects.toMatchObject({
+      statusCode: 503,
+      reason: 'unsupported',
+    });
+  });
+
+  it('retorna resultado de sucesso para Epic quando o adapter responde', async () => {
+    const persistence = {
+      upsertPlatformIntegration: vi.fn().mockResolvedValue(undefined),
+      findPlatformIntegration: vi.fn(),
+      upsertSteamLibraryGame: vi.fn(),
+      upsertEpicLibraryGame: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const service = createIntegrationsService({
+      steamClient: {
+        validateSteamId: vi.fn(),
+        getOwnedGames: vi.fn(),
+      },
+      igdbClient: {
+        searchGame: vi.fn(),
+      },
+      epicClient: {
+        validateToken: vi.fn().mockResolvedValue(true),
+        getLibrary: vi.fn().mockResolvedValue(mockEpicGames),
+      },
+      persistence,
+    });
+
+    const result = await service.connectEpic('user-id-1', 'valid-token');
+
+    expect(result).toMatchObject({
+      imported: 1,
+      message: 'Epic conectado. 1 jogos importados.',
+    });
+    expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
+      'user-id-1',
+      'EPIC',
+      { externalId: 'epic', accessToken: 'valid-token' },
+    );
+  });
+});
+
+describe('igdbService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      IGDB_CLIENT_ID: 'test-client',
+      IGDB_CLIENT_SECRET: 'test-secret',
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('renova token quando Redis miss e retorna jogo', async () => {
+    vi.mocked(redis.get).mockResolvedValue(null);
+    vi.mocked(redis.setex).mockResolvedValue('OK');
+
+    vi.mocked(axios.post)
+      .mockResolvedValueOnce({
+        data: { access_token: 'test-token', expires_in: 3600, token_type: 'bearer' },
+      } as never)
+      .mockResolvedValueOnce({
         data: [{
-          id: 5678,
-          name: 'Helldivers 2',
-          cover: { id: 2, url: '//images.igdb.com/igdb/image/upload/t_thumb/helldivers.jpg' },
+          id: 1234,
+          name: 'Valorant',
+          cover: { id: 1, url: '//images.igdb.com/igdb/image/upload/t_thumb/test.jpg' },
           platforms: [{ name: 'PC (Microsoft Windows)' }],
-          summary: 'Co-op extraction shooter',
+          summary: 'Tactical shooter',
         }],
-      });
+      } as never);
 
-      const result = await igdbService.getGameById(5678);
+    const result = await igdbService.searchGame('Valorant');
 
-      expect(result).toMatchObject({
-        id: 5678,
-        name: 'Helldivers 2',
-      });
-      expect(result?.coverUrl).toContain('t_cover_big');
+    expect(result?.name).toBe('Valorant');
+    expect(result?.coverUrl).toContain('t_cover_big');
+  });
+
+  it('traduz timeout do IGDB para erro coerente', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.mocked(redis.get).mockResolvedValue('cached-token');
+    vi.mocked(axios.post).mockRejectedValue({ code: 'ECONNABORTED' });
+
+    await expect(igdbService.searchGame('Hades')).rejects.toMatchObject({
+      statusCode: 504,
+      reason: 'timeout',
     });
 
-    it('retorna null quando o id nao existe', async () => {
-      vi.mocked(redis.get).mockResolvedValue('cached-token');
-      vi.mocked(axios.post).mockResolvedValueOnce({ data: [] });
-
-      const result = await igdbService.getGameById(999999);
-
-      expect(result).toBeNull();
-    });
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_igdb_timeout"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"provider":"igdb"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"reason":"timeout"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('test-secret');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('Authorization');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('https://');
+    stdoutWriteSpy.mockRestore();
   });
 });
 
 describe('steamService', () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  describe('getOwnedGames', () => {
-    it('retorna biblioteca quando SteamID e valido', async () => {
-      vi.mocked(axios.get).mockResolvedValue({
-        data: {
-          response: {
-            game_count: 2,
-            games: [
-              { appid: 730, name: 'Counter-Strike 2', playtime_forever: 6000, img_icon_url: '' },
-              { appid: 570, name: 'Dota 2', playtime_forever: 1200, img_icon_url: '' },
-            ],
-          },
-        },
-      });
-
-      const games = await steamService.getOwnedGames('76561198000000000');
-
-      expect(games).toHaveLength(2);
-      expect(games[0]?.name).toBe('Counter-Strike 2');
-      expect(axios.get).toHaveBeenCalledWith(
-        'https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/',
-        expect.objectContaining({
-          timeout: 10_000,
-          params: expect.objectContaining({
-            steamid: '76561198000000000',
-            include_appinfo: true,
-            include_played_free_games: true,
-          }),
-        }),
-      );
-    });
-
-    it('retorna array vazio quando perfil nao tem jogos', async () => {
-      vi.mocked(axios.get).mockResolvedValue({
-        data: { response: { game_count: 0 } },
-      });
-
-      const games = await steamService.getOwnedGames('76561198000000000');
-
-      expect(games).toEqual([]);
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      STEAM_API_KEY: 'steam-key',
+    };
   });
 
-  describe('validateSteamId', () => {
-    it('retorna true quando SteamID e valido', async () => {
-      vi.mocked(axios.get).mockResolvedValue({
-        data: {
-          response: {
-            players: [{ steamid: '76561198000000000', personaname: 'player' }],
-          },
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('retorna biblioteca quando Steam responde', async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        response: {
+          game_count: 2,
+          games: mockSteamGames,
         },
-      });
+      },
+    } as never);
 
-      const result = await steamService.validateSteamId('76561198000000000');
+    const games = await steamService.getOwnedGames('76561198000000000');
 
-      expect(result).toBe(true);
+    expect(games).toHaveLength(2);
+  });
+
+  it('traduz timeout da Steam para erro coerente', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.mocked(axios.get).mockRejectedValue({ code: 'ECONNABORTED' });
+
+    await expect(steamService.getOwnedGames('76561198000000000')).rejects.toMatchObject({
+      statusCode: 504,
+      reason: 'timeout',
     });
 
-    it('retorna false quando SteamID e invalido', async () => {
-      vi.mocked(axios.get).mockResolvedValue({
-        data: { response: { players: [] } },
-      });
-
-      const result = await steamService.validateSteamId('steamid-invalido');
-
-      expect(result).toBe(false);
-    });
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_steam_timeout"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"provider":"steam"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('steam-key');
+    stdoutWriteSpy.mockRestore();
   });
 });
 
 describe('epicService', () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  describe('getLibrary', () => {
-    it('retorna biblioteca quando Python service responde', async () => {
-      vi.mocked(axios.get).mockResolvedValue({
-        data: {
-          games: [
-            { id: 'fortnite', title: 'Fortnite', namespace: 'fn', coverUrl: null },
-            { id: 'rocket', title: 'Rocket League', namespace: 'rl', coverUrl: null },
-          ],
-        },
-      });
-
-      const games = await epicService.getLibrary('valid-token');
-
-      expect(games).toHaveLength(2);
-      expect(games[0]?.title).toBe('Fortnite');
-      expect(axios.get).toHaveBeenCalledWith(
-        'http://localhost:8000/library',
-        expect.objectContaining({
-          headers: { Authorization: 'Bearer valid-token' },
-          timeout: 30_000,
-        }),
-      );
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  describe('validateToken', () => {
-    it('retorna true quando token e valido', async () => {
-      vi.mocked(axios.get).mockResolvedValue({ data: { valid: true } });
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
 
-      const result = await epicService.validateToken('valid-token');
+  it('marca integracao como indisponivel quando a URL e placeholder do runtime antigo', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.env = {
+      ...originalEnv,
+      EPIC_SERVICE_URL: 'http://localhost:8000',
+    };
 
-      expect(result).toBe(true);
-      expect(axios.get).toHaveBeenCalledWith(
-        'http://localhost:8000/validate',
-        expect.objectContaining({
-          headers: { Authorization: 'Bearer valid-token' },
-          timeout: 5_000,
-        }),
-      );
+    await expect(epicService.validateToken('valid-token')).rejects.toMatchObject({
+      statusCode: 503,
+      reason: 'unsupported',
     });
 
-    it('retorna false quando token e invalido', async () => {
-      vi.mocked(axios.get).mockRejectedValue(new Error('Unauthorized'));
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_epic_unavailable"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"reason":"unsupported"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('valid-token');
+    stdoutWriteSpy.mockRestore();
+  });
 
-      const result = await epicService.validateToken('invalid-token');
+  it('rejeita URL invalida do adapter Epic de forma explicita', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.env = {
+      ...originalEnv,
+      EPIC_SERVICE_URL: 'not-a-valid-url',
+    };
 
-      expect(result).toBe(false);
+    await expect(epicService.validateToken('valid-token')).rejects.toMatchObject({
+      statusCode: 503,
+      reason: 'misconfigured',
     });
+
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_epic_unavailable"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"reason":"misconfigured"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('not-a-valid-url');
+    stdoutWriteSpy.mockRestore();
+  });
+
+  it('traduz timeout do adapter Epic configurado', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.env = {
+      ...originalEnv,
+      EPIC_SERVICE_URL: 'https://epic-adapter.example.com',
+    };
+    vi.mocked(axios.get).mockRejectedValue({ code: 'ECONNABORTED' });
+
+    await expect(epicService.getLibrary('valid-token')).rejects.toMatchObject({
+      statusCode: 504,
+      reason: 'timeout',
+    });
+
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_epic_timeout"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"provider":"epic"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('valid-token');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('https://epic-adapter.example.com');
+    stdoutWriteSpy.mockRestore();
+  });
+
+  it('retorna biblioteca quando o adapter externo responde', async () => {
+    process.env = {
+      ...originalEnv,
+      EPIC_SERVICE_URL: 'https://epic-adapter.example.com',
+    };
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        games: mockEpicGames,
+      },
+    } as never);
+
+    const games = await epicService.getLibrary('valid-token');
+
+    expect(games).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Resumo
Alinha o contrato real das integrações Steam, IGDB e Epic ao estado atual do repositório, removendo a dependência operacional implícita do python-service vazio e extraindo a regra de negócio de integrations.routes.ts.
A PR também formaliza o tratamento de indisponibilidade versus timeout de providers externos, com logs estruturados mínimos e configuração mais rígida para o adapter Epic.

## O que foi alterado
- Extrai a orquestração de integrações para uma service layer dedicada e remove acesso direto de regra de negócio/prisma das rotas.
- Endurece Steam, IGDB e Epic com timeout explícito, tradução consistente de erro e contrato HTTP coerente.
- Trata Epic como integração parcial dependente de adapter externo configurado, sem fallback implícito para localhost ou python-service.
- Formaliza a semântica de erro:
  - `503` para integração indisponível, não suportada ou mal configurada.
  - `504` para adapter/provider configurado que não respondeu a tempo.
- Adiciona logs estruturados mínimos para indisponibilidade e timeout por provider, sem vazar token, credencial, cookie ou URL sensível completa.
- Atualiza `.env.example` do backend para refletir que o adapter Epic é opcional e externo ao runtime principal.
- Amplia a cobertura de testes unitários e de integração para sucesso, timeout, indisponibilidade e configuração inválida.

## Motivação
A superfície pública de integrações estava mais otimista do que o runtime real do projeto. Isso mantinha regra de negócio acoplada à rota, deixava a semântica de falha externa pouco explícita e ainda sugeria dependência de um python-service que não participa do stack atual.
A mudança torna o contrato honesto, previsível e mais seguro operacionalmente, sem inventar suporte completo onde o repositório não sustenta.

## Como validar
- `cd backend`
- `npm run test -- tests/unit/services/integrations.service.test.ts tests/integration/routes/integrations.routes.test.ts`
- `npm run typecheck`
- `npm run lint`
- `cd ..`
- `docker compose up -d --build`
- `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- Validar fluxo real:
  - `POST http://localhost/api/auth/login`
  - `GET http://localhost/api/integrations/igdb/search?q=Hades`
- Validar contrato do Epic no backend containerizado:
  - sem adapter suportado configurado, `POST /integrations/epic/connect` retorna `503`
  - com adapter configurado mas sem resposta, `POST /integrations/epic/connect` retorna `504`

## Riscos e impactos
- A integração Epic continua parcial: ela depende de um adapter externo real. Esta PR apenas torna esse estado explícito e seguro.
- O frontend/proxy ainda apresentou `502` ao tentar `POST /api/integrations/epic/connect` antes de atingir o backend. Esse follow-up não faz parte desta PR.
- `npm run lint` do backend continua exibindo warnings preexistentes em `src/config/rate-limit.ts`, fora do escopo desta issue.
- O impacto de contrato é intencionalmente restrito à honestidade das respostas de erro de integrações já existentes; não há mudança no contrato de sucesso do auth path ou do restante da API.

## Evidências
- `POST /api/auth/login` via proxy: `200`
- `GET /api/integrations/igdb/search?q=Hades` via proxy: `200`
- `POST /integrations/epic/connect` no backend containerizado sem adapter suportado: `503`
- `POST /integrations/epic/connect` no backend containerizado com upstream sem resposta: `504`
- Inspeção de logs sem ocorrência de `Authorization`, `Bearer `, `STEAM_API_KEY`, `IGDB_CLIENT_SECRET`, `EPIC_SERVICE_URL`, `clutch_session` ou `clutch_refresh`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #108
