### PR TITLE
feat(presence): substituir mock por presença real e consistente no frontend

### DIFF
--- a/frontend/src/components/friends/friends-list.tsx
+++ b/frontend/src/components/friends/friends-list.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { PresenceBadge } from '@/components/profile/presence-badge';
 import { type FriendSummary, type FriendPresenceStatus } from '@/schemas/friends';
@@ -52,6 +53,47 @@ export function sortFriendsByEffectivePresence(
   });
 }
 
+function describeRealtimeState(connectionStatus: string, errorMessage: string | null) {
+  switch (connectionStatus) {
+    case 'connected':
+      return {
+        tone: 'success' as const,
+        label: 'Realtime ativo',
+        detail: 'A ordenacao usa atualizacoes em tempo real.',
+      };
+    case 'connecting':
+      return {
+        tone: 'neutral' as const,
+        label: 'Conectando realtime',
+        detail: 'A lista usa o snapshot do backend ate a conexao estabilizar.',
+      };
+    case 'reconnecting':
+      return {
+        tone: 'warning' as const,
+        label: 'Reconectando realtime',
+        detail: 'A lista voltou temporariamente para o snapshot do backend.',
+      };
+    case 'auth_error':
+      return {
+        tone: 'warning' as const,
+        label: 'Sessao do realtime expirou',
+        detail: errorMessage ?? 'A sessao sera restaurada antes de reabrir o realtime.',
+      };
+    case 'error':
+      return {
+        tone: 'warning' as const,
+        label: 'Realtime indisponivel',
+        detail: errorMessage ?? 'Exibindo o snapshot mais recente do backend.',
+      };
+    default:
+      return {
+        tone: 'neutral' as const,
+        label: 'Realtime inativo',
+        detail: 'Exibindo o snapshot mais recente do backend.',
+      };
+  }
+}
+
 function FriendsListLoadingState() {
   return (
     <Card data-testid="friends-list-loading">
@@ -69,6 +111,8 @@ export function FriendsList({
   title = 'Amigos',
 }: FriendsListProps) {
   const presenceEntries = usePresenceStore((state) => state.entries);
+  const connectionStatus = usePresenceStore((state) => state.connectionStatus);
+  const errorMessage = usePresenceStore((state) => state.errorMessage);
   const friendsQuery = useQuery({
     queryKey: ['friends', userId],
     queryFn: () => fetchFriends(userId),
@@ -93,7 +137,9 @@ export function FriendsList({
     );
   }
 
-  const friends = sortFriendsByEffectivePresence(friendsQuery.data, presenceEntries);
+  const realtimeEntries = connectionStatus === 'connected' ? presenceEntries : {};
+  const friends = sortFriendsByEffectivePresence(friendsQuery.data, realtimeEntries);
+  const realtimeState = describeRealtimeState(connectionStatus, errorMessage);
 
   if (friends.length === 0) {
     return (
@@ -117,7 +163,11 @@ export function FriendsList({
           <p className="text-xs uppercase tracking-[0.35em] text-secondary">
             Amizades
           </p>
-          <h2 className="font-display text-2xl font-semibold text-primary">{title}</h2>
+          <div className="flex flex-wrap items-center gap-3">
+            <h2 className="font-display text-2xl font-semibold text-primary">{title}</h2>
+            <Badge tone={realtimeState.tone}>{realtimeState.label}</Badge>
+          </div>
+          <p className="text-sm text-secondary">{realtimeState.detail}</p>
         </div>
 
         <div className="space-y-3">

--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -18,7 +18,9 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
   const displayName = profile.profile.displayName || profile.username;
   const badgeList = profile.profile.badges.slice(0, 4);
   const initials = profile.username.slice(0, 2).toUpperCase();
-  const realtimePresence = usePresenceStore((state) => state.entries[profile.id]);
+  const realtimePresence = usePresenceStore((state) =>
+    state.connectionStatus === 'connected' ? state.entries[profile.id] : undefined,
+  );
   const effectivePresence = {
     status: realtimePresence?.status ?? profile.presence.status,
     currentGame: realtimePresence?.currentGame ?? profile.presence.currentGame,

--- a/frontend/src/hooks/use-presence.ts
+++ b/frontend/src/hooks/use-presence.ts
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { fetchPresenceCredential, PresenceConnection } from '@/services/presence';
+import {
+  fetchPresenceCredential,
+  PresenceConnection,
+  publishPresenceState,
+} from '@/services/presence';
 import { usePresenceStore } from '@/store/presence-store';
 import { useAuthStore } from '@/store/auth-store';
 
@@ -12,6 +16,12 @@ export function usePresence(): void {
   const upsertPresence = usePresenceStore((state) => state.upsertPresence);
   const clearAll = usePresenceStore((state) => state.clearAll);
   const connectionRef = useRef<PresenceConnection | null>(null);
+  const isPageVisibleRef = useRef(true);
+
+  useEffect(() => {
+    isPageVisibleRef.current =
+      typeof document === 'undefined' ? true : !document.hidden;
+  }, []);
 
   useEffect(() => {
     if (status !== 'authenticated') {
@@ -29,6 +39,12 @@ export function usePresence(): void {
         },
         onConnectionStatusChange: (nextStatus, errorMessage) => {
           setConnectionStatus(nextStatus, errorMessage ?? null);
+
+          if (nextStatus === 'connected') {
+            void publishPresenceState({
+              status: isPageVisibleRef.current ? 'ONLINE' : 'AFK',
+            }).catch(() => undefined);
+          }
         },
         onAuthFailure: () => {
           clearAll();
@@ -39,7 +55,42 @@ export function usePresence(): void {
 
     connectionRef.current.connect();
 
+    const handleVisibilityChange = () => {
+      isPageVisibleRef.current = !document.hidden;
+
+      if (useAuthStore.getState().status !== 'authenticated') {
+        return;
+      }
+
+      if (usePresenceStore.getState().connectionStatus !== 'connected') {
+        return;
+      }
+
+      void publishPresenceState({
+        status: document.hidden ? 'AFK' : 'ONLINE',
+      }).catch(() => undefined);
+    };
+
+    const handlePageHide = () => {
+      if (useAuthStore.getState().status !== 'authenticated') {
+        return;
+      }
+
+      void publishPresenceState(
+        {
+          status: 'OFFLINE',
+          platform: null,
+        },
+        { keepalive: true },
+      ).catch(() => undefined);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
+
     return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handlePageHide);
       connectionRef.current?.disconnect();
       connectionRef.current = null;
     };

--- a/frontend/src/schemas/presence.ts
+++ b/frontend/src/schemas/presence.ts
@@ -11,6 +11,12 @@ export const presenceCredentialResponseSchema = z.object({
   token: z.string().min(1),
 });
 
+export const presenceUpdateRequestSchema = z.object({
+  status: presenceStatusSchema,
+  currentGame: z.string().max(100).nullable().optional(),
+  platform: z.string().max(50).nullable().optional(),
+});
+
 export const friendPresenceEventPayloadSchema = z.object({
   userId: z.string().min(1),
   status: presenceStatusSchema,
@@ -39,6 +45,7 @@ export type PresenceStatus = z.infer<typeof presenceStatusSchema>;
 export type PresenceCredentialResponse = z.infer<
   typeof presenceCredentialResponseSchema
 >;
+export type PresenceUpdateRequest = z.infer<typeof presenceUpdateRequestSchema>;
 export type FriendPresenceEventPayload = z.infer<
   typeof friendPresenceEventPayloadSchema
 >;

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -35,6 +35,8 @@ export {
 } from './integrations';
 export {
   fetchPresenceCredential,
+  frontendPresencePlatform,
+  publishPresenceState,
   PresenceConnection,
   PresenceRequestError,
 } from './presence';

--- a/frontend/src/services/presence.ts
+++ b/frontend/src/services/presence.ts
@@ -3,10 +3,13 @@
 import {
   friendPresenceSocketEventSchema,
   presenceCredentialResponseSchema,
+  presenceUpdateRequestSchema,
   presenceSocketEventSchema,
+  type PresenceStatus,
   type FriendPresenceEventPayload,
 } from '@/schemas/presence';
 import { getClientEnv } from '@/lib/config/env';
+import { apiRequest } from '@/lib/api';
 
 type ErrorResponse = {
   message?: string;
@@ -50,6 +53,7 @@ export class PresenceRequestError extends Error {
 const initialReconnectDelayMs = 1_000;
 const maxReconnectDelayMs = 30_000;
 const appPingIntervalMs = 25_000;
+export const frontendPresencePlatform = 'WEB';
 
 function readJson(response: Response): Promise<unknown> {
   return response.text().then((text) => {
@@ -93,6 +97,40 @@ export async function fetchPresenceCredential(): Promise<string> {
   }
 
   return presenceCredentialResponseSchema.parse(payload).token;
+}
+
+type PublishPresenceOptions = {
+  keepalive?: boolean;
+};
+
+export async function publishPresenceState(
+  input: {
+    status: PresenceStatus;
+    currentGame?: string | null;
+    platform?: string | null;
+  },
+  options: PublishPresenceOptions = {},
+): Promise<void> {
+  const payload = presenceUpdateRequestSchema.parse({
+    status: input.status,
+    currentGame: input.currentGame ?? null,
+    platform: input.platform ?? frontendPresencePlatform,
+  });
+
+  const response = await apiRequest('/presence', {
+    method: 'POST',
+    body: payload,
+    keepalive: options.keepalive,
+    clearSessionOnUnauthorized: false,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new PresenceRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel atualizar sua presenca agora.'),
+    );
+  }
 }
 
 function buildPresenceSocketUrl(token: string): string {

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -1,5 +1,6 @@
 import { apiRequest } from '@/lib/api';
 import { authSessionSchema, type AuthSession } from '@/schemas/auth';
+import { publishPresenceState } from '@/services/presence';
 import { useAuthStore } from '@/store/auth-store';
 
 async function readJson(response: Response): Promise<unknown> {
@@ -34,6 +35,14 @@ export async function fetchAuthSession(): Promise<AuthSession | null> {
 
 export async function logoutAuthSession(): Promise<void> {
   try {
+    await publishPresenceState(
+      {
+        status: 'OFFLINE',
+        platform: null,
+      },
+      { keepalive: true },
+    ).catch(() => undefined);
+
     await apiRequest('/auth/logout', {
       method: 'POST',
     });

--- a/frontend/tests/unit/components/friends-list.test.tsx
+++ b/frontend/tests/unit/components/friends-list.test.tsx
@@ -78,6 +78,7 @@ describe('FriendsList', () => {
       },
     ]);
 
+    usePresenceStore.getState().setConnectionStatus('connected');
     usePresenceStore.getState().upsertPresence(
       {
         userId: 'friend-1',
@@ -94,5 +95,40 @@ describe('FriendsList', () => {
     expect(items[0]).toHaveTextContent(/offline/i);
     expect(items[0]).toHaveTextContent(/jogando marvel rivals/i);
     expect(items[1]).toHaveTextContent(/online/i);
+  });
+
+  it('falls back to the backend snapshot when realtime is disconnected', async () => {
+    mockedFetchFriends.mockResolvedValue([
+      {
+        id: 'friend-1',
+        username: 'offline',
+        profile: { displayName: 'Offline', avatarUrl: null, accentColor: null },
+        presence: { status: 'OFFLINE', currentGame: null, platform: null },
+      },
+      {
+        id: 'friend-2',
+        username: 'online',
+        profile: { displayName: 'Online', avatarUrl: null, accentColor: null },
+        presence: { status: 'ONLINE', currentGame: null, platform: null },
+      },
+    ]);
+
+    usePresenceStore.getState().setConnectionStatus('error', 'Realtime indisponivel');
+    usePresenceStore.getState().upsertPresence(
+      {
+        userId: 'friend-1',
+        status: 'IN_GAME',
+        currentGame: 'Marvel Rivals',
+        platform: 'PC',
+      },
+      123,
+    );
+
+    renderFriendsList();
+
+    expect((await screen.findAllByText(/realtime indisponivel/i)).length).toBeGreaterThan(0);
+    const items = await screen.findAllByTestId('friend-list-item');
+    expect(items[0]).toHaveTextContent(/online/i);
+    expect(items[1]).toHaveTextContent(/offline/i);
   });
 });

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -41,6 +41,7 @@ describe('GamerCard', () => {
   });
 
   it('overrides static profile presence with realtime store data', () => {
+    usePresenceStore.getState().setConnectionStatus('connected');
     usePresenceStore.getState().upsertPresence(
       {
         userId: 'user-1',
@@ -55,5 +56,23 @@ describe('GamerCard', () => {
 
     expect(screen.getByText(/in game/i)).toBeInTheDocument();
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
+  });
+
+  it('falls back to the backend snapshot when realtime is not connected', () => {
+    usePresenceStore.getState().setConnectionStatus('error', 'Realtime indisponivel');
+    usePresenceStore.getState().upsertPresence(
+      {
+        userId: 'user-1',
+        status: 'IN_GAME',
+        currentGame: 'Valorant',
+        platform: 'PC',
+      },
+      123,
+    );
+
+    render(<GamerCard profile={profileFixture} />);
+
+    expect(screen.getByText(/offline/i)).toBeInTheDocument();
+    expect(screen.getByText(/sem atividade ativa/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/presence-provider.test.tsx
+++ b/frontend/tests/unit/components/presence-provider.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PresenceProvider } from '@/components/auth/presence-provider';
+import { resetAuthStore, useAuthStore } from '@/store/auth-store';
+import { resetPresenceStore, usePresenceStore } from '@/store/presence-store';
+
+const {
+  connectMock,
+  disconnectMock,
+  publishPresenceStateMock,
+  getLastOptions,
+  resetLastOptions,
+  setLastOptions,
+} = vi.hoisted(() => {
+  let lastOptions:
+    | {
+        onConnectionStatusChange?: (status: string, errorMessage?: string | null) => void;
+        onAuthFailure?: () => void;
+      }
+    | null = null;
+
+  return {
+    connectMock: vi.fn(),
+    disconnectMock: vi.fn(),
+    publishPresenceStateMock: vi.fn(),
+    getLastOptions: () => lastOptions,
+    resetLastOptions: () => {
+      lastOptions = null;
+    },
+    setLastOptions: (options: typeof lastOptions) => {
+      lastOptions = options;
+    },
+  };
+});
+
+vi.mock('@/services/presence', () => {
+  return {
+    fetchPresenceCredential: vi.fn(),
+    publishPresenceState: publishPresenceStateMock,
+    PresenceConnection: class FakePresenceConnection {
+      constructor(
+        options: {
+          onConnectionStatusChange?: (status: string, errorMessage?: string | null) => void;
+          onAuthFailure?: () => void;
+        },
+      ) {
+        setLastOptions(options);
+      }
+
+      connect() {
+        connectMock();
+      }
+
+      disconnect() {
+        disconnectMock();
+      }
+    },
+  };
+});
+
+describe('PresenceProvider', () => {
+  beforeEach(() => {
+    resetAuthStore();
+    resetPresenceStore();
+    connectMock.mockReset();
+    disconnectMock.mockReset();
+    publishPresenceStateMock.mockReset();
+    publishPresenceStateMock.mockResolvedValue(undefined);
+    resetLastOptions();
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false,
+    });
+  });
+
+  it('publishes online, afk and offline states through the real presence contract', async () => {
+    useAuthStore.getState().setSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+
+    render(
+      <PresenceProvider>
+        <div>content</div>
+      </PresenceProvider>,
+    );
+
+    await waitFor(() => {
+      expect(connectMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      getLastOptions()?.onConnectionStatusChange?.('connected', null);
+    });
+
+    expect(publishPresenceStateMock).toHaveBeenCalledWith({ status: 'ONLINE' });
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true,
+    });
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(publishPresenceStateMock).toHaveBeenCalledWith({ status: 'AFK' });
+
+    await act(async () => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(publishPresenceStateMock).toHaveBeenCalledWith(
+      {
+        status: 'OFFLINE',
+        platform: null,
+      },
+      { keepalive: true },
+    );
+  });
+
+  it('clears auth and presence state when realtime authentication fails', async () => {
+    useAuthStore.getState().setSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+    usePresenceStore.getState().setConnectionStatus('connected');
+    usePresenceStore.getState().upsertPresence(
+      {
+        userId: 'friend-1',
+        status: 'ONLINE',
+        currentGame: null,
+        platform: 'WEB',
+      },
+      123,
+    );
+
+    render(
+      <PresenceProvider>
+        <div>content</div>
+      </PresenceProvider>,
+    );
+
+    await act(async () => {
+      getLastOptions()?.onAuthFailure?.();
+    });
+
+    expect(useAuthStore.getState().status).toBe('unauthenticated');
+    expect(usePresenceStore.getState().connectionStatus).toBe('idle');
+    expect(usePresenceStore.getState().entries).toEqual({});
+  });
+});

--- a/frontend/tests/unit/services/presence.test.ts
+++ b/frontend/tests/unit/services/presence.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchPresenceCredential,
+  frontendPresencePlatform,
+  publishPresenceState,
   PresenceConnection,
   PresenceRequestError,
 } from '@/services/presence';
@@ -54,10 +56,19 @@ class FakeWebSocket {
   }
 }
 
+const { apiRequestMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: apiRequestMock,
+}));
+
 describe('presence service', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8080';
     vi.restoreAllMocks();
+    apiRequestMock.mockReset();
     vi.stubGlobal('WebSocket', { OPEN: FakeWebSocket.OPEN });
   });
 
@@ -80,6 +91,25 @@ describe('presence service', () => {
     );
 
     await expect(fetchPresenceCredential()).resolves.toBe('jwt-token');
+  });
+
+  it('publishes the authenticated presence state through the existing backend contract', async () => {
+    apiRequestMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    await publishPresenceState({
+      status: 'ONLINE',
+    });
+
+    expect(apiRequestMock).toHaveBeenCalledWith('/presence', {
+      method: 'POST',
+      body: {
+        status: 'ONLINE',
+        currentGame: null,
+        platform: frontendPresencePlatform,
+      },
+      keepalive: undefined,
+      clearSessionOnUnauthorized: false,
+    });
   });
 
   it('opens the websocket with the authenticated token and parses presence events', async () => {

--- a/frontend/tests/unit/services/session.test.ts
+++ b/frontend/tests/unit/services/session.test.ts
@@ -5,15 +5,23 @@ import { resetAuthStore, useAuthStore } from '@/store/auth-store';
 const { apiRequestMock } = vi.hoisted(() => ({
   apiRequestMock: vi.fn(),
 }));
+const { publishPresenceStateMock } = vi.hoisted(() => ({
+  publishPresenceStateMock: vi.fn(),
+}));
 
 vi.mock('@/lib/api', () => ({
   apiRequest: apiRequestMock,
+}));
+
+vi.mock('@/services/presence', () => ({
+  publishPresenceState: publishPresenceStateMock,
 }));
 
 describe('session service', () => {
   beforeEach(() => {
     resetAuthStore();
     apiRequestMock.mockReset();
+    publishPresenceStateMock.mockReset();
   });
 
   it('hydrates the session from the auth me contract', async () => {
@@ -72,9 +80,17 @@ describe('session service', () => {
     });
 
     apiRequestMock.mockResolvedValue(new Response(null, { status: 200 }));
+    publishPresenceStateMock.mockResolvedValue(undefined);
 
     await logoutAuthSession();
 
+    expect(publishPresenceStateMock).toHaveBeenCalledWith(
+      {
+        status: 'OFFLINE',
+        platform: null,
+      },
+      { keepalive: true },
+    );
     expect(apiRequestMock).toHaveBeenCalledWith('/auth/logout', {
       method: 'POST',
     });


### PR DESCRIPTION
## Resumo
Substitui o comportamento parcialmente implícito de presence no frontend por publicação real de estados usando o contrato já existente do backend. A mudança também evita que a UI trate dados stale do store como se fossem realtime quando a conexão WebSocket não está saudável.

## O que foi alterado
- Adiciona publicação de presença no frontend via `POST /presence`, usando os estados `ONLINE`, `AFK` e `OFFLINE`.
- Ajusta o lifecycle do hook de presence para publicar estado ao conectar, ao trocar visibilidade da aba e no encerramento da página/logout.
- Faz `FriendsList` e `GamerCard` aplicarem overlay de presença do store apenas quando a conexão está realmente `connected`.
- Expõe feedback mínimo do estado do realtime na lista de amigos.
- Amplia a cobertura de testes para serviços, provider e fallback de UI.

## Motivação
O frontend já consumia token e socket reais de presence, mas ainda não publicava a própria presença pelo contrato endurecido do backend. Isso deixava a experiência inconsistente e permitia que a UI mostrasse presença stale como se fosse atualização ao vivo.

## Como validar
- Executar em `frontend/`:
- `npm run test -- tests/unit/services/presence.test.ts tests/unit/services/session.test.ts tests/unit/components/presence-provider.test.tsx tests/unit/components/friends-list.test.tsx tests/unit/components/gamer-card.test.tsx`
- `npm run typecheck`
- `npm run lint`
- Com o stack rodando e sessão válida, abrir uma tela autenticada com amigos/perfil e verificar:
- presença entra em estado ativo após a conexão WebSocket estabilizar
- alternar a visibilidade da aba não quebra a sessão
- logout limpa a sessão e encerra a presença local
- se o realtime falhar, a UI volta ao snapshot do backend sem manter overlay stale

## Riscos e impactos
- O frontend passa a emitir `POST /presence` em eventos de conexão, visibilidade e saída de página; isso aumenta o tráfego de presence, mas dentro do contrato já existente.
- A issue não introduz publicação de estado `IN_GAME`; esse fluxo continua fora de escopo.
- O contrato de token em query string para `/ws/presence` permanece inalterado nesta PR.

## Evidências
- `npm run test -- tests/unit/services/presence.test.ts tests/unit/services/session.test.ts tests/unit/components/presence-provider.test.tsx tests/unit/components/friends-list.test.tsx tests/unit/components/gamer-card.test.tsx`
- `npm run typecheck`
- `npm run lint`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados