### PR TITLE
feat(frontend): implemente Discord OAuth e vinculacao

### DIFF
--- a/frontend/src/app/(app)/settings/integrations/discord/callback/page.tsx
+++ b/frontend/src/app/(app)/settings/integrations/discord/callback/page.tsx
@@ -1,0 +1,32 @@
+import { DiscordOAuthCallbackContent } from '@/components/settings/discord-oauth-callback-content';
+
+type CallbackPageSearchParams = Record<string, string | string[] | undefined>;
+
+type DiscordCallbackPageProps = {
+  searchParams: Promise<CallbackPageSearchParams>;
+};
+
+function getQueryValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return typeof value[0] === 'string' ? value[0] : undefined;
+  }
+
+  return typeof value === 'string' ? value : undefined;
+}
+
+export default async function DiscordIntegrationCallbackPage({
+  searchParams,
+}: DiscordCallbackPageProps) {
+  const resolvedSearchParams = await searchParams;
+
+  return (
+    <DiscordOAuthCallbackContent
+      searchParams={{
+        code: getQueryValue(resolvedSearchParams.code),
+        state: getQueryValue(resolvedSearchParams.state),
+        error: getQueryValue(resolvedSearchParams.error),
+        errorDescription: getQueryValue(resolvedSearchParams.error_description),
+      }}
+    />
+  );
+}

--- a/frontend/src/components/settings/discord-integration-card.tsx
+++ b/frontend/src/components/settings/discord-integration-card.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  IntegrationsRequestError,
+  startDiscordOAuth,
+} from '@/services/integrations';
+
+type DiscordIntegrationCardProps = {
+  isConnected: boolean;
+  linkedAccountLabel: string | null;
+  onRedirect?: (authorizationUrl: string) => void;
+};
+
+export function DiscordIntegrationCard({
+  isConnected,
+  linkedAccountLabel,
+  onRedirect,
+}: DiscordIntegrationCardProps) {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const discordMutation = useMutation({
+    mutationFn: startDiscordOAuth,
+    onSuccess: (response) => {
+      setErrorMessage(null);
+      if (onRedirect) {
+        onRedirect(response.authorizationUrl);
+        return;
+      }
+
+      window.location.assign(response.authorizationUrl);
+    },
+    onError: (error) => {
+      setErrorMessage(
+        error instanceof IntegrationsRequestError
+          ? error.message
+          : 'Nao foi possivel iniciar a conexao com o Discord agora.',
+      );
+    },
+  });
+
+  return (
+    <Card className="space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Discord</p>
+          <h2 className="font-display text-2xl font-semibold text-primary">
+            Vinculo OAuth do Discord
+          </h2>
+          <p className="text-sm leading-6 text-secondary">
+            Inicia o fluxo OAuth real pelo backend e conclui a vinculacao no retorno do provedor.
+          </p>
+        </div>
+        <Badge tone={isConnected ? 'success' : 'neutral'}>
+          {isConnected ? 'Conectado' : 'Nao conectado'}
+        </Badge>
+      </div>
+
+      <p className="text-sm text-secondary">
+        {isConnected
+          ? `Conta vinculada: ${linkedAccountLabel ?? 'Discord conectado.'}`
+          : 'Ainda nao ha integracao Discord ativa neste perfil.'}
+      </p>
+
+      {errorMessage ? (
+        <div className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          disabled={discordMutation.isPending}
+          onClick={() => {
+            discordMutation.mutate();
+          }}
+        >
+          {discordMutation.isPending
+            ? 'Abrindo Discord...'
+            : isConnected
+              ? 'Reconectar Discord'
+              : 'Conectar Discord'}
+        </Button>
+      </div>
+
+      <p className="text-xs leading-5 text-secondary">
+        O frontend conclui o callback em rota dedicada do App Router. Se o backend Discord nao estiver configurado no runtime atual, a UI exibe indisponibilidade sem expor detalhes internos.
+      </p>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/discord-oauth-callback-content.tsx
+++ b/frontend/src/components/settings/discord-oauth-callback-content.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils/cn';
+import {
+  completeDiscordOAuth,
+  IntegrationsRequestError,
+} from '@/services/integrations';
+
+type DiscordOAuthCallbackSearchParams = {
+  code?: string;
+  state?: string;
+  error?: string;
+  errorDescription?: string;
+};
+
+type CallbackState =
+  | { status: 'loading' }
+  | { status: 'success'; message: string; username: string; globalName: string | null }
+  | { status: 'error'; message: string };
+
+type DiscordOAuthCallbackContentProps = {
+  searchParams: DiscordOAuthCallbackSearchParams;
+};
+
+function hasValidCallbackParams(searchParams: DiscordOAuthCallbackSearchParams): boolean {
+  return Boolean(searchParams.error) || (Boolean(searchParams.code) && Boolean(searchParams.state));
+}
+
+export function DiscordOAuthCallbackContent({
+  searchParams,
+}: DiscordOAuthCallbackContentProps) {
+  const queryClient = useQueryClient();
+  const [callbackState, setCallbackState] = useState<CallbackState>({ status: 'loading' });
+  const hasStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasStartedRef.current) {
+      return;
+    }
+
+    hasStartedRef.current = true;
+
+    if (!hasValidCallbackParams(searchParams)) {
+      setCallbackState({
+        status: 'error',
+        message: 'Callback Discord inválido.',
+      });
+      return;
+    }
+
+    void completeDiscordOAuth(searchParams)
+      .then((response) => {
+        void queryClient.invalidateQueries({ queryKey: ['profile'] });
+        setCallbackState({
+          status: 'success',
+          message: response.message,
+          username: response.username,
+          globalName: response.globalName,
+        });
+      })
+      .catch((error) => {
+        setCallbackState({
+          status: 'error',
+          message:
+            error instanceof IntegrationsRequestError
+              ? error.message
+              : 'Nao foi possivel concluir a conexao com o Discord agora.',
+        });
+      });
+  }, [queryClient, searchParams]);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <Card className="space-y-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">Discord</p>
+            <h1 className="font-display text-3xl font-semibold text-primary">
+              Callback de vinculacao
+            </h1>
+            <p className="text-sm leading-6 text-secondary">
+              Esta tela conclui o fluxo OAuth do Discord usando apenas as rotas reais expostas pelo backend.
+            </p>
+          </div>
+          <Badge
+            tone={
+              callbackState.status === 'success'
+                ? 'success'
+                : callbackState.status === 'error'
+                  ? 'warning'
+                  : 'accent'
+            }
+          >
+            {callbackState.status === 'success'
+              ? 'Concluido'
+              : callbackState.status === 'error'
+                ? 'Falhou'
+                : 'Processando'}
+          </Badge>
+        </div>
+
+        {callbackState.status === 'loading' ? (
+          <div className="space-y-3" data-testid="discord-callback-loading">
+            <div className="h-4 w-48 animate-pulse rounded-control bg-background-tertiary" />
+            <div className="h-12 animate-pulse rounded-control bg-background-tertiary" />
+          </div>
+        ) : null}
+
+        {callbackState.status === 'success' ? (
+          <div className="space-y-4" data-testid="discord-callback-success">
+            <div className="rounded-control border border-status-online/40 bg-[rgba(16,185,129,0.12)] px-control-x py-control-y text-sm text-primary">
+              {callbackState.message}
+            </div>
+            <p className="text-sm text-secondary">
+              Conta vinculada: {callbackState.globalName ?? callbackState.username}
+            </p>
+          </div>
+        ) : null}
+
+        {callbackState.status === 'error' ? (
+          <div className="space-y-4" data-testid="discord-callback-error">
+            <div className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
+              {callbackState.message}
+            </div>
+            <p className="text-sm text-secondary">
+              Revise a configuracao do Discord ou tente iniciar a vinculacao novamente em Integracoes.
+            </p>
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/settings/integrations"
+            className={cn(
+              'inline-flex h-11 items-center justify-center gap-2 rounded-control border border-transparent bg-accent-purple px-control-x text-sm font-medium text-white transition hover:brightness-110',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary',
+            )}
+          >
+            Voltar para integracoes
+          </Link>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/integrations-page-content.tsx
+++ b/frontend/src/components/settings/integrations-page-content.tsx
@@ -1,15 +1,32 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { DiscordIntegrationCard } from '@/components/settings/discord-integration-card';
 import { EpicIntegrationCard } from '@/components/settings/epic-integration-card';
 import { IgdbSearchCard } from '@/components/settings/igdb-search-card';
 import { SettingsNav } from '@/components/settings/settings-nav';
 import { SteamIntegrationCard } from '@/components/settings/steam-integration-card';
-import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { useAuth } from '@/hooks/use-auth';
 import { fetchProfileByUsername, ProfileRequestError } from '@/services/profile';
+
+function resolveDiscordLinkedAccountLabel(metadata: Record<string, unknown> | null): string | null {
+  if (!metadata) {
+    return null;
+  }
+
+  const globalName =
+    typeof metadata.globalName === 'string' && metadata.globalName.length > 0
+      ? metadata.globalName
+      : null;
+  const username =
+    typeof metadata.username === 'string' && metadata.username.length > 0
+      ? metadata.username
+      : null;
+
+  return globalName ?? username;
+}
 
 function IntegrationsLoadingState() {
   return (
@@ -67,13 +84,19 @@ export function IntegrationsPageContent() {
   const connectedPlatforms = new Set(
     profileQuery.data.platformIntegrations.map((integration) => integration.platform),
   );
+  const discordIntegration =
+    profileQuery.data.platformIntegrations.find((integration) => integration.platform === 'DISCORD') ??
+    null;
+  const discordLinkedAccountLabel = resolveDiscordLinkedAccountLabel(
+    discordIntegration?.metadata ?? null,
+  );
 
   return (
     <div className="space-y-section" data-testid="settings-integrations-success">
       <SectionHeading
         eyebrow="Settings"
         title="Integracoes de plataformas"
-        description="Cards conectados apenas aos contratos reais de Steam, Epic e busca IGDB."
+        description="Cards conectados apenas aos contratos reais de Steam, Epic, Discord e busca IGDB."
         level="h1"
       />
 
@@ -95,24 +118,14 @@ export function IntegrationsPageContent() {
             await profileQuery.refetch();
           }}
         />
+
+        <DiscordIntegrationCard
+          isConnected={connectedPlatforms.has('DISCORD')}
+          linkedAccountLabel={discordLinkedAccountLabel}
+        />
       </div>
 
       <IgdbSearchCard />
-
-      <Card className="space-y-4" tone="neutral">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-[0.35em] text-secondary">Discord</p>
-            <h2 className="font-display text-2xl font-semibold text-primary">
-              Ainda fora do contrato frontend atual
-            </h2>
-            <p className="text-sm leading-6 text-secondary">
-              A issue original menciona Discord, mas o backend atual nao expoe rota de connect para essa integracao.
-            </p>
-          </div>
-          <Badge tone="warning">Limitacao real</Badge>
-        </div>
-      </Card>
     </div>
   );
 }

--- a/frontend/src/components/settings/settings-nav.tsx
+++ b/frontend/src/components/settings/settings-nav.tsx
@@ -15,7 +15,7 @@ const navItems = [
   {
     href: '/settings/integrations',
     label: 'Integracoes',
-    description: 'Steam, Epic e busca IGDB.',
+    description: 'Steam, Epic, Discord e busca IGDB.',
   },
 ] as const;
 

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -41,6 +41,8 @@ export {
   postLikeNotificationPayloadSchema,
 } from './notifications';
 export {
+  discordOAuthCallbackResponseSchema,
+  discordOAuthStartResponseSchema,
   epicConnectRequestSchema,
   epicConnectResponseSchema,
   igdbSearchRequestSchema,

--- a/frontend/src/schemas/integrations.ts
+++ b/frontend/src/schemas/integrations.ts
@@ -23,6 +23,18 @@ export const epicConnectResponseSchema = z.object({
   imported: z.number().int().min(0),
 });
 
+export const discordOAuthStartResponseSchema = z.object({
+  authorizationUrl: z.string().url(),
+});
+
+export const discordOAuthCallbackResponseSchema = z.object({
+  message: z.string().min(1),
+  platform: z.literal('DISCORD'),
+  externalId: z.string().min(1),
+  username: z.string().min(1),
+  globalName: z.string().nullable(),
+});
+
 export const igdbSearchRequestSchema = z.object({
   q: z
     .string()
@@ -43,5 +55,7 @@ export type SteamConnectResponse = z.infer<typeof steamConnectResponseSchema>;
 export type SteamSyncResponse = z.infer<typeof steamSyncResponseSchema>;
 export type EpicConnectValues = z.infer<typeof epicConnectRequestSchema>;
 export type EpicConnectResponse = z.infer<typeof epicConnectResponseSchema>;
+export type DiscordOAuthStartResponse = z.infer<typeof discordOAuthStartResponseSchema>;
+export type DiscordOAuthCallbackResponse = z.infer<typeof discordOAuthCallbackResponseSchema>;
 export type IgdbSearchValues = z.infer<typeof igdbSearchRequestSchema>;
 export type IgdbSearchResponse = z.infer<typeof igdbSearchResponseSchema>;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -25,10 +25,12 @@ export {
   NotificationsRequestError,
 } from './notifications';
 export {
+  completeDiscordOAuth,
   connectEpic,
   connectSteam,
   IntegrationsRequestError,
   searchIgdbGame,
+  startDiscordOAuth,
   syncSteamLibrary,
 } from './integrations';
 export {

--- a/frontend/src/services/integrations.ts
+++ b/frontend/src/services/integrations.ts
@@ -1,5 +1,7 @@
 import { apiRequest } from '@/lib/api';
 import {
+  discordOAuthCallbackResponseSchema,
+  discordOAuthStartResponseSchema,
   epicConnectRequestSchema,
   epicConnectResponseSchema,
   igdbSearchRequestSchema,
@@ -7,6 +9,8 @@ import {
   steamConnectRequestSchema,
   steamConnectResponseSchema,
   steamSyncResponseSchema,
+  type DiscordOAuthCallbackResponse,
+  type DiscordOAuthStartResponse,
   type EpicConnectResponse,
   type EpicConnectValues,
   type IgdbSearchResponse,
@@ -17,6 +21,13 @@ import {
 
 type ErrorResponse = {
   message?: string;
+};
+
+type DiscordOAuthCallbackInput = {
+  code?: string;
+  state?: string;
+  error?: string;
+  errorDescription?: string;
 };
 
 export class IntegrationsRequestError extends Error {
@@ -109,6 +120,58 @@ export async function connectEpic(
   }
 
   return epicConnectResponseSchema.parse(responsePayload);
+}
+
+export async function startDiscordOAuth(): Promise<DiscordOAuthStartResponse> {
+  const response = await apiRequest('/integrations/discord/auth', {
+    method: 'GET',
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel iniciar a conexao com o Discord agora.'),
+    );
+  }
+
+  return discordOAuthStartResponseSchema.parse(responsePayload);
+}
+
+export async function completeDiscordOAuth(
+  input: DiscordOAuthCallbackInput,
+): Promise<DiscordOAuthCallbackResponse> {
+  const query = new URLSearchParams();
+
+  if (typeof input.code === 'string' && input.code.length > 0) {
+    query.set('code', input.code);
+  }
+
+  if (typeof input.state === 'string' && input.state.length > 0) {
+    query.set('state', input.state);
+  }
+
+  if (typeof input.error === 'string' && input.error.length > 0) {
+    query.set('error', input.error);
+  }
+
+  if (typeof input.errorDescription === 'string' && input.errorDescription.length > 0) {
+    query.set('error_description', input.errorDescription);
+  }
+
+  const response = await apiRequest(`/integrations/discord/callback?${query.toString()}`, {
+    method: 'GET',
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel concluir a conexao com o Discord agora.'),
+    );
+  }
+
+  return discordOAuthCallbackResponseSchema.parse(responsePayload);
 }
 
 export async function searchIgdbGame(query: string): Promise<IgdbSearchResponse> {

--- a/frontend/tests/unit/components/discord-integration-card.test.tsx
+++ b/frontend/tests/unit/components/discord-integration-card.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DiscordIntegrationCard } from '@/components/settings/discord-integration-card';
+import {
+  IntegrationsRequestError,
+  startDiscordOAuth,
+} from '@/services/integrations';
+
+vi.mock('@/services/integrations', () => ({
+  startDiscordOAuth: vi.fn(),
+  IntegrationsRequestError: class IntegrationsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'IntegrationsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedStartDiscordOAuth = vi.mocked(startDiscordOAuth);
+
+function renderDiscordIntegrationCard(props?: {
+  isConnected?: boolean;
+  linkedAccountLabel?: string | null;
+  onRedirect?: (authorizationUrl: string) => void;
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DiscordIntegrationCard
+        isConnected={props?.isConnected ?? false}
+        linkedAccountLabel={props?.linkedAccountLabel ?? null}
+        onRedirect={props?.onRedirect}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('DiscordIntegrationCard', () => {
+  beforeEach(() => {
+    mockedStartDiscordOAuth.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('starts the discord oauth flow and redirects to the provider url', async () => {
+    const onRedirect = vi.fn();
+
+    mockedStartDiscordOAuth.mockResolvedValue({
+      authorizationUrl: 'https://discord.com/oauth2/authorize?client_id=123',
+    });
+
+    renderDiscordIntegrationCard({ onRedirect });
+
+    fireEvent.click(screen.getByRole('button', { name: /conectar discord/i }));
+
+    await waitFor(() => {
+      expect(mockedStartDiscordOAuth).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onRedirect).toHaveBeenCalledWith(
+      'https://discord.com/oauth2/authorize?client_id=123',
+    );
+  });
+
+  it('shows a safe error message when oauth start fails', async () => {
+    mockedStartDiscordOAuth.mockRejectedValue(
+      new Error('Nao foi possivel iniciar a conexao com o Discord agora.'),
+    );
+
+    renderDiscordIntegrationCard();
+
+    fireEvent.click(screen.getByRole('button', { name: /conectar discord/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/nao foi possivel iniciar a conexao com o discord agora/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows a coherent unavailable message when backend discord is not configured', async () => {
+    mockedStartDiscordOAuth.mockRejectedValue(
+      new IntegrationsRequestError(
+        503,
+        'Integração Discord indisponível no runtime atual.',
+      ),
+    );
+
+    renderDiscordIntegrationCard();
+
+    fireEvent.click(screen.getByRole('button', { name: /conectar discord/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/integração discord indisponível no runtime atual/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/unit/components/discord-oauth-callback-content.test.tsx
+++ b/frontend/tests/unit/components/discord-oauth-callback-content.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DiscordOAuthCallbackContent } from '@/components/settings/discord-oauth-callback-content';
+import { completeDiscordOAuth } from '@/services/integrations';
+
+vi.mock('@/services/integrations', () => ({
+  completeDiscordOAuth: vi.fn(),
+  IntegrationsRequestError: class IntegrationsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'IntegrationsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedCompleteDiscordOAuth = vi.mocked(completeDiscordOAuth);
+
+function renderCallbackContent(searchParams: {
+  code?: string;
+  state?: string;
+  error?: string;
+  errorDescription?: string;
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DiscordOAuthCallbackContent searchParams={searchParams} />
+    </QueryClientProvider>,
+  );
+
+  return { invalidateQueriesSpy };
+}
+
+describe('DiscordOAuthCallbackContent', () => {
+  beforeEach(() => {
+    mockedCompleteDiscordOAuth.mockReset();
+  });
+
+  it('fails fast when callback params are invalid', async () => {
+    renderCallbackContent({});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discord-callback-error')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Callback Discord inválido.')).toBeInTheDocument();
+    expect(mockedCompleteDiscordOAuth).not.toHaveBeenCalled();
+  });
+
+  it('completes the discord callback and invalidates cached profiles', async () => {
+    mockedCompleteDiscordOAuth.mockResolvedValue({
+      message: 'Discord conectado com sucesso.',
+      platform: 'DISCORD',
+      externalId: 'discord-user-1',
+      username: 'clutchplayer',
+      globalName: 'CLUTCH Player',
+    });
+
+    const { invalidateQueriesSpy } = renderCallbackContent({
+      code: 'oauth-code',
+      state: 'signed-state',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discord-callback-success')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/discord conectado com sucesso/i)).toBeInTheDocument();
+    expect(screen.getByText(/clutch player/i)).toBeInTheDocument();
+    expect(mockedCompleteDiscordOAuth).toHaveBeenCalledWith({
+      code: 'oauth-code',
+      state: 'signed-state',
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('shows a safe error message when the provider callback fails', async () => {
+    mockedCompleteDiscordOAuth.mockRejectedValue(
+      new Error('Nao foi possivel concluir a conexao com o Discord agora.'),
+    );
+
+    renderCallbackContent({
+      error: 'access_denied',
+      errorDescription: 'User denied access',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discord-callback-error')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/nao foi possivel concluir a conexao com o discord agora/i),
+    ).toBeInTheDocument();
+  });
+
+  it('does not re-run the callback request on rerender with the same params', async () => {
+    mockedCompleteDiscordOAuth.mockResolvedValue({
+      message: 'Discord conectado com sucesso.',
+      platform: 'DISCORD',
+      externalId: 'discord-user-1',
+      username: 'clutchplayer',
+      globalName: 'CLUTCH Player',
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <DiscordOAuthCallbackContent
+          searchParams={{ code: 'oauth-code', state: 'signed-state' }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discord-callback-success')).toBeInTheDocument();
+    });
+
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <DiscordOAuthCallbackContent
+          searchParams={{ code: 'oauth-code', state: 'signed-state' }}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(mockedCompleteDiscordOAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -49,7 +49,7 @@ describe('IntegrationsPageContent', () => {
     mockedFetchProfileByUsername.mockReset();
   });
 
-  it('renders integrations status and contract limitation', async () => {
+  it('renders integrations status including discord oauth state', async () => {
     mockedUseAuth.mockReturnValue({
       status: 'authenticated',
       user: {
@@ -88,6 +88,13 @@ describe('IntegrationsPageContent', () => {
       platformIntegrations: [
         { platform: 'STEAM', metadata: null },
         { platform: 'EPIC', metadata: null },
+        {
+          platform: 'DISCORD',
+          metadata: {
+            username: 'clutchplayer',
+            globalName: 'CLUTCH Guild',
+          },
+        },
       ],
       gameLibrary: [
         {
@@ -109,6 +116,8 @@ describe('IntegrationsPageContent', () => {
     expect(screen.getByText(/biblioteca steam/i)).toBeInTheDocument();
     expect(screen.getByText(/biblioteca epic games/i)).toBeInTheDocument();
     expect(screen.getByText(/^discord$/i)).toBeInTheDocument();
-    expect(screen.getByText(/ainda fora do contrato frontend atual/i)).toBeInTheDocument();
+    expect(screen.getByText(/vinculo oauth do discord/i)).toBeInTheDocument();
+    expect(screen.getByText(/conta vinculada: clutch guild/i)).toBeInTheDocument();
+    expect(screen.queryByText(/ainda fora do contrato frontend atual/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/services/integrations.test.ts
+++ b/frontend/tests/unit/services/integrations.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiRequest } from '@/lib/api';
 import {
+  completeDiscordOAuth,
   connectEpic,
   connectSteam,
   searchIgdbGame,
+  startDiscordOAuth,
   syncSteamLibrary,
 } from '@/services/integrations';
 
@@ -75,6 +77,53 @@ describe('integrations service', () => {
       method: 'POST',
       body: { authToken: 'valid-token' },
     });
+  });
+
+  it('starts discord oauth with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          authorizationUrl: 'https://discord.com/oauth2/authorize?client_id=123',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await startDiscordOAuth();
+
+    expect(response.authorizationUrl).toBe(
+      'https://discord.com/oauth2/authorize?client_id=123',
+    );
+    expect(mockedApiRequest).toHaveBeenCalledWith('/integrations/discord/auth', {
+      method: 'GET',
+    });
+  });
+
+  it('completes discord oauth with callback query params', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: 'Discord conectado com sucesso.',
+          platform: 'DISCORD',
+          externalId: 'discord-user-1',
+          username: 'clutchplayer',
+          globalName: 'CLUTCH Player',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await completeDiscordOAuth({
+      code: 'oauth-code',
+      state: 'signed-state',
+      errorDescription: 'User denied access',
+    });
+
+    expect(response.platform).toBe('DISCORD');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/integrations/discord/callback?code=oauth-code&state=signed-state&error_description=User+denied+access',
+      { method: 'GET' },
+    );
   });
 
   it('searches the igdb endpoint with the real contract', async () => {


### PR DESCRIPTION
﻿## Resumo
Implementa o consumo real do Discord OAuth no frontend, alinhado ao contrato j? exposto pelo backend. A mudan?a adiciona a superf?cie de conex?o, o callback no App Router e o tratamento expl?cito de sucesso, falha e indisponibilidade sem depender de payloads inexistentes.

## O que foi alterado
- Adiciona schemas e services para iniciar e concluir o Discord OAuth usando apenas os endpoints reais do backend.
- Substitui a limita??o est?tica da tela de integra??es por um card funcional de Discord com estado conectado e feedback seguro.
- Adiciona a rota `/settings/integrations/discord/callback` no App Router para concluir o fluxo e exibir loading, sucesso e falha.
- Invalida o cache de perfil ap?s sucesso do callback para refletir a vincula??o sem depender apenas do `staleTime`.
- Amplia os testes unit?rios para cobrir in?cio do OAuth, callback inv?lido, sucesso, falha e backend indispon?vel.

## Motiva??o
O frontend ainda tratava Discord como limita??o conhecida mesmo ap?s o backend passar a expor um fluxo OAuth real. Esta mudan?a fecha essa lacuna sem inventar contratos, mantendo o comportamento consistente com o estado atual do reposit?rio.

## Como validar
- `cd frontend`
- `npm run test -- tests/unit/services/integrations.test.ts tests/unit/components/discord-integration-card.test.tsx tests/unit/components/discord-oauth-callback-content.test.tsx tests/unit/components/integrations-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `cd ..`
- Validar operacionalmente com o stack local:
  - `POST /api/auth/login` retorna `200`
  - `GET /settings/integrations` autenticado retorna `200`
  - `GET /settings/integrations/discord/callback?error=access_denied&error_description=User%20denied%20access` retorna `200` e renderiza a tela de callback
  - `GET /api/integrations/discord/callback?error=access_denied&error_description=User%20denied%20access` retorna erro coerente do backend
- Observa??o: o caminho feliz com o provedor real depende de `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET` e `DISCORD_REDIRECT_URI` configurados no runtime do backend. No compose local atual, a PR valida explicitamente o comportamento seguro de indisponibilidade e callback com erro do provedor, n?o um OAuth real com credenciais v?lidas.

## Riscos e impactos
- A PR depende do contrato do backend j? entregue na `#53`, mas a branch foi rebaseada sobre `develop`, ent?o o diff fica restrito ao frontend.
- Sem a configura??o real do Discord no backend, o usu?rio ver? indisponibilidade coerente e segura ao iniciar o OAuth. Isso ? intencional e evita expectativa errada de happy path local.
- N?o h? mudan?a de contrato HTTP no frontend; o impacto ? a ativa??o da integra??o Discord no fluxo de settings.

## Evid?ncias
- Testes focados do frontend: `14 passed`
- `npm run typecheck` e `npm run lint` passaram
- Valida??o operacional local:
  - `POST /api/auth/login` ? `200`
  - `GET /settings/integrations` autenticado ? `200`
  - `GET /settings/integrations/discord/callback?error=access_denied...` ? `200`
  - `GET /api/integrations/discord/callback?error=access_denied...` ? `400` com mensagem coerente
- N?o h? evid?ncias de vazamento de `code`, token, cookie ou query string completa do callback na superf?cie nova do frontend.

## Checklist
- [x] Altera??o limitada ao objetivo da PR
- [x] Sem mudan?as desconexas
- [x] Impactos principais descritos
- [x] Valida??o documentada
- [x] Riscos identificados

Closes #98
