### PR TITLE
fix(frontend): reduzir ruído de hidratação e aumentar resiliência a extensões

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -25,8 +25,11 @@ type RootLayoutProps = Readonly<{
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
-    <html lang="en" className="dark">
-      <body className={`${bodyFont.variable} ${displayFont.variable}`}>
+    <html lang="en" className="dark" suppressHydrationWarning>
+      <body
+        className={`${bodyFont.variable} ${displayFont.variable}`}
+        suppressHydrationWarning
+      >
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/frontend/src/components/feed/comment-section.tsx
+++ b/frontend/src/components/feed/comment-section.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
+import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
 import { commentContentSchema, type PostComment } from '@/schemas/feed';
 import {
   createPostComment,
@@ -22,19 +23,6 @@ type CommentComposerProps = {
   disabled: boolean;
   onSubmit: (content: string) => Promise<void>;
 };
-
-function formatCommentDate(value: string): string {
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat('pt-BR', {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  }).format(date);
-}
 
 function resolveCommentAuthorName(comment: PostComment | PostComment['replies'][number]) {
   return comment.author.profile?.displayName && comment.author.profile.displayName.length > 0
@@ -132,7 +120,12 @@ function CommentItem({
           </div>
         </div>
 
-        <span className="text-xs text-secondary">{formatCommentDate(comment.createdAt)}</span>
+        <HydrationSafeTime
+          value={comment.createdAt}
+          options={{ dateStyle: 'short', timeStyle: 'short' }}
+          fallback={comment.createdAt}
+          className="text-xs text-secondary"
+        />
       </header>
 
       <p className="text-sm leading-6 text-primary">{comment.content}</p>
@@ -193,9 +186,12 @@ function CommentItem({
                     </div>
                   </div>
 
-                  <span className="text-xs text-secondary">
-                    {formatCommentDate(reply.createdAt)}
-                  </span>
+                  <HydrationSafeTime
+                    value={reply.createdAt}
+                    options={{ dateStyle: 'short', timeStyle: 'short' }}
+                    fallback={reply.createdAt}
+                    className="text-xs text-secondary"
+                  />
                 </header>
 
                 <p className="text-sm leading-6 text-primary">{reply.content}</p>

--- a/frontend/src/components/feed/post-card.tsx
+++ b/frontend/src/components/feed/post-card.tsx
@@ -8,6 +8,7 @@ import { Card } from '@/components/ui/card';
 import { CommentSection } from '@/components/feed/comment-section';
 import { GameContextBadge } from '@/components/feed/game-context-badge';
 import { ReactionBar } from '@/components/feed/reaction-bar';
+import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
 import { useAuth } from '@/hooks/use-auth';
 import { type FeedPost } from '@/schemas/feed';
 import { deletePost, FeedRequestError } from '@/services/feed';
@@ -15,19 +16,6 @@ import { deletePost, FeedRequestError } from '@/services/feed';
 type PostCardProps = {
   post: FeedPost;
 };
-
-function formatPostDate(value: string): string {
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat('pt-BR', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(date);
-}
 
 export function PostCard({ post }: PostCardProps) {
   const queryClient = useQueryClient();
@@ -104,7 +92,11 @@ export function PostCard({ post }: PostCardProps) {
 
         <footer className="space-y-3 border-t border-border/70 pt-4">
           <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-secondary">
-            <span>{formatPostDate(post.createdAt)}</span>
+            <HydrationSafeTime
+              value={post.createdAt}
+              options={{ dateStyle: 'medium', timeStyle: 'short' }}
+              fallback={post.createdAt}
+            />
             {isOwnPost ? (
               <Button
                 size="sm"

--- a/frontend/src/components/friends/friend-request-card.tsx
+++ b/frontend/src/components/friends/friend-request-card.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Avatar } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
 import { type PendingFriendRequest } from '@/schemas/friends';
 import {
   acceptFriendRequest,
@@ -14,19 +15,6 @@ type FriendRequestCardProps = {
   request: PendingFriendRequest;
   receiverUserId: string;
 };
-
-function formatCreatedAt(value: string): string {
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat('pt-BR', {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  }).format(date);
-}
 
 export function FriendRequestCard({
   request,
@@ -75,7 +63,12 @@ export function FriendRequestCard({
             <p className="truncate text-sm font-semibold text-primary">{senderName}</p>
             <p className="truncate text-xs text-secondary">@{request.sender.username}</p>
             <p className="mt-2 text-xs text-secondary">
-              Pedido enviado em {formatCreatedAt(request.createdAt)}
+              Pedido enviado em{' '}
+              <HydrationSafeTime
+                value={request.createdAt}
+                options={{ dateStyle: 'short', timeStyle: 'short' }}
+                fallback={request.createdAt}
+              />
             </p>
           </div>
         </div>

--- a/frontend/src/components/library/game-card.tsx
+++ b/frontend/src/components/library/game-card.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
+import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
 
 export type LibraryGameRecord = {
   gameName: string;
@@ -22,24 +23,6 @@ function formatHoursPlayed(hoursPlayed: number | null): string {
   const roundedHours = Math.max(0, Math.round(hoursPlayed));
 
   return `${roundedHours}h jogadas`;
-}
-
-function formatLastPlayedAt(lastPlayedAt: string | null): string {
-  if (!lastPlayedAt) {
-    return 'Sem atividade recente';
-  }
-
-  const parsedDate = new Date(lastPlayedAt);
-
-  if (Number.isNaN(parsedDate.getTime())) {
-    return 'Sem atividade recente';
-  }
-
-  return new Intl.DateTimeFormat('pt-BR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  }).format(parsedDate);
 }
 
 export function GameCard({ game }: GameCardProps) {
@@ -72,7 +55,16 @@ export function GameCard({ game }: GameCardProps) {
         </div>
 
         <p className="text-xs uppercase tracking-[0.24em] text-secondary">
-          Ultima atividade: {formatLastPlayedAt(game.lastPlayedAt)}
+          Ultima atividade:{' '}
+          {game.lastPlayedAt ? (
+            <HydrationSafeTime
+              value={game.lastPlayedAt}
+              options={{ day: '2-digit', month: '2-digit', year: 'numeric' }}
+              fallback="Sem atividade recente"
+            />
+          ) : (
+            'Sem atividade recente'
+          )}
         </p>
       </div>
     </Card>

--- a/frontend/src/components/notifications/notification-item.tsx
+++ b/frontend/src/components/notifications/notification-item.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
 import {
   friendAcceptedNotificationPayloadSchema,
   friendRequestNotificationPayloadSchema,
@@ -28,13 +29,6 @@ type NotificationPresentation = {
   ctaHref?: string;
   ctaLabel?: string;
 };
-
-function formatNotificationDate(createdAt: string): string {
-  return new Intl.DateTimeFormat('pt-BR', {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  }).format(new Date(createdAt));
-}
 
 function getNotificationPresentation(
   notification: NotificationRecord,
@@ -146,9 +140,12 @@ export function NotificationItem({
         </div>
 
         <div className="flex flex-col items-end gap-2">
-          <span className="text-xs uppercase tracking-[0.24em] text-secondary">
-            {formatNotificationDate(notification.createdAt)}
-          </span>
+          <HydrationSafeTime
+            value={notification.createdAt}
+            options={{ dateStyle: 'short', timeStyle: 'short' }}
+            fallback={notification.createdAt}
+            className="text-xs uppercase tracking-[0.24em] text-secondary"
+          />
           <Badge tone={notification.isRead ? 'neutral' : 'accent'}>
             {notification.isRead ? 'Lida' : 'Nao lida'}
           </Badge>

--- a/frontend/src/components/ui/hydration-safe-time.tsx
+++ b/frontend/src/components/ui/hydration-safe-time.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type HydrationSafeTimeProps = {
+  value: string;
+  locale?: string;
+  options: Intl.DateTimeFormatOptions;
+  fallback?: string;
+  className?: string;
+};
+
+function parseDate(value: string): Date | null {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function formatDate(
+  value: Date,
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(value);
+}
+
+export function HydrationSafeTime({
+  value,
+  locale = 'pt-BR',
+  options,
+  fallback,
+  className,
+}: HydrationSafeTimeProps) {
+  const [hydrated, setHydrated] = useState(false);
+  const parsedDate = useMemo(() => parseDate(value), [value]);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!parsedDate) {
+    const safeFallback = fallback ?? value;
+
+    return (
+      <time suppressHydrationWarning className={className}>
+        {safeFallback}
+      </time>
+    );
+  }
+
+  const initialLabel = formatDate(parsedDate, locale, {
+    ...options,
+    timeZone: 'UTC',
+  });
+  const hydratedLabel = hydrated ? formatDate(parsedDate, locale, options) : initialLabel;
+
+  return (
+    <time
+      suppressHydrationWarning
+      className={className}
+      dateTime={parsedDate.toISOString()}
+    >
+      {hydratedLabel}
+    </time>
+  );
+}

--- a/frontend/tests/unit/components/hydration-safe-time.test.tsx
+++ b/frontend/tests/unit/components/hydration-safe-time.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
+
+describe('HydrationSafeTime', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders deterministic UTC content on the server and localizes after hydration', async () => {
+    const formatterSpy = vi
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation(((_locale?: string, options?: Intl.DateTimeFormatOptions) => {
+        const timezone = options?.timeZone ?? 'LOCAL';
+
+        return {
+          format: () => `formatted:${timezone}`,
+        } as Intl.DateTimeFormat;
+      }) as typeof Intl.DateTimeFormat);
+
+    const markup = renderToStaticMarkup(
+      <HydrationSafeTime
+        value="2026-04-09T12:00:00.000Z"
+        options={{ dateStyle: 'short', timeStyle: 'short' }}
+      />,
+    );
+
+    expect(markup).toContain('formatted:UTC');
+
+    render(
+      <HydrationSafeTime
+        value="2026-04-09T12:00:00.000Z"
+        options={{ dateStyle: 'short', timeStyle: 'short' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('formatted:LOCAL')).toBeInTheDocument();
+    });
+
+    expect(formatterSpy).toHaveBeenCalled();
+  });
+
+  it('falls back safely when the date is invalid', () => {
+    render(
+      <HydrationSafeTime
+        value="data-invalida"
+        fallback="Sem data valida"
+        options={{ dateStyle: 'short' }}
+      />,
+    );
+
+    expect(screen.getByText('Sem data valida')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Resumo
Reduz causas próprias de hydration mismatch nos fluxos principais do frontend e adiciona tolerância explícita a mutações externas em `html` e `body`. A mudança foca em renderização determinística de datas no SSR e localização apenas após a hidratação.

## O que foi alterado
- Adiciona o componente reutilizável `HydrationSafeTime` para renderizar datas de forma estável no primeiro paint.
- Substitui formatação direta de data/hora em feed, comentários, notificações, pedidos de amizade e cards da library.
- Adiciona `suppressHydrationWarning` em `html` e `body` para reduzir ruído gerado por extensões que mutam o DOM fora do controle do app.
- Inclui teste unitário focado no comportamento determinístico de hidratação do novo componente.

## Motivação
A auditoria dos fluxos principais mostrou uma causa própria plausível para mismatch: datas formatadas com `Intl.DateTimeFormat` no primeiro render, sujeitas a divergência entre SSR e browser. Além disso, o ambiente real pode ter extensões alterando `html` e `body`, o que gera ruído inevitável que não deve degradar a app além do necessário.

## Como validar
- Executar em `frontend/`:
- `npm run test -- tests/unit/components/hydration-safe-time.test.tsx`
- `npm run test -- tests/unit/components/comment-section.test.tsx tests/unit/components/notification-item.test.tsx tests/unit/components/friend-request-card.test.tsx tests/unit/components/library-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- Validar manualmente os fluxos principais em browser:
- `/feed`
- `/notifications`
- `/:username`
- `/:username/library`
- Confirmar que textos de data renderizam sem mismatch visível e que mutações externas em `html/body` não travam a interface.

## Riscos e impactos
- O conteúdo de data/hora passa a usar um fallback determinístico em UTC no primeiro render e localiza após a hidratação; isso pode mudar levemente o texto inicial antes do hydration, mas evita mismatch estrutural.
- `suppressHydrationWarning` em `html/body` reduz ruído de mutações externas, mas não elimina problemas causados por extensões que injetem DOM arbitrário depois da hidratação.
- A PR não tenta “corrigir” extensões externas nem cobre todas as superfícies do produto; ela trata os pontos auditados desta issue.

## Evidências
- `npm run test -- tests/unit/components/hydration-safe-time.test.tsx`
- `npm run test -- tests/unit/components/comment-section.test.tsx tests/unit/components/notification-item.test.tsx tests/unit/components/friend-request-card.test.tsx tests/unit/components/library-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados