### PR TITLE
feat(frontend): fortalecer UX mínima dos fluxos principais do produto

### DIFF
--- a/frontend/src/components/friends/friend-button.tsx
+++ b/frontend/src/components/friends/friend-button.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toaster';
 import { useAuth } from '@/hooks/use-auth';
 import {
   acceptFriendRequest,
@@ -19,6 +20,7 @@ type FriendButtonProps = {
 
 export function FriendButton({ targetUserId }: FriendButtonProps) {
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const { user, status } = useAuth();
   const currentUserId = user?.id ?? null;
   const [localPending, setLocalPending] = useState(false);
@@ -72,12 +74,31 @@ export function FriendButton({ targetUserId }: FriendButtonProps) {
     mutationFn: sendFriendRequest,
     onSuccess: async () => {
       setLocalPending(true);
+      showToast({
+        title: 'Pedido enviado',
+        description: 'O usuario foi notificado sobre o convite de amizade.',
+        tone: 'success',
+      });
       await commonSuccessHandler();
     },
     onError: (error) => {
       if (error instanceof FriendsRequestError && error.status === 409) {
         setLocalPending(true);
+        showToast({
+          title: 'Pedido ja existente',
+          description: error.message,
+          tone: 'info',
+        });
+        return;
       }
+
+      showToast({
+        title: 'Nao foi possivel enviar o pedido',
+        description: error instanceof FriendsRequestError
+          ? error.message
+          : 'Tente novamente em alguns instantes.',
+        tone: 'error',
+      });
     },
   });
 
@@ -85,7 +106,21 @@ export function FriendButton({ targetUserId }: FriendButtonProps) {
     mutationFn: acceptFriendRequest,
     onSuccess: async () => {
       setLocalPending(false);
+      showToast({
+        title: 'Amizade confirmada',
+        description: 'A amizade foi aceita com sucesso.',
+        tone: 'success',
+      });
       await commonSuccessHandler();
+    },
+    onError: (error) => {
+      showToast({
+        title: 'Nao foi possivel aceitar o pedido',
+        description: error instanceof FriendsRequestError
+          ? error.message
+          : 'Tente novamente em alguns instantes.',
+        tone: 'error',
+      });
     },
   });
 
@@ -93,7 +128,21 @@ export function FriendButton({ targetUserId }: FriendButtonProps) {
     mutationFn: removeFriend,
     onSuccess: async () => {
       setLocalPending(false);
+      showToast({
+        title: 'Amizade removida',
+        description: 'O perfil voltou a ficar fora da sua lista de amigos.',
+        tone: 'success',
+      });
       await commonSuccessHandler();
+    },
+    onError: (error) => {
+      showToast({
+        title: 'Nao foi possivel remover a amizade',
+        description: error instanceof FriendsRequestError
+          ? error.message
+          : 'Tente novamente em alguns instantes.',
+        tone: 'error',
+      });
     },
   });
 

