### PR TITLE
feat(integrations): implemente Discord OAuth e vinculação

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,10 +29,14 @@ STEAM_API_KEY=
 
 # ── Discord ──────────────────────────────────────────────────
 # Obter em: https://discord.com/developers/applications
-# Obrigatório para integração Discord
-DISCORD_BOT_TOKEN=
+# Obrigatório para OAuth de vinculação Discord
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
+# URL pública registrada no app Discord.
+# Exemplo local: http://localhost/api/integrations/discord/callback
+DISCORD_REDIRECT_URI=
+# Opcional. Não é usado pelo fluxo OAuth de vinculação atual.
+DISCORD_BOT_TOKEN=
 
 # ── IGDB (Twitch) ────────────────────────────────────────────
 # Obter em: https://dev.twitch.tv/console

--- a/backend/src/api/routes/integrations.routes.ts
+++ b/backend/src/api/routes/integrations.routes.ts
@@ -10,20 +10,35 @@ const epicConnectSchema = z.object({
   authToken: z.string().min(1, 'Token Epic é obrigatório'),
 });
 
+const discordCallbackSchema = z.object({
+  code: z.string().min(1).optional(),
+  state: z.string().min(1).optional(),
+  error: z.string().min(1).optional(),
+  error_description: z.string().optional(),
+}).refine(
+  (input) => Boolean(input.error) || (Boolean(input.code) && Boolean(input.state)),
+  {
+    message: 'Callback Discord inválido.',
+  },
+);
+
 function replyWithIntegrationError(
   request: { id: string; method: string; url: string; log: FastifyInstance['log'] },
   error: unknown,
+  options: { logFailure?: boolean } = {},
 ): { statusCode: number; payload: { message: string } } {
   if (isIntegrationError(error)) {
-    request.log.warn({
-      event: 'integration_request_failed',
-      requestId: request.id,
-      method: request.method,
-      path: request.url,
-      provider: error.integration,
-      reason: error.reason,
-      status: error.statusCode,
-    }, 'Integration request failed');
+    if (options.logFailure !== false) {
+      request.log.warn({
+        event: 'integration_request_failed',
+        requestId: request.id,
+        method: request.method,
+        path: request.url,
+        provider: error.integration,
+        reason: error.reason,
+        status: error.statusCode,
+      }, 'Integration request failed');
+    }
 
     return {
       statusCode: error.statusCode,
@@ -89,6 +104,50 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(200).send(game);
       } catch (error) {
         const integrationError = replyWithIntegrationError(request, error);
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
+      }
+    },
+  );
+
+  // ── GET /integrations/discord/auth ──────────────────────
+  app.get(
+    '/discord/auth',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      try {
+        const resultPayload = await app.discordOAuthService.getAuthorizationUrl({
+          userId: request.userId,
+          requestId: request.id,
+        });
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error, { logFailure: false });
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
+      }
+    },
+  );
+
+  // ── GET /integrations/discord/callback ──────────────────
+  app.get<{ Querystring: { code?: string; state?: string; error?: string; error_description?: string } }>(
+    '/discord/callback',
+    async (request, reply) => {
+      const result = discordCallbackSchema.safeParse(request.query);
+      if (!result.success) {
+        return reply.status(400).send({ message: 'Callback Discord inválido.' });
+      }
+
+      try {
+        const resultPayload = await app.discordOAuthService.completeCallback({
+          code: result.data.code,
+          state: result.data.state,
+          providerError: result.data.error,
+          requestId: request.id,
+        });
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error, { logFailure: false });
         return reply.status(integrationError.statusCode).send(integrationError.payload);
       }
     },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -32,6 +32,10 @@ import {
   createIntegrationsService,
   type IntegrationsService,
 } from './core/services/integrations.service';
+import {
+  createDiscordOAuthService,
+  type DiscordOAuthService,
+} from './core/services/discord-oauth.service';
 import { createRedisRefreshSessionStore } from './infra/cache/refresh-session.store';
 import { redis as runtimeRedis } from './infra/cache/redis';
 import type Redis from 'ioredis';
@@ -44,6 +48,7 @@ export type BuildAppOptions = {
   refreshSessionStore?: RefreshSessionStore;
   rateLimitRedis?: Redis | null;
   integrationsService?: IntegrationsService;
+  discordOAuthService?: DiscordOAuthService;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -65,12 +70,14 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
     refreshSessionStore: options.refreshSessionStore ?? createRedisRefreshSessionStore(),
   });
   const integrationsService = options.integrationsService ?? createIntegrationsService();
+  const discordOAuthService = options.discordOAuthService ?? createDiscordOAuthService();
 
   app.decorate('authenticate', authenticate);
   app.decorate('signAccessToken', signAccessToken);
   app.decorate('verifyAccessToken', verifyAccessToken);
   app.decorate('refreshTokenService', refreshTokenService);
   app.decorate('integrationsService', integrationsService);
+  app.decorate('discordOAuthService', discordOAuthService);
 
   await app.register(
     fastifyRateLimit,

--- a/backend/src/core/services/discord-oauth.service.ts
+++ b/backend/src/core/services/discord-oauth.service.ts
@@ -1,0 +1,226 @@
+/* eslint-disable no-unused-vars */
+import { Prisma } from '@prisma/client';
+import { prisma } from '../../infra/database/client';
+import {
+  createIntegrationError,
+  type IntegrationError,
+} from '../../infra/integrations/integration.errors';
+import {
+  discordService,
+  type DiscordIdentity,
+  type DiscordTokenSet,
+} from '../../infra/integrations/discord/discord.service';
+import { writeBackendRuntimeLog } from '../../config/logging';
+
+type PersistDiscordIntegrationInput = {
+  externalId: string;
+  accessToken: string;
+  refreshToken: string | null;
+  metadata: Prisma.InputJsonValue;
+};
+
+type DiscordOAuthPersistence = {
+  upsertDiscordIntegration(
+    userId: string,
+    data: PersistDiscordIntegrationInput,
+  ): Promise<void>;
+};
+
+type DiscordOAuthClient = Pick<
+typeof discordService,
+  'createAuthorizationUrl' | 'validateState' | 'exchangeCode' | 'getCurrentUser'
+>;
+
+type DiscordCallbackResult = {
+  message: string;
+  platform: 'DISCORD';
+  externalId: string;
+  username: string;
+  globalName: string | null;
+};
+
+type CompleteDiscordOAuthInput = {
+  code?: string;
+  state?: string;
+  providerError?: string;
+  requestId?: string;
+};
+
+function createPrismaDiscordOAuthPersistence(): DiscordOAuthPersistence {
+  return {
+    async upsertDiscordIntegration(userId, data): Promise<void> {
+      await prisma.platformIntegration.upsert({
+        where: {
+          userId_platform: {
+            userId,
+            platform: 'DISCORD',
+          },
+        },
+        create: {
+          userId,
+          platform: 'DISCORD',
+          externalId: data.externalId,
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+          metadata: data.metadata,
+          isActive: true,
+        },
+        update: {
+          externalId: data.externalId,
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+          metadata: data.metadata,
+          isActive: true,
+        },
+      });
+    },
+  };
+}
+
+function normalizeDiscordOAuthError(error: unknown): IntegrationError {
+  if (error instanceof Error && error.name === 'IntegrationError') {
+    return error as IntegrationError;
+  }
+
+  return createIntegrationError(
+    'discord',
+    503,
+    'upstream_unavailable',
+    'Integração Discord indisponível no momento.',
+  );
+}
+
+function buildDiscordMetadata(identity: DiscordIdentity, tokenSet: DiscordTokenSet): Prisma.InputJsonValue {
+  return {
+    username: identity.username,
+    globalName: identity.globalName,
+    avatarUrl: identity.avatarUrl,
+    tokenType: tokenSet.tokenType,
+    scope: tokenSet.scope,
+    tokenExpiresAt: new Date(Date.now() + tokenSet.expiresIn * 1000).toISOString(),
+  };
+}
+
+export type DiscordOAuthService = ReturnType<typeof createDiscordOAuthService>;
+
+export function createDiscordOAuthService(dependencies?: {
+  discordClient?: DiscordOAuthClient;
+  persistence?: DiscordOAuthPersistence;
+}): {
+  getAuthorizationUrl: (input: { userId: string; requestId?: string }) => Promise<{ authorizationUrl: string }>;
+  completeCallback: (input: CompleteDiscordOAuthInput) => Promise<DiscordCallbackResult>;
+} {
+  const discordClient = dependencies?.discordClient ?? discordService;
+  const persistence = dependencies?.persistence ?? createPrismaDiscordOAuthPersistence();
+
+  return {
+    async getAuthorizationUrl({
+      userId,
+      requestId,
+    }: {
+      userId: string;
+      requestId?: string;
+    }): Promise<{ authorizationUrl: string }> {
+      writeBackendRuntimeLog(
+        'info',
+        'integration_discord_oauth_started',
+        'Discord OAuth flow started.',
+        {
+          requestId,
+          provider: 'discord',
+          userId,
+        },
+      );
+
+      const { authorizationUrl } = discordClient.createAuthorizationUrl(userId);
+
+      return {
+        authorizationUrl,
+      };
+    },
+
+    async completeCallback({
+      code,
+      state,
+      providerError,
+      requestId,
+    }: CompleteDiscordOAuthInput): Promise<DiscordCallbackResult> {
+      writeBackendRuntimeLog(
+        'info',
+        'integration_discord_oauth_callback_received',
+        'Discord OAuth callback received.',
+        {
+          requestId,
+          provider: 'discord',
+        },
+      );
+
+      try {
+        if (providerError) {
+          throw createIntegrationError(
+            'discord',
+            400,
+            'invalid_request',
+            'Autorização Discord não foi concluída.',
+          );
+        }
+
+        if (!code || !state) {
+          throw createIntegrationError(
+            'discord',
+            400,
+            'invalid_request',
+            'Callback Discord inválido.',
+          );
+        }
+
+        const statePayload = discordClient.validateState(state);
+        const tokenSet = await discordClient.exchangeCode(code);
+        const identity = await discordClient.getCurrentUser(tokenSet.accessToken);
+
+        await persistence.upsertDiscordIntegration(statePayload.userId, {
+          externalId: identity.id,
+          accessToken: tokenSet.accessToken,
+          refreshToken: tokenSet.refreshToken,
+          metadata: buildDiscordMetadata(identity, tokenSet),
+        });
+
+        writeBackendRuntimeLog(
+          'info',
+          'integration_discord_link_succeeded',
+          'Discord account linked successfully.',
+          {
+            requestId,
+            provider: 'discord',
+            userId: statePayload.userId,
+            externalId: identity.id,
+          },
+        );
+
+        return {
+          message: 'Discord conectado com sucesso.',
+          platform: 'DISCORD',
+          externalId: identity.id,
+          username: identity.username,
+          globalName: identity.globalName,
+        };
+      } catch (error) {
+        const integrationError = normalizeDiscordOAuthError(error);
+
+        writeBackendRuntimeLog(
+          'warn',
+          'integration_discord_oauth_failed',
+          'Discord OAuth flow failed.',
+          {
+            requestId,
+            provider: 'discord',
+            reason: integrationError.reason,
+            status: integrationError.statusCode,
+          },
+        );
+
+        throw integrationError;
+      }
+    },
+  };
+}

--- a/backend/src/infra/integrations/discord/discord.service.ts
+++ b/backend/src/infra/integrations/discord/discord.service.ts
@@ -1,0 +1,343 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import axios from 'axios';
+import {
+  createIntegrationError,
+  logIntegrationProviderEvent,
+  translateUpstreamError,
+} from '../integration.errors';
+
+const DISCORD_AUTHORIZE_URL = 'https://discord.com/oauth2/authorize';
+const DISCORD_TOKEN_URL = 'https://discord.com/api/oauth2/token';
+const DISCORD_CURRENT_USER_URL = 'https://discord.com/api/v10/users/@me';
+const DISCORD_TIMEOUT_MS = 10_000;
+const DISCORD_STATE_TTL_MS = 10 * 60 * 1000;
+const DISCORD_OAUTH_SCOPE = 'identify';
+
+type DiscordOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+};
+
+type DiscordStatePayload = {
+  userId: string;
+  issuedAt: number;
+};
+
+type DiscordTokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+};
+
+type DiscordCurrentUserResponse = {
+  id: string;
+  username: string;
+  global_name: string | null;
+  avatar: string | null;
+};
+
+export type DiscordTokenSet = {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresIn: number;
+  scope: string;
+  tokenType: string;
+};
+
+export type DiscordIdentity = {
+  id: string;
+  username: string;
+  globalName: string | null;
+  avatarUrl: string | null;
+};
+
+function createStateSignature(payload: string, secret: string): string {
+  return createHmac('sha256', secret).update(payload).digest('base64url');
+}
+
+function assertValidRedirectUri(redirectUri: string): void {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(redirectUri);
+  } catch {
+    throw createIntegrationError(
+      'discord',
+      503,
+      'misconfigured',
+      'Integração Discord indisponível no runtime atual.',
+    );
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol) || parsedUrl.username || parsedUrl.password) {
+    throw createIntegrationError(
+      'discord',
+      503,
+      'misconfigured',
+      'Integração Discord indisponível no runtime atual.',
+    );
+  }
+}
+
+function resolveDiscordOAuthConfig(): DiscordOAuthConfig {
+  const clientId = process.env['DISCORD_CLIENT_ID']?.trim();
+  const clientSecret = process.env['DISCORD_CLIENT_SECRET']?.trim();
+  const redirectUri = process.env['DISCORD_REDIRECT_URI']?.trim();
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    logIntegrationProviderEvent(
+      'discord',
+      'integration_discord_unavailable',
+      'misconfigured',
+      'Discord OAuth config is incomplete in the current runtime.',
+    );
+
+    throw createIntegrationError(
+      'discord',
+      503,
+      'misconfigured',
+      'Integração Discord indisponível no runtime atual.',
+    );
+  }
+
+  try {
+    assertValidRedirectUri(redirectUri);
+  } catch (error) {
+    logIntegrationProviderEvent(
+      'discord',
+      'integration_discord_unavailable',
+      'misconfigured',
+      'Discord redirect URI is invalid for the current runtime.',
+      { targetUrl: redirectUri },
+    );
+    throw error;
+  }
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri,
+  };
+}
+
+function encodeStatePayload(payload: DiscordStatePayload): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function decodeStatePayload(value: string): DiscordStatePayload {
+  let parsedPayload: Partial<DiscordStatePayload>;
+
+  try {
+    parsedPayload = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Partial<DiscordStatePayload>;
+  } catch {
+    throw createIntegrationError(
+      'discord',
+      400,
+      'invalid_request',
+      'Callback Discord inválido.',
+    );
+  }
+
+  if (
+    typeof parsedPayload.userId !== 'string' ||
+    parsedPayload.userId.trim().length === 0 ||
+    typeof parsedPayload.issuedAt !== 'number' ||
+    !Number.isFinite(parsedPayload.issuedAt)
+  ) {
+    throw createIntegrationError(
+      'discord',
+      400,
+      'invalid_request',
+      'Callback Discord inválido.',
+    );
+  }
+
+  return {
+    userId: parsedPayload.userId,
+    issuedAt: parsedPayload.issuedAt,
+  };
+}
+
+function createStateValue(userId: string, secret: string): string {
+  const encodedPayload = encodeStatePayload({
+    userId,
+    issuedAt: Date.now(),
+  });
+
+  return `${encodedPayload}.${createStateSignature(encodedPayload, secret)}`;
+}
+
+function validateStateValue(state: string, secret: string): DiscordStatePayload {
+  const segments = state.split('.');
+
+  if (segments.length !== 2 || !segments[0] || !segments[1]) {
+    throw createIntegrationError(
+      'discord',
+      400,
+      'invalid_request',
+      'Callback Discord inválido.',
+    );
+  }
+
+  const [encodedPayload, receivedSignature] = segments;
+  const expectedSignature = createStateSignature(encodedPayload, secret);
+  const receivedSignatureBuffer = Buffer.from(receivedSignature, 'utf8');
+  const expectedSignatureBuffer = Buffer.from(expectedSignature, 'utf8');
+
+  if (
+    receivedSignatureBuffer.length !== expectedSignatureBuffer.length ||
+    !timingSafeEqual(receivedSignatureBuffer, expectedSignatureBuffer)
+  ) {
+    throw createIntegrationError(
+      'discord',
+      400,
+      'invalid_request',
+      'Callback Discord inválido.',
+    );
+  }
+
+  const payload = decodeStatePayload(encodedPayload);
+
+  if (Date.now() - payload.issuedAt > DISCORD_STATE_TTL_MS) {
+    throw createIntegrationError(
+      'discord',
+      400,
+      'invalid_request',
+      'Callback Discord inválido ou expirado.',
+    );
+  }
+
+  return payload;
+}
+
+function buildAvatarUrl(userId: string, avatarHash: string | null): string | null {
+  if (!avatarHash) {
+    return null;
+  }
+
+  return `https://cdn.discordapp.com/avatars/${userId}/${avatarHash}.png`;
+}
+
+export const discordService = {
+  createAuthorizationUrl(userId: string): { authorizationUrl: string; state: string } {
+    const config = resolveDiscordOAuthConfig();
+    const state = createStateValue(userId, config.clientSecret);
+    const authorizationUrl = new URL(DISCORD_AUTHORIZE_URL);
+
+    authorizationUrl.searchParams.set('client_id', config.clientId);
+    authorizationUrl.searchParams.set('response_type', 'code');
+    authorizationUrl.searchParams.set('redirect_uri', config.redirectUri);
+    authorizationUrl.searchParams.set('scope', DISCORD_OAUTH_SCOPE);
+    authorizationUrl.searchParams.set('state', state);
+    authorizationUrl.searchParams.set('prompt', 'consent');
+
+    return {
+      authorizationUrl: authorizationUrl.toString(),
+      state,
+    };
+  },
+
+  validateState(state: string): DiscordStatePayload {
+    const config = resolveDiscordOAuthConfig();
+    return validateStateValue(state, config.clientSecret);
+  },
+
+  async exchangeCode(code: string): Promise<DiscordTokenSet> {
+    const config = resolveDiscordOAuthConfig();
+
+    try {
+      const response = await axios.post<DiscordTokenResponse>(
+        DISCORD_TOKEN_URL,
+        new URLSearchParams({
+          client_id: config.clientId,
+          client_secret: config.clientSecret,
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: config.redirectUri,
+        }).toString(),
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          timeout: DISCORD_TIMEOUT_MS,
+        },
+      );
+
+      return {
+        accessToken: response.data.access_token,
+        refreshToken: response.data.refresh_token ?? null,
+        expiresIn: response.data.expires_in,
+        scope: response.data.scope,
+        tokenType: response.data.token_type,
+      };
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        typeof (error as { response?: { status?: number } }).response?.status === 'number' &&
+        [400, 401, 403].includes((error as { response?: { status?: number } }).response?.status as number)
+      ) {
+        throw createIntegrationError(
+          'discord',
+          400,
+          'invalid_request',
+          'Autorização Discord inválida ou expirada.',
+        );
+      }
+
+      throw translateUpstreamError(
+        'discord',
+        error,
+        'Integração Discord indisponível no momento.',
+        { targetUrl: DISCORD_TOKEN_URL },
+      );
+    }
+  },
+
+  async getCurrentUser(accessToken: string): Promise<DiscordIdentity> {
+    try {
+      const response = await axios.get<DiscordCurrentUserResponse>(
+        DISCORD_CURRENT_USER_URL,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+          timeout: DISCORD_TIMEOUT_MS,
+        },
+      );
+
+      return {
+        id: response.data.id,
+        username: response.data.username,
+        globalName: response.data.global_name,
+        avatarUrl: buildAvatarUrl(response.data.id, response.data.avatar),
+      };
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        typeof (error as { response?: { status?: number } }).response?.status === 'number' &&
+        [401, 403].includes((error as { response?: { status?: number } }).response?.status as number)
+      ) {
+        throw createIntegrationError(
+          'discord',
+          400,
+          'invalid_request',
+          'Autorização Discord inválida ou expirada.',
+        );
+      }
+
+      throw translateUpstreamError(
+        'discord',
+        error,
+        'Integração Discord indisponível no momento.',
+        { targetUrl: DISCORD_CURRENT_USER_URL },
+      );
+    }
+  },
+};

--- a/backend/src/infra/integrations/integration.errors.ts
+++ b/backend/src/infra/integrations/integration.errors.ts
@@ -3,7 +3,7 @@ import {
   writeBackendRuntimeLog,
 } from '../../config/logging';
 
-export type IntegrationName = 'steam' | 'igdb' | 'epic';
+export type IntegrationName = 'steam' | 'igdb' | 'epic' | 'discord';
 
 export type IntegrationErrorReason =
   | 'invalid_request'

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
 import { FastifyRequest, FastifyReply } from 'fastify';
 import type { JwtPayload, VerifiedJwtPayload } from '../config/jwt';
+import type { DiscordOAuthService } from '../core/services/discord-oauth.service';
 import type { IntegrationsService } from '../core/services/integrations.service';
 import type { RefreshTokenService } from '../core/services/refresh-token.service';
 
@@ -16,6 +17,7 @@ declare module 'fastify' {
     verifyAccessToken(token: string): VerifiedJwtPayload;
     refreshTokenService: RefreshTokenService;
     integrationsService: IntegrationsService;
+    discordOAuthService: DiscordOAuthService;
   }
 
   interface FastifyRequest {

--- a/backend/tests/integration/routes/integrations.routes.test.ts
+++ b/backend/tests/integration/routes/integrations.routes.test.ts
@@ -12,6 +12,11 @@ const createMockIntegrationsService = () => ({
   connectEpic: vi.fn(),
 });
 
+const createMockDiscordOAuthService = () => ({
+  getAuthorizationUrl: vi.fn(),
+  completeCallback: vi.fn(),
+});
+
 describe('Integrations Routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -232,6 +237,120 @@ describe('Integrations Routes', () => {
 
       expect(response.statusCode).toBe(200);
       expect(integrationsService.connectEpic).toHaveBeenCalledWith('user-id-1', 'valid-token');
+      await app.close();
+    });
+  });
+
+  describe('GET /integrations/discord/auth', () => {
+    it('retorna 401 sem token', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      const app = await buildApp({ integrationsService, discordOAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/discord/auth',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(discordOAuthService.getAuthorizationUrl).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna URL coerente quando o service inicia o OAuth', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      discordOAuthService.getAuthorizationUrl.mockResolvedValue({
+        authorizationUrl: 'https://discord.com/oauth2/authorize?client_id=test-client&state=signed-state',
+      });
+
+      const app = await buildApp({ integrationsService, discordOAuthService });
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/discord/auth',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(discordOAuthService.getAuthorizationUrl).toHaveBeenCalledWith({
+        userId: 'user-id-1',
+        requestId: expect.any(String),
+      });
+      expect(response.json()).toMatchObject({
+        authorizationUrl: expect.stringContaining('https://discord.com/oauth2/authorize'),
+      });
+      await app.close();
+    });
+  });
+
+  describe('GET /integrations/discord/callback', () => {
+    it('retorna 400 quando callback nao traz dados minimos', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      const app = await buildApp({ integrationsService, discordOAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/discord/callback',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(discordOAuthService.completeCallback).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('persiste com sucesso no callback quando o service conclui o OAuth', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      discordOAuthService.completeCallback.mockResolvedValue({
+        message: 'Discord conectado com sucesso.',
+        platform: 'DISCORD',
+        externalId: 'discord-user-id',
+        username: 'clutchdiscord',
+        globalName: 'Clutch Discord',
+      });
+
+      const app = await buildApp({ integrationsService, discordOAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/discord/callback?code=oauth-code&state=signed-state',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(discordOAuthService.completeCallback).toHaveBeenCalledWith({
+        code: 'oauth-code',
+        state: 'signed-state',
+        providerError: undefined,
+        requestId: expect.any(String),
+      });
+      expect(response.json()).toMatchObject({
+        platform: 'DISCORD',
+        externalId: 'discord-user-id',
+      });
+      await app.close();
+    });
+
+    it('traduz falha do provedor de forma coerente', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      discordOAuthService.completeCallback.mockRejectedValue(
+        createIntegrationError('discord', 400, 'invalid_request', 'Autorização Discord inválida ou expirada.'),
+      );
+
+      const app = await buildApp({ integrationsService, discordOAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/discord/callback?code=oauth-code&state=signed-state',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({
+        message: 'Autorização Discord inválida ou expirada.',
+      });
       await app.close();
     });
   });

--- a/backend/tests/unit/services/discord-oauth.service.test.ts
+++ b/backend/tests/unit/services/discord-oauth.service.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios');
+
+import axios from 'axios';
+import { createDiscordOAuthService } from '@/core/services/discord-oauth.service';
+import { createIntegrationError } from '@/infra/integrations/integration.errors';
+import { discordService } from '@/infra/integrations/discord/discord.service';
+
+const originalEnv = { ...process.env };
+
+describe('discordService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      DISCORD_CLIENT_ID: 'discord-client-id',
+      DISCORD_CLIENT_SECRET: 'discord-client-secret',
+      DISCORD_REDIRECT_URI: 'http://localhost/api/integrations/discord/callback',
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('gera URL de autorizacao coerente com state assinado', () => {
+    const { authorizationUrl, state } = discordService.createAuthorizationUrl('user-id-1');
+    const parsedUrl = new URL(authorizationUrl);
+
+    expect(parsedUrl.origin).toBe('https://discord.com');
+    expect(parsedUrl.pathname).toBe('/oauth2/authorize');
+    expect(parsedUrl.searchParams.get('client_id')).toBe('discord-client-id');
+    expect(parsedUrl.searchParams.get('response_type')).toBe('code');
+    expect(parsedUrl.searchParams.get('redirect_uri')).toBe('http://localhost/api/integrations/discord/callback');
+    expect(parsedUrl.searchParams.get('scope')).toBe('identify');
+    expect(parsedUrl.searchParams.get('state')).toBeTruthy();
+    expect(discordService.validateState(state)).toMatchObject({
+      userId: 'user-id-1',
+    });
+  });
+
+  it('falha explicitamente quando a configuracao do Discord esta ausente', () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.env = {
+      ...originalEnv,
+      DISCORD_CLIENT_ID: 'discord-client-id',
+      DISCORD_CLIENT_SECRET: '',
+      DISCORD_REDIRECT_URI: '',
+    };
+
+    let capturedError: unknown;
+
+    try {
+      discordService.createAuthorizationUrl('user-id-1');
+    } catch (error) {
+      capturedError = error;
+    }
+
+    expect(capturedError).toMatchObject({
+      statusCode: 503,
+      reason: 'misconfigured',
+    });
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_discord_unavailable"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('discord-client-secret');
+    stdoutWriteSpy.mockRestore();
+  });
+
+  it('rejeita state adulterado com erro coerente', () => {
+    const { state } = discordService.createAuthorizationUrl('user-id-1');
+    const tamperedState = `${state.slice(0, -1)}x`;
+
+    let capturedError: unknown;
+
+    try {
+      discordService.validateState(tamperedState);
+    } catch (error) {
+      capturedError = error;
+    }
+
+    expect(capturedError).toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+    });
+  });
+
+  it('traduz code OAuth invalido para erro coerente', async () => {
+    vi.mocked(axios.post).mockRejectedValue({
+      response: { status: 400 },
+    });
+
+    await expect(discordService.exchangeCode('oauth-code')).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+    });
+  });
+
+  it('traduz timeout do Discord para 504 e log seguro', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.mocked(axios.post).mockRejectedValue({ code: 'ECONNABORTED' });
+
+    await expect(discordService.exchangeCode('oauth-code')).rejects.toMatchObject({
+      statusCode: 504,
+      reason: 'timeout',
+    });
+
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_discord_timeout"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"provider":"discord"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('oauth-code');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('discord-client-secret');
+    stdoutWriteSpy.mockRestore();
+  });
+});
+
+describe('createDiscordOAuthService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('retorna URL de autorizacao e registra inicio do fluxo', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const service = createDiscordOAuthService({
+      discordClient: {
+        createAuthorizationUrl: vi.fn().mockReturnValue({
+          authorizationUrl: 'https://discord.com/oauth2/authorize?client_id=test-client&state=signed-state',
+          state: 'signed-state',
+        }),
+        validateState: vi.fn(),
+        exchangeCode: vi.fn(),
+        getCurrentUser: vi.fn(),
+      },
+      persistence: {
+        upsertDiscordIntegration: vi.fn(),
+      },
+    });
+
+    const result = await service.getAuthorizationUrl({
+      userId: 'user-id-1',
+      requestId: 'req-1',
+    });
+
+    expect(result).toMatchObject({
+      authorizationUrl: 'https://discord.com/oauth2/authorize?client_id=test-client&state=signed-state',
+    });
+    expect(stdoutWriteSpy).toHaveBeenCalled();
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"event":"integration_discord_oauth_started"');
+    expect(stdoutWriteSpy.mock.calls[0]?.[0]).toContain('"requestId":"req-1"');
+    stdoutWriteSpy.mockRestore();
+  });
+
+  it('persiste integracao DISCORD no callback bem-sucedido', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const persistence = {
+      upsertDiscordIntegration: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const service = createDiscordOAuthService({
+      discordClient: {
+        createAuthorizationUrl: vi.fn(),
+        validateState: vi.fn().mockReturnValue({
+          userId: 'user-id-1',
+          issuedAt: Date.now(),
+        }),
+        exchangeCode: vi.fn().mockResolvedValue({
+          accessToken: 'discord-access-token',
+          refreshToken: 'discord-refresh-token',
+          expiresIn: 3600,
+          scope: 'identify',
+          tokenType: 'Bearer',
+        }),
+        getCurrentUser: vi.fn().mockResolvedValue({
+          id: 'discord-user-id',
+          username: 'clutchdiscord',
+          globalName: 'Clutch Discord',
+          avatarUrl: 'https://cdn.discordapp.com/avatar.png',
+        }),
+      },
+      persistence,
+    });
+
+    const result = await service.completeCallback({
+      code: 'oauth-code',
+      state: 'signed-state',
+      requestId: 'req-1',
+    });
+
+    expect(result).toMatchObject({
+      platform: 'DISCORD',
+      externalId: 'discord-user-id',
+      username: 'clutchdiscord',
+    });
+    expect(persistence.upsertDiscordIntegration).toHaveBeenCalledWith(
+      'user-id-1',
+      expect.objectContaining({
+        externalId: 'discord-user-id',
+        accessToken: 'discord-access-token',
+        refreshToken: 'discord-refresh-token',
+        metadata: expect.objectContaining({
+          username: 'clutchdiscord',
+          globalName: 'Clutch Discord',
+          tokenType: 'Bearer',
+          scope: 'identify',
+        }),
+      }),
+    );
+    expect(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('\n')).toContain('"event":"integration_discord_link_succeeded"');
+    expect(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain('oauth-code');
+    expect(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain('discord-access-token');
+    expect(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain('discord-refresh-token');
+    stdoutWriteSpy.mockRestore();
+  });
+
+  it('traduz falha do provedor e registra erro seguro no callback', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const service = createDiscordOAuthService({
+      discordClient: {
+        createAuthorizationUrl: vi.fn(),
+        validateState: vi.fn().mockReturnValue({
+          userId: 'user-id-1',
+          issuedAt: Date.now(),
+        }),
+        exchangeCode: vi.fn().mockRejectedValue(
+          createIntegrationError(
+            'discord',
+            400,
+            'invalid_request',
+            'Autorização Discord inválida ou expirada.',
+          ),
+        ),
+        getCurrentUser: vi.fn(),
+      },
+      persistence: {
+        upsertDiscordIntegration: vi.fn(),
+      },
+    });
+
+    await expect(service.completeCallback({
+      code: 'oauth-code',
+      state: 'signed-state',
+      requestId: 'req-1',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+    });
+
+    expect(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('\n')).toContain('"event":"integration_discord_oauth_failed"');
+    expect(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('\n')).toContain('"requestId":"req-1"');
+    expect(stdoutWriteSpy.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain('oauth-code');
+    stdoutWriteSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Resumo
Implementa o fluxo real de Discord OAuth no backend com rotas de início e callback, isolamento da lógica em service/client dedicados e persistência segura da integração `DISCORD`.
A PR torna o contrato do backend suficiente para o frontend consumir o OAuth de forma real, sem depender de endpoints imaginários ou callback não sustentado pelo runtime atual.

## O que foi alterado
- Adiciona client de integração Discord para montar a URL de autorização, validar `state`, trocar `code` por token e buscar a identidade mínima do usuário.
- Adiciona service dedicado para orquestrar o fluxo OAuth, persistir `PlatformIntegration(DISCORD)` e emitir logs estruturados seguros.
- Expõe as rotas `GET /integrations/discord/auth` e `GET /integrations/discord/callback` com handlers finos.
- Atualiza o wiring do Fastify para registrar o novo decorator do service de Discord OAuth.
- Ajusta `.env.example` para declarar explicitamente `DISCORD_REDIRECT_URI` e o papel opcional do `DISCORD_BOT_TOKEN` no fluxo atual.
- Amplia os testes unitários e de integração para sucesso, callback inválido, falha do provedor e configuração ausente.

## Motivação
A integração Discord ainda estava ausente no backend, o que mantinha o frontend bloqueado por um contrato inexistente. A mudança fecha essa lacuna com um fluxo OAuth real, seguro e consistente com o padrão já adotado nas demais integrações endurecidas.

## Como validar
- `cd backend`
- `npm run test -- tests/unit/services/discord-oauth.service.test.ts tests/integration/routes/integrations.routes.test.ts tests/unit/services/integrations.service.test.ts`
- `npm run typecheck`
- `npm run lint`
- `cd ..`
- `docker compose up -d --build`
- `docker compose exec -T backend sh ./scripts/container-bootstrap.sh`
- Validar operacionalmente:
  - `GET /integrations/discord/auth` autenticada retorna `200` com `authorizationUrl`
  - `GET /integrations/discord/callback` com cenário simulado de sucesso retorna `200` e persiste `PlatformIntegration(DISCORD)`
  - `GET /integrations/discord/callback` com falha simulada do provedor retorna erro coerente sem detalhes internos

## Riscos e impactos
- O callback do backend responde JSON; o tratamento de UX e navegação fica para a issue do frontend (`#98`).
- A validação operacional do sucesso do callback usa client mockado no container para evitar dependência do provedor externo durante o teste local.
- `npm run lint` do backend continua exibindo warnings preexistentes em `src/config/rate-limit.ts`, fora do escopo desta PR.
- Não há breaking change no restante do backend; o impacto é a adição do contrato real de Discord OAuth.

## Evidências
- Testes focados do backend: `36 passed`
- `GET /integrations/discord/auth` autenticada no backend containerizado: `200`
- `GET /integrations/discord/callback` com success path simulado: `200`
- Persistência `PlatformIntegration(DISCORD)` confirmada no Postgres: `true`
- `GET /integrations/discord/callback` com erro simulado do provedor: `400`
- Inspeção de logs sem ocorrência de `Authorization`, `Bearer `, `oauth-code`, token de acesso, refresh token ou secret do Discord

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #53
