### PR TITLE
feat(frontend): implemente a biblioteca de jogos do usuario

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -23,6 +23,7 @@ export const config = {
     '/login',
     '/register',
     '/:username',
+    '/:username/:path*',
     '/feed/:path*',
     '/notifications/:path*',
     '/settings/:path*',

--- a/frontend/src/app/(app)/[username]/library/page.tsx
+++ b/frontend/src/app/(app)/[username]/library/page.tsx
@@ -1,0 +1,13 @@
+import { LibraryPageContent } from '@/components/library/library-page-content';
+
+type LibraryPageProps = {
+  params: Promise<{
+    username: string;
+  }>;
+};
+
+export default async function LibraryPage({ params }: LibraryPageProps) {
+  const { username } = await params;
+
+  return <LibraryPageContent username={username} />;
+}

--- a/frontend/src/components/library/game-card.tsx
+++ b/frontend/src/components/library/game-card.tsx
@@ -1,0 +1,80 @@
+import Image from 'next/image';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+
+export type LibraryGameRecord = {
+  gameName: string;
+  coverUrl: string | null;
+  platform: string;
+  hoursPlayed: number | null;
+  lastPlayedAt: string | null;
+};
+
+type GameCardProps = {
+  game: LibraryGameRecord;
+};
+
+function formatHoursPlayed(hoursPlayed: number | null): string {
+  if (typeof hoursPlayed !== 'number' || !Number.isFinite(hoursPlayed)) {
+    return 'Horas indisponiveis';
+  }
+
+  const roundedHours = Math.max(0, Math.round(hoursPlayed));
+
+  return `${roundedHours}h jogadas`;
+}
+
+function formatLastPlayedAt(lastPlayedAt: string | null): string {
+  if (!lastPlayedAt) {
+    return 'Sem atividade recente';
+  }
+
+  const parsedDate = new Date(lastPlayedAt);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return 'Sem atividade recente';
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(parsedDate);
+}
+
+export function GameCard({ game }: GameCardProps) {
+  return (
+    <Card className="overflow-hidden p-0" data-testid="library-game-card">
+      <div className="relative h-40 w-full border-b border-border bg-background-tertiary">
+        {game.coverUrl ? (
+          <Image
+            src={game.coverUrl}
+            alt={game.gameName}
+            fill
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-background-secondary text-xs uppercase tracking-[0.35em] text-secondary">
+            Sem capa
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3 p-card">
+        <div className="space-y-2">
+          <div className="flex items-start justify-between gap-3">
+            <h3 className="line-clamp-2 font-display text-xl font-semibold text-primary">
+              {game.gameName}
+            </h3>
+            <Badge tone="neutral">{game.platform}</Badge>
+          </div>
+          <p className="text-sm text-secondary">{formatHoursPlayed(game.hoursPlayed)}</p>
+        </div>
+
+        <p className="text-xs uppercase tracking-[0.24em] text-secondary">
+          Ultima atividade: {formatLastPlayedAt(game.lastPlayedAt)}
+        </p>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/library/library-filters.tsx
+++ b/frontend/src/components/library/library-filters.tsx
@@ -1,0 +1,76 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils/cn';
+
+export type LibrarySortOption = 'most-played' | 'recent' | 'alphabetical';
+
+type LibraryFiltersProps = {
+  platforms: string[];
+  selectedPlatform: string;
+  selectedSort: LibrarySortOption;
+  onPlatformChange: (platform: string) => void;
+  onSortChange: (sort: LibrarySortOption) => void;
+};
+
+const sortOptions: Array<{ value: LibrarySortOption; label: string }> = [
+  { value: 'most-played', label: 'Mais jogados' },
+  { value: 'recent', label: 'Mais recentes' },
+  { value: 'alphabetical', label: 'Alfabetica' },
+];
+
+export function LibraryFilters({
+  platforms,
+  selectedPlatform,
+  selectedSort,
+  onPlatformChange,
+  onSortChange,
+}: LibraryFiltersProps) {
+  return (
+    <Card className="space-y-4">
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Filtros</p>
+        <div className="flex flex-wrap gap-2">
+          {platforms.map((platform) => {
+            const isActive = selectedPlatform === platform;
+
+            return (
+              <button
+                key={platform}
+                type="button"
+                className={cn(
+                  'inline-flex items-center rounded-pill border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.24em] transition',
+                  isActive
+                    ? 'border-accent-cyan/40 bg-[rgba(6,182,212,0.1)] text-primary'
+                    : 'border-border bg-background-secondary text-secondary hover:text-primary',
+                )}
+                onClick={() => {
+                  onPlatformChange(platform);
+                }}
+              >
+                {platform === 'ALL' ? 'Todas' : platform}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge tone="accent">Ordenacao</Badge>
+        {sortOptions.map((option) => (
+          <Button
+            key={option.value}
+            type="button"
+            size="sm"
+            variant={selectedSort === option.value ? 'primary' : 'secondary'}
+            onClick={() => {
+              onSortChange(option.value);
+            }}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/library/library-page-content.tsx
+++ b/frontend/src/components/library/library-page-content.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { GameCard, type LibraryGameRecord } from '@/components/library/game-card';
+import {
+  LibraryFilters,
+  type LibrarySortOption,
+} from '@/components/library/library-filters';
+import { LibrarySearch } from '@/components/library/library-search';
+import { LibraryStats } from '@/components/library/library-stats';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { fetchProfileByUsername, ProfileRequestError } from '@/services/profile';
+
+type LibraryPageContentProps = {
+  username: string;
+};
+
+function sortLibraryGames(
+  games: LibraryGameRecord[],
+  sortBy: LibrarySortOption,
+): LibraryGameRecord[] {
+  const sortedGames = [...games];
+
+  const compareAlphabetically = (left: LibraryGameRecord, right: LibraryGameRecord): number => {
+    return left.gameName.localeCompare(right.gameName, 'pt-BR');
+  };
+
+  const resolveTimestamp = (value: string | null): number => {
+    if (!value) {
+      return 0;
+    }
+
+    const parsedValue = new Date(value).getTime();
+
+    return Number.isNaN(parsedValue) ? 0 : parsedValue;
+  };
+
+  sortedGames.sort((left, right) => {
+    if (sortBy === 'most-played') {
+      const hoursDifference = (right.hoursPlayed ?? -1) - (left.hoursPlayed ?? -1);
+
+      if (hoursDifference !== 0) {
+        return hoursDifference;
+      }
+
+      const recentDifference = resolveTimestamp(right.lastPlayedAt) - resolveTimestamp(left.lastPlayedAt);
+
+      if (recentDifference !== 0) {
+        return recentDifference;
+      }
+
+      return compareAlphabetically(left, right);
+    }
+
+    if (sortBy === 'recent') {
+      const recentDifference = resolveTimestamp(right.lastPlayedAt) - resolveTimestamp(left.lastPlayedAt);
+
+      if (recentDifference !== 0) {
+        return recentDifference;
+      }
+
+      const hoursDifference = (right.hoursPlayed ?? -1) - (left.hoursPlayed ?? -1);
+
+      if (hoursDifference !== 0) {
+        return hoursDifference;
+      }
+
+      return compareAlphabetically(left, right);
+    }
+
+    return compareAlphabetically(left, right);
+  });
+
+  return sortedGames;
+}
+
+function LibraryLoadingState() {
+  return (
+    <div className="space-y-section" data-testid="library-loading">
+      <Card>
+        <div className="h-8 w-64 animate-pulse rounded-control bg-background-tertiary" />
+        <div className="mt-4 h-5 w-80 animate-pulse rounded-control bg-background-tertiary" />
+      </Card>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Card key={index} className="p-0">
+            <div className="h-40 animate-pulse bg-background-tertiary" />
+            <div className="space-y-3 p-card">
+              <div className="h-5 w-40 animate-pulse rounded-control bg-background-tertiary" />
+              <div className="h-4 w-24 animate-pulse rounded-control bg-background-tertiary" />
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LibraryErrorState({ message }: { message: string }) {
+  return (
+    <Card data-testid="library-error">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Biblioteca</p>
+        <h1 className="font-display text-3xl font-semibold text-primary">
+          Nao foi possivel carregar a biblioteca
+        </h1>
+        <p className="text-sm leading-6 text-secondary">{message}</p>
+      </div>
+    </Card>
+  );
+}
+
+function LibraryEmptyState({
+  hasGames,
+}: {
+  hasGames: boolean;
+}) {
+  return (
+    <Card data-testid="library-empty">
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Biblioteca</p>
+        <h2 className="font-display text-2xl font-semibold text-primary">
+          {hasGames ? 'Nenhum jogo corresponde aos filtros atuais' : 'Biblioteca vazia'}
+        </h2>
+        <p className="text-sm leading-6 text-secondary">
+          {hasGames
+            ? 'Ajuste a busca, a plataforma ou a ordenacao para ver outros jogos.'
+            : 'Este perfil ainda nao possui jogos importados pelas integracoes atuais.'}
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+export function LibraryPageContent({ username }: LibraryPageContentProps) {
+  const [selectedPlatform, setSelectedPlatform] = useState('ALL');
+  const [searchValue, setSearchValue] = useState('');
+  const [sortBy, setSortBy] = useState<LibrarySortOption>('most-played');
+
+  const profileQuery = useQuery({
+    queryKey: ['profile', username],
+    queryFn: () => fetchProfileByUsername(username),
+  });
+
+  const allGames = useMemo(() => {
+    return profileQuery.data?.gameLibrary ?? [];
+  }, [profileQuery.data?.gameLibrary]);
+
+  const platforms = useMemo(() => {
+    return ['ALL', ...Array.from(new Set(allGames.map((game) => game.platform))).sort()];
+  }, [allGames]);
+
+  const filteredGames = useMemo(() => {
+    const normalizedSearch = searchValue.trim().toLocaleLowerCase('pt-BR');
+
+    const visibleGames = allGames.filter((game) => {
+      const matchesPlatform =
+        selectedPlatform === 'ALL' || game.platform === selectedPlatform;
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        game.gameName.toLocaleLowerCase('pt-BR').includes(normalizedSearch);
+
+      return matchesPlatform && matchesSearch;
+    });
+
+    return sortLibraryGames(visibleGames, sortBy);
+  }, [allGames, searchValue, selectedPlatform, sortBy]);
+
+  if (profileQuery.isPending) {
+    return <LibraryLoadingState />;
+  }
+
+  if (profileQuery.isError) {
+    const message =
+      profileQuery.error instanceof ProfileRequestError
+        ? profileQuery.error.message
+        : 'Tente novamente em alguns instantes.';
+
+    return <LibraryErrorState message={message} />;
+  }
+
+  return (
+    <div className="space-y-section" data-testid="library-success">
+      <SectionHeading
+        eyebrow="Biblioteca"
+        title={`Biblioteca de @${profileQuery.data.username}`}
+        description="A biblioteca usa apenas o gameLibrary retornado pelo profile atual, com busca, filtro e ordenacao locais."
+        level="h1"
+      />
+
+      <LibraryStats games={allGames} />
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="space-y-4">
+          <LibrarySearch value={searchValue} onChange={setSearchValue} />
+
+          {filteredGames.length === 0 ? (
+            <LibraryEmptyState hasGames={allGames.length > 0} />
+          ) : (
+            <div
+              className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
+              data-testid="library-grid"
+            >
+              {filteredGames.map((game) => (
+                <GameCard
+                  key={`${game.platform}-${game.gameName}-${game.lastPlayedAt ?? 'never'}`}
+                  game={game}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <LibraryFilters
+          platforms={platforms}
+          selectedPlatform={selectedPlatform}
+          selectedSort={sortBy}
+          onPlatformChange={setSelectedPlatform}
+          onSortChange={setSortBy}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/library/library-search.tsx
+++ b/frontend/src/components/library/library-search.tsx
@@ -1,0 +1,27 @@
+import { Card } from '@/components/ui/card';
+
+type LibrarySearchProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function LibrarySearch({ value, onChange }: LibrarySearchProps) {
+  return (
+    <Card>
+      <label className="space-y-2">
+        <span className="text-xs uppercase tracking-[0.35em] text-secondary">
+          Buscar jogo
+        </span>
+        <input
+          type="search"
+          value={value}
+          placeholder="Ex.: Counter-Strike 2"
+          className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+          onChange={(event) => {
+            onChange(event.target.value);
+          }}
+        />
+      </label>
+    </Card>
+  );
+}

--- a/frontend/src/components/library/library-stats.tsx
+++ b/frontend/src/components/library/library-stats.tsx
@@ -1,0 +1,54 @@
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { type LibraryGameRecord } from '@/components/library/game-card';
+
+type LibraryStatsProps = {
+  games: LibraryGameRecord[];
+};
+
+function formatHours(games: LibraryGameRecord[]): string {
+  const totalHours = games.reduce((sum, game) => {
+    if (typeof game.hoursPlayed !== 'number' || !Number.isFinite(game.hoursPlayed)) {
+      return sum;
+    }
+
+    return sum + game.hoursPlayed;
+  }, 0);
+
+  return `${Math.round(totalHours)}h`;
+}
+
+export function LibraryStats({ games }: LibraryStatsProps) {
+  const connectedPlatforms = new Set(games.map((game) => game.platform));
+
+  return (
+    <Card>
+      <div className="flex flex-wrap items-start gap-4">
+        <div className="min-w-[8rem] space-y-1">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Jogos</p>
+          <p className="font-display text-3xl font-semibold text-primary">{games.length}</p>
+        </div>
+
+        <div className="min-w-[8rem] space-y-1">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Horas</p>
+          <p className="font-display text-3xl font-semibold text-primary">{formatHours(games)}</p>
+        </div>
+
+        <div className="flex-1 space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Plataformas</p>
+          <div className="flex flex-wrap gap-2">
+            {connectedPlatforms.size > 0 ? (
+              Array.from(connectedPlatforms).sort().map((platform) => (
+                <Badge key={platform} tone="neutral">
+                  {platform}
+                </Badge>
+              ))
+            ) : (
+              <Badge tone="neutral">Sem plataformas</Badge>
+            )}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/game-library-preview.tsx
+++ b/frontend/src/components/profile/game-library-preview.tsx
@@ -1,24 +1,34 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { Card } from '@/components/ui/card';
 import { type ProfileResponse } from '@/schemas/profile';
 
 type GameLibraryPreviewProps = {
+  username: string;
   games: ProfileResponse['gameLibrary'];
 };
 
-export function GameLibraryPreview({ games }: GameLibraryPreviewProps) {
+export function GameLibraryPreview({ games, username }: GameLibraryPreviewProps) {
   const visibleGames = games.slice(0, 6);
 
   return (
     <Card>
       <div className="space-y-4">
-        <div>
-          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
-            Biblioteca
-          </p>
-          <h3 className="mt-2 font-display text-2xl font-semibold text-primary">
-            Jogos recentes
-          </h3>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+              Biblioteca
+            </p>
+            <h3 className="mt-2 font-display text-2xl font-semibold text-primary">
+              Jogos recentes
+            </h3>
+          </div>
+          <Link
+            href={`/${username}/library`}
+            className="text-sm font-medium text-accent-cyan transition hover:text-primary"
+          >
+            Ver biblioteca completa
+          </Link>
         </div>
 
         {visibleGames.length === 0 ? (

--- a/frontend/src/components/profile/profile-page-content.tsx
+++ b/frontend/src/components/profile/profile-page-content.tsx
@@ -102,7 +102,10 @@ export function ProfilePageContent({ username }: ProfilePageContentProps) {
         userId={profileQuery.data.id}
         title={`Amigos de @${profileQuery.data.username}`}
       />
-      <GameLibraryPreview games={profileQuery.data.gameLibrary} />
+      <GameLibraryPreview
+        username={profileQuery.data.username}
+        games={profileQuery.data.gameLibrary}
+      />
     </div>
   );
 }

--- a/frontend/src/lib/auth/routes.ts
+++ b/frontend/src/lib/auth/routes.ts
@@ -1,12 +1,17 @@
 const PROTECTED_PREFIXES = ['/feed', '/notifications', '/settings'];
 const PUBLIC_ENTRY_PATHS = ['/', '/login', '/register'];
 const PROFILE_PATH_REGEX = /^\/[a-zA-Z0-9_]{3,30}$/;
+const PROFILE_LIBRARY_PATH_REGEX = /^\/[a-zA-Z0-9_]{3,30}\/library$/;
 
 export function isProtectedPath(pathname: string): boolean {
   if (
     PROFILE_PATH_REGEX.test(pathname) &&
     !PUBLIC_ENTRY_PATHS.includes(pathname)
   ) {
+    return true;
+  }
+
+  if (PROFILE_LIBRARY_PATH_REGEX.test(pathname)) {
     return true;
   }
 

--- a/frontend/tests/unit/components/library-page-content.test.tsx
+++ b/frontend/tests/unit/components/library-page-content.test.tsx
@@ -1,0 +1,276 @@
+import React, { type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LibraryPageContent } from '@/components/library/library-page-content';
+import {
+  fetchProfileByUsername,
+  ProfileRequestError,
+} from '@/services/profile';
+import { type ProfileResponse } from '@/schemas/profile';
+
+vi.mock('@/services/profile', () => ({
+  fetchProfileByUsername: vi.fn(),
+  ProfileRequestError: class ProfileRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'ProfileRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedFetchProfile = vi.mocked(fetchProfileByUsername);
+
+const profileFixture: ProfileResponse = {
+  id: 'user-1',
+  username: 'clutchplayer',
+  createdAt: '2026-03-29T22:15:00.000Z',
+  profile: {
+    displayName: 'CLUTCH Player',
+    bio: 'Bio de teste',
+    avatarUrl: null,
+    bannerUrl: null,
+    accentColor: '#7C3AED',
+    badges: ['Founder'],
+  },
+  stats: {
+    level: 18,
+    xp: 4820,
+    reputation: 215,
+    friendCount: 2,
+    postCount: 2,
+  },
+  presence: {
+    status: 'ONLINE',
+    currentGame: null,
+    gameDetails: null,
+    platform: 'PC',
+    updatedAt: '2026-03-29T22:15:00.000Z',
+  },
+  platformIntegrations: [
+    { platform: 'STEAM', metadata: null },
+    { platform: 'EPIC', metadata: null },
+  ],
+  gameLibrary: [
+    {
+      gameName: 'Counter-Strike 2',
+      coverUrl: null,
+      platform: 'STEAM',
+      hoursPlayed: 980,
+      lastPlayedAt: '2026-03-30T10:00:00.000Z',
+    },
+    {
+      gameName: 'Fortnite',
+      coverUrl: null,
+      platform: 'EPIC',
+      hoursPlayed: 12,
+      lastPlayedAt: '2026-03-29T10:00:00.000Z',
+    },
+    {
+      gameName: 'Valorant',
+      coverUrl: null,
+      platform: 'PC',
+      hoursPlayed: 120,
+      lastPlayedAt: '2026-03-28T10:00:00.000Z',
+    },
+    {
+      gameName: 'Dota 2',
+      coverUrl: null,
+      platform: 'STEAM',
+      hoursPlayed: 45,
+      lastPlayedAt: '2026-03-27T10:00:00.000Z',
+    },
+  ],
+};
+
+function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('LibraryPageContent', () => {
+  beforeEach(() => {
+    mockedFetchProfile.mockReset();
+  });
+
+  it('renders loading state while profile is pending', () => {
+    mockedFetchProfile.mockImplementation(
+      () =>
+        new Promise(() => {
+          return undefined;
+        }),
+    );
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    expect(screen.getByTestId('library-loading')).toBeInTheDocument();
+  });
+
+  it('renders the library grid with real profile data', async () => {
+    mockedFetchProfile.mockResolvedValue(profileFixture);
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-success')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/biblioteca de @clutchplayer/i)).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('1157h')).toBeInTheDocument();
+    expect(screen.getAllByTestId('library-game-card')).toHaveLength(4);
+  });
+
+  it('filters the library by platform', async () => {
+    mockedFetchProfile.mockResolvedValue(profileFixture);
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-grid')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'STEAM' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('library-game-card')).toHaveLength(2);
+    });
+
+    expect(screen.getByText('Counter-Strike 2')).toBeInTheDocument();
+    expect(screen.getByText('Dota 2')).toBeInTheDocument();
+    expect(screen.queryByText('Fortnite')).not.toBeInTheDocument();
+  });
+
+  it('filters the library by local search', async () => {
+    mockedFetchProfile.mockResolvedValue(profileFixture);
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-grid')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/counter-strike 2/i), {
+      target: { value: 'fort' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('library-game-card')).toHaveLength(1);
+    });
+
+    expect(screen.getByText('Fortnite')).toBeInTheDocument();
+  });
+
+  it('sorts the library alphabetically when requested', async () => {
+    mockedFetchProfile.mockResolvedValue(profileFixture);
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-grid')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /alfabetica/i }));
+
+    await waitFor(() => {
+      const cards = screen.getAllByTestId('library-game-card');
+      expect(within(cards[0] as HTMLElement).getByText('Counter-Strike 2')).toBeInTheDocument();
+      expect(within(cards[1] as HTMLElement).getByText('Dota 2')).toBeInTheDocument();
+    });
+  });
+
+  it('renders empty state when the profile has no games', async () => {
+    mockedFetchProfile.mockResolvedValue({
+      ...profileFixture,
+      gameLibrary: [],
+    });
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-empty')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/biblioteca vazia/i)).toBeInTheDocument();
+  });
+
+  it('renders a distinct empty state when filters remove all current results', async () => {
+    mockedFetchProfile.mockResolvedValue(profileFixture);
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-grid')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/counter-strike 2/i), {
+      target: { value: 'zzz' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-empty')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/nenhum jogo corresponde aos filtros atuais/i),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps sorting deterministic when hours and last activity are missing', async () => {
+    mockedFetchProfile.mockResolvedValue({
+      ...profileFixture,
+      gameLibrary: [
+        {
+          gameName: 'Bravo Game',
+          coverUrl: null,
+          platform: 'STEAM',
+          hoursPlayed: null,
+          lastPlayedAt: null,
+        },
+        {
+          gameName: 'Alpha Game',
+          coverUrl: null,
+          platform: 'STEAM',
+          hoursPlayed: null,
+          lastPlayedAt: null,
+        },
+      ],
+    });
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-grid')).toBeInTheDocument();
+    });
+
+    const cards = screen.getAllByTestId('library-game-card');
+    expect(within(cards[0] as HTMLElement).getByText('Alpha Game')).toBeInTheDocument();
+    expect(within(cards[1] as HTMLElement).getByText('Bravo Game')).toBeInTheDocument();
+    expect(screen.getAllByText(/sem capa/i)).toHaveLength(2);
+    expect(screen.getAllByText(/horas indisponiveis/i)).toHaveLength(2);
+  });
+
+  it('renders error state when the profile request fails', async () => {
+    mockedFetchProfile.mockRejectedValue(
+      new ProfileRequestError(503, 'Nao foi possivel carregar o perfil agora.'),
+    );
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -126,6 +126,10 @@ describe('ProfilePageContent', () => {
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
     expect(screen.getByTestId('friend-button')).toHaveTextContent('friend-button:user-1');
     expect(screen.getByTestId('friends-list')).toHaveTextContent('friends-list:user-1');
+    expect(screen.getByRole('link', { name: /ver biblioteca completa/i })).toHaveAttribute(
+      'href',
+      '/clutchplayer/library',
+    );
   });
 
   it('renders not found state', async () => {

--- a/frontend/tests/unit/lib/auth-routes.test.ts
+++ b/frontend/tests/unit/lib/auth-routes.test.ts
@@ -7,6 +7,7 @@ describe('auth route helpers', () => {
     expect(isProtectedPath('/feed/new')).toBe(true);
     expect(isProtectedPath('/settings')).toBe(true);
     expect(isProtectedPath('/clutchplayer')).toBe(true);
+    expect(isProtectedPath('/clutchplayer/library')).toBe(true);
     expect(isProtectedPath('/ab')).toBe(false);
     expect(isProtectedPath('/login')).toBe(false);
   });


### PR DESCRIPTION
## Resumo
Implementa a página `/:username/library` consumindo apenas o `gameLibrary` já retornado por `GET /profiles/:username`. A entrega adiciona a navegação a partir do profile e trata busca, filtro, ordenação e estados de loading, vazio e erro sem criar contrato novo no backend.

## O que foi alterado
- Cria a rota `frontend/src/app/(app)/[username]/library/page.tsx` e a camada de apresentação da biblioteca.
- Adiciona componentes dedicados para grid, card de jogo, filtros, busca e estatísticas da biblioteca.
- Reaproveita a query de profile existente como fonte única de dados, com transformação e ordenação locais.
- Atualiza o preview da biblioteca no profile para expor o link `Ver biblioteca completa`.
- Ajusta a proteção de rota do frontend para `/:username/library` e amplia a cobertura de testes focados.

## Motivação
O profile já expõe `gameLibrary`, mas o frontend ainda não oferecia uma superfície dedicada para explorar essa informação. A mudança fecha essa lacuna usando apenas o contrato real atual, sem inventar endpoint dedicado, paginação server-side ou metadados ausentes.

## Como validar
- Executar `npm run test -- tests/unit/components/library-page-content.test.tsx tests/unit/components/profile-page-content.test.tsx tests/unit/lib/auth-routes.test.ts` em `frontend`.
- Executar `npm run typecheck` em `frontend`.
- Executar `npm run lint` em `frontend`.
- Com o stack ativo, autenticar no app e abrir `/:username/library`.
- Validar render da grade, busca local, filtro por plataforma, ordenação e estados vazio/erro.
- Validar a navegação a partir do preview de biblioteca no profile.

## Riscos e impactos
- A superfície da biblioteca depende exclusivamente do payload atual de `GET /profiles/:username`; qualquer mudança futura nesse contrato impactará essa tela.
- A validação operacional feita nesta branch comprova resposta HTTP e a lógica via testes unitários. O DOM hidratado final ainda depende de smoke em browser real, se o time quiser evidência visual adicional antes do merge.
- O matcher do middleware foi ampliado para rotas dinâmicas aninhadas de usuário. A decisão mantém o comportamento atual porque a proteção efetiva continua centralizada em `isProtectedPath`.

## Evidências
- Testes focados passaram: `15 passed`.
- `npm run typecheck` passou.
- `npm run lint` passou.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #97