--- a/frontend/src/components/friends/friend-request-card.tsx
+++ b/frontend/src/components/friends/friend-request-card.tsx
@@ -5,6 +5,7 @@ import { Avatar } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
+import { useToast } from '@/components/ui/toaster';
 import { type PendingFriendRequest } from '@/schemas/friends';
 import {
   acceptFriendRequest,
@@ -21,6 +22,7 @@ export function FriendRequestCard({
   receiverUserId,
 }: FriendRequestCardProps) {
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const senderName =
     request.sender.profile?.displayName && request.sender.profile.displayName.length > 0
       ? request.sender.profile.displayName
@@ -30,6 +32,11 @@ export function FriendRequestCard({
   const acceptMutation = useMutation({
     mutationFn: acceptFriendRequest,
     onSuccess: async () => {
+      showToast({
+        title: 'Pedido aceito',
+        description: 'A amizade ja pode aparecer nas superfices sociais do app.',
+        tone: 'success',
+      });
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: ['friend-requests', receiverUserId],
@@ -41,6 +48,15 @@ export function FriendRequestCard({
           queryKey: ['profile'],
         }),
       ]);
+    },
+    onError: (error) => {
+      showToast({
+        title: 'Nao foi possivel aceitar o pedido',
+        description: error instanceof FriendsRequestError
+          ? error.message
+          : 'Tente novamente em alguns instantes.',
+        tone: 'error',
+      });
     },
   });
 

--- a/frontend/src/components/notifications/notifications-page-content.tsx
+++ b/frontend/src/components/notifications/notifications-page-content.tsx
@@ -5,11 +5,13 @@ import { NotificationItem } from '@/components/notifications/notification-item';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { SectionHeading } from '@/components/ui/section-heading';
+import { useToast } from '@/components/ui/toaster';
 import { useAuth } from '@/hooks/use-auth';
 import {
   fetchNotifications,
   markAllNotificationsAsRead,
   markNotificationAsRead,
+  NotificationsRequestError,
 } from '@/services/notifications';
 
 function NotificationsLoadingState() {
@@ -61,6 +63,7 @@ function NotificationsEmptyState() {
 
 export function NotificationsPageContent() {
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const { status, user } = useAuth();
   const userId = user?.id;
 
@@ -81,14 +84,46 @@ export function NotificationsPageContent() {
   const markOneMutation = useMutation({
     mutationFn: markNotificationAsRead,
     onSuccess: async () => {
+      showToast({
+        title: 'Notificacao atualizada',
+        description: 'A notificacao foi marcada como lida.',
+        tone: 'success',
+      });
       await invalidateNotifications();
+    },
+    onError: (error) => {
+      const description = error instanceof NotificationsRequestError
+        ? error.message
+        : 'Tente novamente em alguns instantes.';
+
+      showToast({
+        title: 'Nao foi possivel atualizar a notificacao',
+        description,
+        tone: 'error',
+      });
     },
   });
 
   const markAllMutation = useMutation({
     mutationFn: markAllNotificationsAsRead,
     onSuccess: async () => {
+      showToast({
+        title: 'Inbox atualizado',
+        description: 'Todas as notificacoes foram marcadas como lidas.',
+        tone: 'success',
+      });
       await invalidateNotifications();
+    },
+    onError: (error) => {
+      const description = error instanceof NotificationsRequestError
+        ? error.message
+        : 'Tente novamente em alguns instantes.';
+
+      showToast({
+        title: 'Nao foi possivel limpar o inbox',
+        description,
+        tone: 'error',
+      });
     },
   });
 

--- a/frontend/tests/unit/components/friend-button.test.tsx
+++ b/frontend/tests/unit/components/friend-button.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FriendButton } from '@/components/friends/friend-button';
+import { ToastProvider } from '@/components/ui/toaster';
 import { useAuth } from '@/hooks/use-auth';
 import {
   acceptFriendRequest,
@@ -49,9 +50,11 @@ function renderFriendButton(targetUserId = 'user-2') {
   });
 
   render(
-    <QueryClientProvider client={queryClient}>
-      <FriendButton targetUserId={targetUserId} />
-    </QueryClientProvider>,
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>
+        <FriendButton targetUserId={targetUserId} />
+      </QueryClientProvider>
+    </ToastProvider>,
   );
 }
 
@@ -99,6 +102,7 @@ describe('FriendButton', () => {
     expect(mockedSendFriendRequest.mock.calls[0]?.[0]).toBe('user-2');
 
     expect(await screen.findByRole('button', { name: /pedido enviado/i })).toBeDisabled();
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(/pedido enviado/i);
   });
 
   it('accepts an incoming request state', async () => {
@@ -126,6 +130,7 @@ describe('FriendButton', () => {
       expect(mockedAcceptFriendRequest).toHaveBeenCalled();
     });
     expect(mockedAcceptFriendRequest.mock.calls[0]?.[0]).toBe('request-1');
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(/amizade confirmada/i);
   });
 
   it('renders the friend state and removes friendship', async () => {
@@ -156,5 +161,6 @@ describe('FriendButton', () => {
       expect(mockedRemoveFriend).toHaveBeenCalled();
     });
     expect(mockedRemoveFriend.mock.calls[0]?.[0]).toBe('user-2');
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(/amizade removida/i);
   });
 });

--- a/frontend/tests/unit/components/friend-request-card.test.tsx
+++ b/frontend/tests/unit/components/friend-request-card.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FriendRequestCard } from '@/components/friends/friend-request-card';
+import { ToastProvider } from '@/components/ui/toaster';
 import { acceptFriendRequest } from '@/services/friends';
 
 vi.mock('@/services/friends', () => ({
@@ -29,23 +30,25 @@ function renderFriendRequestCard() {
   });
 
   render(
-    <QueryClientProvider client={queryClient}>
-      <FriendRequestCard
-        receiverUserId="user-1"
-        request={{
-          id: 'request-1',
-          createdAt: '2026-03-31T10:00:00.000Z',
-          sender: {
-            id: 'user-2',
-            username: 'pixelsamurai',
-            profile: {
-              displayName: 'Pixel Samurai',
-              avatarUrl: null,
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>
+        <FriendRequestCard
+          receiverUserId="user-1"
+          request={{
+            id: 'request-1',
+            createdAt: '2026-03-31T10:00:00.000Z',
+            sender: {
+              id: 'user-2',
+              username: 'pixelsamurai',
+              profile: {
+                displayName: 'Pixel Samurai',
+                avatarUrl: null,
+              },
             },
-          },
-        }}
-      />
-    </QueryClientProvider>,
+          }}
+        />
+      </QueryClientProvider>
+    </ToastProvider>,
   );
 }
 
@@ -65,5 +68,6 @@ describe('FriendRequestCard', () => {
       expect(mockedAcceptFriendRequest).toHaveBeenCalled();
     });
     expect(mockedAcceptFriendRequest.mock.calls[0]?.[0]).toBe('request-1');
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(/pedido aceito/i);
   });
 });

