### PR TITLE
fix(auth): estabilize o reconhecimento da sessão após login

### DIFF
--- a/frontend/src/components/auth/auth-provider.tsx
+++ b/frontend/src/components/auth/auth-provider.tsx
@@ -36,6 +36,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
         return;
       }
 
+      if (useAuthStore.getState().status !== 'loading') {
+        return;
+      }
+
       if (session) {
         setSession(session);
         return;

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { loginRequestSchema, type LoginRequestValues } from '@/schemas/auth';
 import { AuthRequestError, login } from '@/services/auth';
+import { useAuthStore } from '@/store/auth-store';
 
 const demoCredentials: LoginRequestValues = {
   email: 'clutchplayer@clutch.gg',
@@ -23,6 +24,7 @@ const fieldClassName = 'space-y-2';
 export function LoginForm() {
   const router = useRouter();
   const [serverError, setServerError] = useState<string | null>(null);
+  const setSession = useAuthStore((state) => state.setSession);
 
   const {
     register,
@@ -56,7 +58,12 @@ export function LoginForm() {
     setServerError(null);
 
     try {
-      await login(values);
+      const session = await login(values);
+      setSession({
+        id: session.id,
+        username: session.username,
+        email: values.email,
+      });
       router.replace('/feed');
       router.refresh();
     } catch (error) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ type JsonBody = Record<string, unknown>;
 
 type ApiRequestInit = Omit<RequestInit, 'body'> & {
   body?: BodyInit | JsonBody;
+  clearSessionOnUnauthorized?: boolean;
 };
 
 function isJsonBody(value: ApiRequestInit['body']): value is JsonBody {
@@ -14,7 +15,12 @@ export async function apiRequest(
   pathname: string,
   init: ApiRequestInit = {},
 ): Promise<Response> {
-  const { body, headers, ...rest } = init;
+  const {
+    body,
+    clearSessionOnUnauthorized = true,
+    headers,
+    ...rest
+  } = init;
   const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
 
   const requestHeaders = new Headers(headers);
@@ -34,7 +40,7 @@ export async function apiRequest(
     body: requestBody,
   });
 
-  if (response.status === 401) {
+  if (clearSessionOnUnauthorized && response.status === 401) {
     useAuthStore.getState().clearSession();
   }
 

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -19,6 +19,7 @@ async function readJson(response: Response): Promise<unknown> {
 export async function fetchAuthSession(): Promise<AuthSession | null> {
   const response = await apiRequest('/auth/me', {
     method: 'GET',
+    clearSessionOnUnauthorized: false,
   });
 
   if (!response.ok) {

--- a/frontend/tests/unit/components/auth-provider.test.tsx
+++ b/frontend/tests/unit/components/auth-provider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthProvider } from '@/components/auth/auth-provider';
 import { resetAuthStore, useAuthStore } from '@/store/auth-store';
@@ -68,5 +68,42 @@ describe('AuthProvider', () => {
       expect(replaceMock).toHaveBeenCalledWith('/login');
       expect(refreshMock).toHaveBeenCalled();
     });
+  });
+
+  it('does not overwrite an authenticated session with a stale bootstrap result', async () => {
+    let resolveSession: (value: null) => void;
+
+    fetchAuthSessionMock.mockReturnValue(
+      new Promise<null>((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+
+    render(
+      <AuthProvider>
+        <div>content</div>
+      </AuthProvider>,
+    );
+
+    await act(async () => {
+      useAuthStore.getState().setSession({
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      });
+
+      resolveSession!(null);
+    });
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().status).toBe('authenticated');
+      expect(useAuthStore.getState().user).toEqual({
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      });
+    });
+
+    expect(replaceMock).not.toHaveBeenCalledWith('/login');
   });
 });

--- a/frontend/tests/unit/components/login-page.test.tsx
+++ b/frontend/tests/unit/components/login-page.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import LoginPage from '@/app/(auth)/login/page';
 import { AuthRequestError, login as mockedLogin } from '@/services/auth';
+import { resetAuthStore, useAuthStore } from '@/store/auth-store';
 
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
@@ -33,6 +34,7 @@ const mockedLoginFn = vi.mocked(mockedLogin);
 
 describe('LoginPage', () => {
   beforeEach(() => {
+    resetAuthStore();
     pushMock.mockReset();
     replaceMock.mockReset();
     refreshMock.mockReset();
@@ -87,6 +89,13 @@ describe('LoginPage', () => {
         email: 'clutchplayer@clutch.gg',
         password: 'clutch123',
       });
+    });
+
+    expect(useAuthStore.getState().status).toBe('authenticated');
+    expect(useAuthStore.getState().user).toEqual({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
     });
 
     expect(replaceMock).toHaveBeenCalledWith('/feed');

--- a/frontend/tests/unit/services/session.test.ts
+++ b/frontend/tests/unit/services/session.test.ts
@@ -38,6 +38,30 @@ describe('session service', () => {
       username: 'clutchplayer',
       email: 'clutchplayer@clutch.gg',
     });
+
+    expect(apiRequestMock).toHaveBeenCalledWith('/auth/me', {
+      method: 'GET',
+      clearSessionOnUnauthorized: false,
+    });
+  });
+
+  it('does not clear an existing session when bootstrap auth me returns 401', async () => {
+    useAuthStore.getState().setSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+
+    apiRequestMock.mockResolvedValue(new Response(null, { status: 401 }));
+
+    await expect(fetchAuthSession()).resolves.toBeNull();
+
+    expect(useAuthStore.getState().status).toBe('authenticated');
+    expect(useAuthStore.getState().user).toEqual({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
   });
 
   it('clears the local session on logout', async () => {


### PR DESCRIPTION
## Resumo
Corrige uma race no reconhecimento da sessão logo após o login, que fazia o frontend navegar para `/feed` e voltar indevidamente para `/login` mesmo com cookies já emitidos. A mudança estabiliza a hidratação da sessão no cliente sem alterar o contrato atual de autenticação.

## O que foi alterado
- Ajustado o bootstrap da sessão para não limpar o estado global de autenticação de forma prematura quando `/api/auth/me` retorna `401` durante a descoberta inicial.
- Protegido o `AuthProvider` contra resultados atrasados de bootstrap que poderiam sobrescrever uma sessão já autenticada.
- Atualizado o fluxo de login para hidratar o `authStore` imediatamente antes da navegação para `/feed`.
- Adicionados testes focados para bootstrap atrasado, login seguido de navegação autenticada e preservação da sessão local no cenário observado.

## Motivação
Na validação manual recente, o login concluía com sucesso e os cookies eram emitidos, mas o frontend ainda tratava a sessão como ausente por um curto intervalo e executava um redirect indevido para `/login`. Era necessário eliminar essa dependência de timing entre cookies, bootstrap de `/api/auth/me` e estado client-side.

## Como validar
- Executar `npm run test -- tests/unit/components/auth-provider.test.tsx tests/unit/components/login-page.test.tsx tests/unit/services/session.test.ts tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-logout-route.test.ts` em `frontend/`.
- Executar `npm run typecheck` em `frontend/`.
- Executar `npm run lint` em `frontend/`.
- Abrir `/login`, autenticar com sucesso e confirmar que a navegação para `/feed` ocorre sem bounce de volta para `/login`.
- Recarregar uma rota protegida autenticada e validar que a sessão continua reconhecida.
- Executar logout e confirmar limpeza da sessão e redirect apropriado.

## Riscos e impactos
- O ajuste altera a coordenação entre bootstrap de sessão e estado global de autenticação no frontend; merece atenção em fluxos de login, logout e restauração de sessão.
- O comportamento do cadastro continua fora deste escopo. O race principal foi neutralizado no bootstrap global, mas a hidratação otimista local foi aplicada apenas no login.
- O risco é baixo e localizado ao frontend de autenticação, sem mudança de contrato HTTP.

## Evidências
- Testes focados passaram para os cenários de bootstrap, login, `/api/auth/me` e logout.
- Houve validação manual do fluxo `/login -> /feed` sem retorno indevido para `/login`.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #183