### PR TITLE
feat(frontend): implemente Error Boundaries, loading states e página 404

### DIFF
--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AppErrorState } from '@/components/ui/app-error-state';
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en" className="dark">
+      <body>
+        <AppErrorState
+          message="O aplicativo encontrou um erro inesperado e interrompeu esta renderizacao."
+          onRetry={reset}
+        />
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { AppLoadingScreen } from '@/components/ui/app-loading-screen';
+
+export default function GlobalLoading() {
+  return <AppLoadingScreen />;
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,5 @@
+import { AppNotFoundState } from '@/components/ui/app-not-found-state';
+
+export default function GlobalNotFound() {
+  return <AppNotFoundState />;
+}

--- a/frontend/src/app/offline/page.tsx
+++ b/frontend/src/app/offline/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+
+export default function OfflinePage() {
+  return (
+    <main className="min-h-screen bg-background-primary px-6 py-10 text-primary">
+      <div className="mx-auto flex w-full max-w-3xl items-center justify-center">
+        <Card className="w-full max-w-2xl">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+              Conectividade
+            </p>
+            <h1 className="font-display text-4xl font-semibold text-primary">
+              Conexao indisponivel
+            </h1>
+            <p className="text-sm leading-6 text-secondary">
+              O app perdeu conectividade com o stack atual. Verifique a rede e
+              tente novamente.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/feed"
+                className="inline-flex h-11 items-center justify-center rounded-control border border-transparent bg-accent-purple px-control-x text-sm font-medium text-white transition hover:brightness-110"
+              >
+                Tentar novamente
+              </Link>
+              <Link
+                href="/"
+                className="inline-flex h-11 items-center justify-center rounded-control border border-border bg-[var(--button-background)] px-control-x text-sm font-medium text-primary transition hover:border-accent-cyan hover:bg-[var(--button-background-hover)] hover:text-accent-cyan"
+              >
+                Voltar para a home
+              </Link>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { useState, type ReactNode } from 'react';
 import { AuthProvider } from '@/components/auth/auth-provider';
 import { PresenceProvider } from '@/components/auth/presence-provider';
+import { ToastProvider } from '@/components/ui/toaster';
 import { makeQueryClient } from '@/lib/query/make-query-client';
 
 type ProvidersProps = {
@@ -14,10 +15,12 @@ export function Providers({ children }: ProvidersProps) {
   const [queryClient] = useState(makeQueryClient);
 
   return (
-    <AuthProvider>
-      <PresenceProvider>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      </PresenceProvider>
-    </AuthProvider>
+    <ToastProvider>
+      <AuthProvider>
+        <PresenceProvider>
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        </PresenceProvider>
+      </AuthProvider>
+    </ToastProvider>
   );
 }

--- a/frontend/src/components/feed/create-post-form.tsx
+++ b/frontend/src/components/feed/create-post-form.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toaster';
 import {
   createPostRequestSchema,
   type CreatePostRequest,
@@ -29,6 +30,7 @@ const postTypeOptions: Array<{
 
 export function CreatePostForm({ userId }: CreatePostFormProps) {
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -52,6 +54,11 @@ export function CreatePostForm({ userId }: CreatePostFormProps) {
     onSuccess: async () => {
       setServerError(null);
       setFeedbackMessage('Post publicado com sucesso.');
+      showToast({
+        title: 'Post publicado com sucesso',
+        description: 'Seu post ja apareceu no fluxo atual do feed.',
+        tone: 'success',
+      });
       reset({
         contentText: '',
         mediaUrl: '',
@@ -66,10 +73,20 @@ export function CreatePostForm({ userId }: CreatePostFormProps) {
 
       if (error instanceof FeedRequestError) {
         setServerError(error.message);
+        showToast({
+          title: 'Nao foi possivel publicar o post',
+          description: error.message,
+          tone: 'error',
+        });
         return;
       }
 
       setServerError('Nao foi possivel publicar agora. Tente novamente.');
+      showToast({
+        title: 'Nao foi possivel publicar o post',
+        description: 'Tente novamente em alguns instantes.',
+        tone: 'error',
+      });
     },
   });
 

--- a/frontend/src/components/feed/feed-page-content.tsx
+++ b/frontend/src/components/feed/feed-page-content.tsx
@@ -2,27 +2,12 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { CreatePostForm } from '@/components/feed/create-post-form';
+import { FeedSkeleton } from '@/components/feed/feed-skeleton';
 import { InfiniteScroll } from '@/components/feed/infinite-scroll';
 import { PostCard } from '@/components/feed/post-card';
 import { Card } from '@/components/ui/card';
 import { useAuth } from '@/hooks/use-auth';
 import { fetchFeed } from '@/services/feed';
-
-function FeedLoadingState() {
-  return (
-    <div className="space-y-4" data-testid="feed-loading">
-      <Card>
-        <div className="h-8 w-48 animate-pulse rounded-control bg-background-tertiary" />
-        <div className="mt-4 h-6 w-full animate-pulse rounded-control bg-background-tertiary" />
-        <div className="mt-2 h-6 w-2/3 animate-pulse rounded-control bg-background-tertiary" />
-      </Card>
-      <Card>
-        <div className="h-8 w-40 animate-pulse rounded-control bg-background-tertiary" />
-        <div className="mt-4 h-6 w-full animate-pulse rounded-control bg-background-tertiary" />
-      </Card>
-    </div>
-  );
-}
 
 function FeedEmptyState() {
   return (
@@ -83,7 +68,7 @@ export function FeedPageContent() {
   });
 
   if (status === 'loading') {
-    return <FeedLoadingState />;
+    return <FeedSkeleton />;
   }
 
   if (!userId || status !== 'authenticated') {
@@ -109,7 +94,7 @@ export function FeedPageContent() {
 
       <CreatePostForm userId={userId} />
 
-      {showInitialLoading ? <FeedLoadingState /> : null}
+      {showInitialLoading ? <FeedSkeleton /> : null}
       {showInitialError ? <FeedErrorState /> : null}
       {!showInitialLoading && !showInitialError && posts.length === 0 ? (
         <FeedEmptyState />

--- a/frontend/src/components/feed/feed-skeleton.tsx
+++ b/frontend/src/components/feed/feed-skeleton.tsx
@@ -1,0 +1,20 @@
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type FeedSkeletonProps = {
+  items?: number;
+};
+
+export function FeedSkeleton({ items = 2 }: FeedSkeletonProps) {
+  return (
+    <div className="space-y-4" data-testid="feed-loading">
+      {Array.from({ length: items }).map((_, index) => (
+        <Card key={index}>
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="mt-4 h-6 w-full" />
+          <Skeleton className="mt-2 h-6 w-2/3" />
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/profile-page-content.tsx
+++ b/frontend/src/components/profile/profile-page-content.tsx
@@ -6,6 +6,7 @@ import { FriendsList } from '@/components/friends/friends-list';
 import { Card } from '@/components/ui/card';
 import { GamerCard } from '@/components/profile/gamer-card';
 import { GameLibraryPreview } from '@/components/profile/game-library-preview';
+import { ProfileSkeleton } from '@/components/profile/profile-skeleton';
 import { ProfileStats } from '@/components/profile/profile-stats';
 import {
   fetchProfileByUsername,
@@ -15,24 +16,6 @@ import {
 type ProfilePageContentProps = {
   username: string;
 };
-
-function ProfileLoadingState() {
-  return (
-    <div className="space-y-section" data-testid="profile-loading">
-      <Card className="p-0">
-        <div className="h-40 w-full animate-pulse bg-background-tertiary" />
-        <div className="space-y-4 p-card">
-          <div className="h-8 w-56 animate-pulse rounded-control bg-background-tertiary" />
-          <div className="h-5 w-72 animate-pulse rounded-control bg-background-tertiary" />
-          <div className="h-5 w-44 animate-pulse rounded-control bg-background-tertiary" />
-        </div>
-      </Card>
-      <Card>
-        <div className="h-28 animate-pulse rounded-control bg-background-tertiary" />
-      </Card>
-    </div>
-  );
-}
 
 function ProfileNotFoundState() {
   return (
@@ -77,7 +60,7 @@ export function ProfilePageContent({ username }: ProfilePageContentProps) {
   });
 
   if (profileQuery.isPending) {
-    return <ProfileLoadingState />;
+    return <ProfileSkeleton />;
   }
 
   if (profileQuery.isError) {

--- a/frontend/src/components/profile/profile-skeleton.tsx
+++ b/frontend/src/components/profile/profile-skeleton.tsx
@@ -1,0 +1,23 @@
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function ProfileSkeleton() {
+  return (
+    <div
+      className="space-y-section"
+      data-testid="profile-loading"
+    >
+      <Card className="p-0">
+        <Skeleton className="h-40 w-full rounded-none" />
+        <div className="space-y-4 p-card">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-5 w-72" />
+          <Skeleton className="h-5 w-44" />
+        </div>
+      </Card>
+      <Card>
+        <Skeleton className="h-28 w-full" />
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/app-error-state.tsx
+++ b/frontend/src/components/ui/app-error-state.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+
+type AppErrorStateProps = {
+  message?: string;
+  onRetry?: () => void;
+};
+
+export function AppErrorState({
+  message = 'Tente novamente em alguns instantes.',
+  onRetry,
+}: AppErrorStateProps) {
+  return (
+    <main
+      className="min-h-screen bg-background-primary px-6 py-10 text-primary"
+      data-testid="app-error-state"
+    >
+      <div className="mx-auto flex w-full max-w-3xl items-center justify-center">
+        <Card className="w-full max-w-2xl">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+              Erro global
+            </p>
+            <h1 className="font-display text-4xl font-semibold text-primary">
+              Algo saiu do fluxo esperado
+            </h1>
+            <p className="text-sm leading-6 text-secondary">{message}</p>
+            {onRetry ? (
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  onClick={() => {
+                    onRetry();
+                  }}
+                >
+                  Tentar novamente
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/ui/app-loading-screen.tsx
+++ b/frontend/src/components/ui/app-loading-screen.tsx
@@ -1,0 +1,35 @@
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function AppLoadingScreen() {
+  return (
+    <main
+      className="min-h-screen bg-background-primary px-6 py-10 text-primary"
+      data-testid="app-loading-screen"
+    >
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <Card>
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-10 w-80" />
+            <Skeleton className="h-5 w-full max-w-2xl" />
+          </div>
+        </Card>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card>
+            <div className="space-y-4">
+              <Skeleton className="h-8 w-44" />
+              <Skeleton className="h-24 w-full" />
+            </div>
+          </Card>
+          <Card>
+            <div className="space-y-4">
+              <Skeleton className="h-8 w-36" />
+              <Skeleton className="h-24 w-full" />
+            </div>
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/ui/app-not-found-state.tsx
+++ b/frontend/src/components/ui/app-not-found-state.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+
+export function AppNotFoundState() {
+  return (
+    <main
+      className="min-h-screen bg-background-primary px-6 py-10 text-primary"
+      data-testid="app-not-found-state"
+    >
+      <div className="mx-auto flex w-full max-w-3xl items-center justify-center">
+        <Card className="w-full max-w-2xl">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+              Erro 404
+            </p>
+            <h1 className="font-display text-4xl font-semibold text-primary">
+              GG EZ — Pagina nao encontrada
+            </h1>
+            <p className="text-sm leading-6 text-secondary">
+              O caminho pedido nao existe no estado atual do produto ou nao esta
+              disponivel para esta sessao.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/feed"
+                className="inline-flex h-11 items-center justify-center rounded-control border border-transparent bg-accent-purple px-control-x text-sm font-medium text-white transition hover:brightness-110"
+              >
+                Voltar ao feed
+              </Link>
+              <Link
+                href="/"
+                className="inline-flex h-11 items-center justify-center rounded-control border border-border bg-[var(--button-background)] px-control-x text-sm font-medium text-primary transition hover:border-accent-cyan hover:bg-[var(--button-background-hover)] hover:text-accent-cyan"
+              >
+                Ir para a home
+              </Link>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/ui/error-boundary.tsx
+++ b/frontend/src/components/ui/error-boundary.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AppErrorState } from '@/components/ui/app-error-state';
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  fallback?: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  public constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  public static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(_error: Error, _errorInfo: ErrorInfo) {}
+
+  public render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <AppErrorState message="O componente falhou ao renderizar." />
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,17 @@
+import type { HTMLAttributes } from 'react';
+import { cn } from '@/lib/utils/cn';
+
+type SkeletonProps = HTMLAttributes<HTMLDivElement>;
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-control bg-background-tertiary',
+        className,
+      )}
+      aria-hidden="true"
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { cn } from '@/lib/utils/cn';
+
+type ToastTone = 'success' | 'error' | 'info';
+
+type Toast = {
+  id: number;
+  title: string;
+  description?: string;
+  tone: ToastTone;
+};
+
+type ToastInput = {
+  title: string;
+  description?: string;
+  tone?: ToastTone;
+};
+
+type ToastContextValue = {
+  showToast: (input: ToastInput) => void;
+};
+
+const toastToneClassName: Record<ToastTone, string> = {
+  success: 'border-status-online/35 bg-[rgba(16,185,129,0.12)]',
+  error: 'border-status-afk/35 bg-[rgba(245,158,11,0.12)]',
+  info: 'border-accent-cyan/35 bg-[rgba(6,182,212,0.12)]',
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+type ToastProviderProps = {
+  children: ReactNode;
+};
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback((input: ToastInput) => {
+    const id = Date.now() + Math.floor(Math.random() * 1000);
+
+    setToasts((currentToasts) => [
+      ...currentToasts,
+      {
+        id,
+        title: input.title,
+        description: input.description,
+        tone: input.tone ?? 'info',
+      },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    if (toasts.length === 0) {
+      return undefined;
+    }
+
+    const timers = toasts.map((toast) =>
+      window.setTimeout(() => {
+        dismissToast(toast.id);
+      }, 4000),
+    );
+
+    return () => {
+      timers.forEach((timer) => {
+        window.clearTimeout(timer);
+      });
+    };
+  }, [dismissToast, toasts]);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({
+      showToast,
+    }),
+    [showToast],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-3"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            role="status"
+            data-testid="toast-item"
+            className={cn(
+              'pointer-events-auto rounded-surface border px-4 py-3 shadow-lg backdrop-blur',
+              toastToneClassName[toast.tone],
+            )}
+          >
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-primary">{toast.title}</p>
+              {toast.description ? (
+                <p className="text-sm leading-5 text-secondary">{toast.description}</p>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+
+  return context;
+}

--- a/frontend/tests/unit/components/create-post-form.test.tsx
+++ b/frontend/tests/unit/components/create-post-form.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreatePostForm } from '@/components/feed/create-post-form';
+import { ToastProvider } from '@/components/ui/toaster';
 import { createPost, FeedRequestError } from '@/services/feed';
 
 vi.mock('@/services/feed', () => ({
@@ -35,9 +36,11 @@ function renderCreatePostForm() {
   const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
   render(
-    <QueryClientProvider client={queryClient}>
-      <CreatePostForm userId="user-1" />
-    </QueryClientProvider>,
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>
+        <CreatePostForm userId="user-1" />
+      </QueryClientProvider>
+    </ToastProvider>,
   );
 
   return { invalidateQueriesSpy };
@@ -101,7 +104,8 @@ describe('CreatePostForm', () => {
       });
     });
 
-    expect(await screen.findByRole('status')).toHaveTextContent(
+    expect(await screen.findByText(/post publicado com sucesso\./i)).toBeInTheDocument();
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(
       /post publicado com sucesso/i,
     );
   });
@@ -120,6 +124,9 @@ describe('CreatePostForm', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /post precisa ter texto ou midia/i,
+    );
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(
+      /nao foi possivel publicar o post/i,
     );
   });
 });

--- a/frontend/tests/unit/components/ui-feedback.test.tsx
+++ b/frontend/tests/unit/components/ui-feedback.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppErrorState } from '@/components/ui/app-error-state';
+import { AppLoadingScreen } from '@/components/ui/app-loading-screen';
+import { AppNotFoundState } from '@/components/ui/app-not-found-state';
+import { ErrorBoundary } from '@/components/ui/error-boundary';
+import { ToastProvider, useToast } from '@/components/ui/toaster';
+
+function ToastTrigger() {
+  const { showToast } = useToast();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        showToast({
+          title: 'Acao concluida',
+          description: 'Feedback global renderizado.',
+          tone: 'success',
+        });
+      }}
+    >
+      disparar
+    </button>
+  );
+}
+
+function BrokenComponent(): React.JSX.Element {
+  throw new Error('render failed');
+}
+
+describe('UI feedback foundation', () => {
+  it('renders the global loading screen', () => {
+    render(<AppLoadingScreen />);
+
+    expect(screen.getByTestId('app-loading-screen')).toBeInTheDocument();
+  });
+
+  it('renders the global not found state', () => {
+    render(<AppNotFoundState />);
+
+    expect(screen.getByTestId('app-not-found-state')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /voltar ao feed/i })).toHaveAttribute(
+      'href',
+      '/feed',
+    );
+  });
+
+  it('renders the global error state and retries', () => {
+    let retryCount = 0;
+
+    render(
+      <AppErrorState
+        message="Falha controlada."
+        onRetry={() => {
+          retryCount += 1;
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /tentar novamente/i }));
+
+    expect(retryCount).toBe(1);
+  });
+
+  it('shows fallback through the reusable error boundary', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <BrokenComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByTestId('app-error-state')).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
+
+  it('renders global toasts through the provider', () => {
+    render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /disparar/i }));
+
+    expect(screen.getByTestId('toast-item')).toHaveTextContent(/acao concluida/i);
+    expect(screen.getByTestId('toast-item')).toHaveTextContent(
+      /feedback global renderizado/i,
+    );
+  });
+});


### PR DESCRIPTION
## Resumo
Adiciona as superfícies globais de erro, loading e 404 do App Router e completa a base de feedback visual do frontend com skeletons reutilizáveis e toaster interno. A mudança fecha a lacuna principal da issue #103 sem ampliar o escopo para redesign de UX geral.

## O que foi alterado
- Cria `frontend/src/app/error.tsx`, `frontend/src/app/loading.tsx` e `frontend/src/app/not-found.tsx` com fallbacks globais coerentes.
- Adiciona a rota `/offline` como fallback explícito de conectividade.
- Cria componentes reutilizáveis de foundation: `Skeleton`, `ErrorBoundary`, `Toaster`, `AppLoadingScreen`, `AppNotFoundState` e `AppErrorState`.
- Extrai skeletons dedicados de feed e profile e reaproveita essas superfícies nas páginas existentes.
- Conecta o toaster no provider global e usa feedback toast real no fluxo de criação de post.
- Amplia a cobertura de testes para as novas superfícies de feedback.

## Motivação
A foundation do frontend ainda estava sem as superfícies globais mínimas de App Router e sem infraestrutura unificada de feedback visual. Isso deixava carregamentos, erros e 404 dependentes apenas de estados locais espalhados e mantinha a issue #103 aberta no milestone de foundation.

## Como validar
- Executar `npm run test -- tests/unit/components/ui-feedback.test.tsx tests/unit/components/create-post-form.test.tsx tests/unit/components/feed-page-content.test.tsx tests/unit/components/profile-page-content.test.tsx` em `frontend`.
- Executar `npm run typecheck` em `frontend`.
- Executar `npm run lint` em `frontend`.
- Abrir uma rota inexistente e validar a superfície global de 404.
- Forçar um erro de renderização em ambiente de desenvolvimento e validar a superfície global de erro.
- Validar criação de post com sucesso e com erro para confirmar o toaster global.

## Riscos e impactos
- O toaster foi implementado internamente, sem nova dependência. Isso reduz superfície operacional, mas deixa para follow-up eventual a decisão de migrar ou não para uma biblioteca dedicada.
- A rota `/offline` é uma página explícita, não um mecanismo automático de detecção de rede. Ela atende ao requisito da issue sem prometer comportamento PWA inexistente.
- A mudança não cobre a UX baseline completa do produto; isso continua rastreado separadamente em #187.

## Evidências
- Testes focados passaram: `18 passed`.
- `npm run typecheck` passou.
- `npm run lint` passou.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #103