--- a/frontend/tests/unit/components/notifications-page-content.test.tsx
+++ b/frontend/tests/unit/components/notifications-page-content.test.tsx
@@ -3,9 +3,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationsPageContent } from '@/components/notifications/notifications-page-content';
+import { ToastProvider } from '@/components/ui/toaster';
 import { useAuth } from '@/hooks/use-auth';
 import {
   fetchNotifications,
+  NotificationsRequestError,
   markAllNotificationsAsRead,
   markNotificationAsRead,
 } from '@/services/notifications';
@@ -18,6 +20,15 @@ vi.mock('@/services/notifications', () => ({
   fetchNotifications: vi.fn(),
   markNotificationAsRead: vi.fn(),
   markAllNotificationsAsRead: vi.fn(),
+  NotificationsRequestError: class NotificationsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'NotificationsRequestError';
+      this.status = status;
+    }
+  },
 }));
 
 const mockedUseAuth = vi.mocked(useAuth);
@@ -34,7 +45,9 @@ function renderWithQuery(ui: ReactElement) {
   });
 
   return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </ToastProvider>,
   );
 }
 
@@ -96,6 +109,8 @@ describe('NotificationsPageContent', () => {
     await waitFor(() => {
       expect(mockedMarkAllNotificationsAsRead).toHaveBeenCalled();
     });
+
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(/inbox atualizado/i);
   });
 
   it('marks a single notification as read from the list', async () => {
@@ -147,6 +162,47 @@ describe('NotificationsPageContent', () => {
     });
 
     expect(mockedMarkNotificationAsRead.mock.calls[0]?.[0]).toBe('notification-1');
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(/notificacao atualizada/i);
+  });
+
+  it('renders toast feedback when marking all as read fails', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'notification-1',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'POST_LIKE',
+          payload: {
+            postId: 'post-1',
+            interactionType: 'GG',
+          },
+          isRead: false,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        },
+      ],
+      unreadCount: 1,
+    });
+    mockedMarkAllNotificationsAsRead.mockRejectedValue(
+      new NotificationsRequestError(503, 'Inbox temporariamente indisponivel.'),
+    );
+
+    renderWithQuery(<NotificationsPageContent />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /marcar todas como lidas/i }));
+
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(
+      /nao foi possivel limpar o inbox/i,
+    );
   });
 
   it('renders empty state when there are no notifications', async () => {


### PR DESCRIPTION
## Resumo
Esta PR fortalece a UX mínima em ações centrais de notificações e amizade, adicionando feedback visível de sucesso e erro sem alterar contratos nem ampliar o escopo da foundation global já entregue em `#103`.
A mudança elimina interações silenciosas nesses fluxos e torna o comportamento mais previsível para o usuário.

## O que foi alterado
- Adição de feedback toast de sucesso e erro nas ações de notificações.
- Adição de feedback toast de sucesso e erro nas ações principais de amizade.
- Atualização dos testes unitários para cobrir os novos estados de feedback.

## Motivação
A issue `#187` pede fortalecimento da UX mínima dos fluxos principais do produto. O inventário mostrou que feed, loading global, erro global e estados vazios já estavam cobertos, mas notificações e amizade ainda executavam ações importantes sem confirmação visível consistente.

## Como validar
- Executar `npm run test -- tests/unit/components/notifications-page-content.test.tsx tests/unit/components/friend-button.test.tsx tests/unit/components/friend-request-card.test.tsx` em `frontend/`.
- Executar `npm run typecheck` em `frontend/`.
- Executar `npm run lint` em `frontend/`.
- Com o app autenticado, validar que marcar notificações como lidas exibe feedback visível.
- Com o app autenticado, validar que enviar, aceitar e remover amizade exibem feedback visível.

## Riscos e impactos
- O risco técnico é baixo e localizado ao frontend, porque a lógica de invalidação e os contratos existentes não foram alterados.
- A PR não cobre todos os fluxos do produto; ela fecha apenas os gaps objetivos de feedback mínimo identificados em notificações e amizade.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #187