### PR TITLE
feat(integrations): melhorar UX de busca e seleção de resultados do IGDB

### DIFF
--- a/backend/src/api/routes/integrations.routes.ts
+++ b/backend/src/api/routes/integrations.routes.ts
@@ -98,10 +98,8 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
       if (!q || q.trim().length < 2) return reply.status(400).send({ message: 'Query deve ter pelo menos 2 caracteres.' });
 
       try {
-        const game = await app.integrationsService.searchIgdbGame(q.trim());
-        if (!game) return reply.status(404).send({ message: 'Jogo não encontrado.' });
-
-        return reply.status(200).send(game);
+        const games = await app.integrationsService.searchIgdbGames(q.trim());
+        return reply.status(200).send({ games });
       } catch (error) {
         const integrationError = replyWithIntegrationError(request, error);
         return reply.status(integrationError.statusCode).send(integrationError.payload);

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -23,7 +23,7 @@ type PersistIntegrationInput = {
 };
 
 type SteamIntegrationClient = Pick<typeof steamService, 'validateSteamId' | 'getOwnedGames'>;
-type IgdbIntegrationClient = Pick<typeof igdbService, 'searchGame'>;
+type IgdbIntegrationClient = Pick<typeof igdbService, 'searchGame' | 'searchGames'>;
 type EpicIntegrationClient = Pick<typeof epicService, 'validateToken' | 'getLibrary'>;
 
 type IntegrationsPersistence = {
@@ -177,7 +177,7 @@ export function createIntegrationsService(dependencies?: {
 }): {
   connectSteam: (userId: string, steamId: string) => Promise<{ imported: number; message: string }>;
   syncSteamLibrary: (userId: string) => Promise<{ synced: number; message: string }>;
-  searchIgdbGame: (query: string) => Promise<IgdbGame | null>;
+  searchIgdbGames: (query: string) => Promise<IgdbGame[]>;
   connectEpic: (userId: string, authToken: string) => Promise<{ imported: number; message: string }>;
 } {
   const steamClient = dependencies?.steamClient ?? steamService;
@@ -237,8 +237,8 @@ export function createIntegrationsService(dependencies?: {
       };
     },
 
-    async searchIgdbGame(query: string): Promise<IgdbGame | null> {
-      return igdbClient.searchGame(query);
+    async searchIgdbGames(query: string): Promise<IgdbGame[]> {
+      return igdbClient.searchGames(query, 5);
     },
 
     async connectEpic(userId: string, authToken: string): Promise<{ imported: number; message: string }> {

--- a/backend/src/infra/integrations/igdb/igdb.service.ts
+++ b/backend/src/infra/integrations/igdb/igdb.service.ts
@@ -47,6 +47,14 @@ export interface IgdbGame {
   summary:  string | null;
 }
 
+type IgdbApiGame = {
+  id: number;
+  name: string;
+  cover?: { id: number; url: string };
+  platforms?: Array<{ name: string }>;
+  summary?: string;
+};
+
 async function getAccessToken(): Promise<string> {
   const cached = await redis.get(TOKEN_REDIS_KEY);
   if (cached) return cached;
@@ -80,29 +88,16 @@ async function getAccessToken(): Promise<string> {
 }
 
 export const igdbService = {
-
-  async searchGame(name: string): Promise<IgdbGame | null> {
+  async searchGames(name: string, limit = 5): Promise<IgdbGame[]> {
     const token = await getAccessToken();
     const credentials = resolveIgdbCredentials();
 
-    let response: { data: Array<{
-      id: number;
-      name: string;
-      cover?: { id: number; url: string };
-      platforms?: Array<{ name: string }>;
-      summary?: string;
-    }> };
+    let response: { data: IgdbApiGame[] };
 
     try {
-      response = await axios.post<Array<{
-        id: number;
-        name: string;
-        cover?: { id: number; url: string };
-        platforms?: Array<{ name: string }>;
-        summary?: string;
-      }>>(
+      response = await axios.post<IgdbApiGame[]>(
         `${IGDB_BASE_URL}/games`,
-        `search "${name}"; fields name,cover.url,platforms.name,summary; limit 1;`,
+        `search "${name}"; fields name,cover.url,platforms.name,summary; limit ${limit};`,
         {
           headers: {
             'Client-ID': credentials.clientId,
@@ -121,18 +116,20 @@ export const igdbService = {
       );
     }
 
-    const game = response.data[0];
-    if (!game) return null;
-
-    return {
-      id:        game.id,
-      name:      game.name,
-      coverUrl:  game.cover?.url
+    return response.data.map((game) => ({
+      id: game.id,
+      name: game.name,
+      coverUrl: game.cover?.url
         ? `https:${game.cover.url.replace('t_thumb', 't_cover_big')}`
         : null,
-      platforms: game.platforms?.map((p) => p.name) ?? [],
-      summary:   game.summary ?? null,
-    };
+      platforms: game.platforms?.map((platform) => platform.name) ?? [],
+      summary: game.summary ?? null,
+    }));
+  },
+
+  async searchGame(name: string): Promise<IgdbGame | null> {
+    const games = await this.searchGames(name, 1);
+    return games[0] ?? null;
   },
 
   async getGameById(igdbId: number): Promise<IgdbGame | null> {

--- a/backend/tests/integration/routes/integrations.routes.test.ts
+++ b/backend/tests/integration/routes/integrations.routes.test.ts
@@ -8,7 +8,7 @@ import {
 const createMockIntegrationsService = () => ({
   connectSteam: vi.fn(),
   syncSteamLibrary: vi.fn(),
-  searchIgdbGame: vi.fn(),
+  searchIgdbGames: vi.fn(),
   connectEpic: vi.fn(),
 });
 
@@ -117,13 +117,13 @@ describe('Integrations Routes', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(integrationsService.searchIgdbGame).not.toHaveBeenCalled();
+      expect(integrationsService.searchIgdbGames).not.toHaveBeenCalled();
       await app.close();
     });
 
-    it('retorna 404 quando jogo nao e encontrado', async () => {
+    it('retorna lista vazia quando nenhum candidato e encontrado', async () => {
       const integrationsService = createMockIntegrationsService();
-      integrationsService.searchIgdbGame.mockResolvedValue(null);
+      integrationsService.searchIgdbGames.mockResolvedValue([]);
       const app = await buildApp({ integrationsService });
 
       const response = await app.inject({
@@ -131,14 +131,50 @@ describe('Integrations Routes', () => {
         url: '/integrations/igdb/search?q=unknown-game',
       });
 
-      expect(response.statusCode).toBe(404);
-      expect(integrationsService.searchIgdbGame).toHaveBeenCalledWith('unknown-game');
+      expect(response.statusCode).toBe(200);
+      expect(integrationsService.searchIgdbGames).toHaveBeenCalledWith('unknown-game');
+      expect(response.json()).toEqual({ games: [] });
+      await app.close();
+    });
+
+    it('retorna multiplos candidatos quando o service encontra correspondencias ambiguas', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.searchIgdbGames.mockResolvedValue([
+        {
+          id: 1,
+          name: 'DOOM',
+          coverUrl: null,
+          platforms: ['PC'],
+          summary: 'Classic shooter',
+        },
+        {
+          id: 2,
+          name: 'DOOM Eternal',
+          coverUrl: null,
+          platforms: ['PC', 'PlayStation 5'],
+          summary: 'Modern shooter',
+        },
+      ]);
+      const app = await buildApp({ integrationsService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/integrations/igdb/search?q=DOOM',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        games: [
+          { name: 'DOOM' },
+          { name: 'DOOM Eternal' },
+        ],
+      });
       await app.close();
     });
 
     it('traduz timeout de IGDB para 504', async () => {
       const integrationsService = createMockIntegrationsService();
-      integrationsService.searchIgdbGame.mockRejectedValue(
+      integrationsService.searchIgdbGames.mockRejectedValue(
         createIntegrationError('igdb', 504, 'timeout', 'Integração IGDB indisponível no momento.'),
       );
       const app = await buildApp({ integrationsService });

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -52,6 +52,7 @@ describe('integrations service layer', () => {
         getOwnedGames: vi.fn().mockResolvedValue(mockSteamGames),
       },
       igdbClient: {
+        searchGames: vi.fn(),
         searchGame: vi.fn()
           .mockResolvedValueOnce({
             id: 730,
@@ -101,6 +102,7 @@ describe('integrations service layer', () => {
         getOwnedGames: vi.fn(),
       },
       igdbClient: {
+        searchGames: vi.fn(),
         searchGame: vi.fn(),
       },
       epicClient: {
@@ -128,6 +130,7 @@ describe('integrations service layer', () => {
         getOwnedGames: vi.fn(),
       },
       igdbClient: {
+        searchGames: vi.fn(),
         searchGame: vi.fn(),
       },
       epicClient: {
@@ -169,6 +172,7 @@ describe('integrations service layer', () => {
         getOwnedGames: vi.fn(),
       },
       igdbClient: {
+        searchGames: vi.fn(),
         searchGame: vi.fn(),
       },
       epicClient: {
@@ -228,6 +232,34 @@ describe('igdbService', () => {
 
     expect(result?.name).toBe('Valorant');
     expect(result?.coverUrl).toContain('t_cover_big');
+  });
+
+  it('retorna multiplos candidatos quando a consulta e ambigua', async () => {
+    vi.mocked(redis.get).mockResolvedValue('cached-token');
+    vi.mocked(axios.post).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          name: 'DOOM',
+          cover: { id: 1, url: '//images.igdb.com/igdb/image/upload/t_thumb/doom.jpg' },
+          platforms: [{ name: 'PC' }],
+          summary: 'Classic shooter',
+        },
+        {
+          id: 2,
+          name: 'DOOM Eternal',
+          cover: { id: 2, url: '//images.igdb.com/igdb/image/upload/t_thumb/doom-eternal.jpg' },
+          platforms: [{ name: 'PC' }, { name: 'PlayStation 5' }],
+          summary: 'Modern shooter',
+        },
+      ],
+    } as never);
+
+    const result = await igdbService.searchGames('DOOM', 5);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.name).toBe('DOOM');
+    expect(result[1]?.name).toBe('DOOM Eternal');
   });
 
   it('traduz timeout do IGDB para erro coerente', async () => {

--- a/frontend/src/components/settings/igdb-search-card.tsx
+++ b/frontend/src/components/settings/igdb-search-card.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
   igdbSearchRequestSchema,
+  type IgdbSearchGame,
   type IgdbSearchResponse,
   type IgdbSearchValues,
 } from '@/schemas/integrations';
@@ -17,6 +18,7 @@ import { IntegrationsRequestError, searchIgdbGame } from '@/services/integration
 
 export function IgdbSearchCard() {
   const [result, setResult] = useState<IgdbSearchResponse | null>(null);
+  const [selectedGameId, setSelectedGameId] = useState<number | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const {
@@ -36,9 +38,11 @@ export function IgdbSearchCard() {
     onSuccess: (response) => {
       setErrorMessage(null);
       setResult(response);
+      setSelectedGameId(response.games.length === 1 ? response.games[0]?.id ?? null : null);
     },
     onError: (error) => {
       setResult(null);
+      setSelectedGameId(null);
       setErrorMessage(
         error instanceof IntegrationsRequestError
           ? error.message
@@ -51,6 +55,44 @@ export function IgdbSearchCard() {
     await searchMutation.mutateAsync(values);
   });
 
+  const games = result?.games ?? [];
+  const selectedGame = selectedGameId === null
+    ? null
+    : games.find((game) => game.id === selectedGameId) ?? null;
+
+  const renderGamePreview = (game: IgdbSearchGame) => (
+    <Card className="space-y-4" tone="neutral">
+      <div className="flex items-start gap-4">
+        <Avatar
+          src={game.coverUrl}
+          alt={game.name}
+          fallback={game.name.slice(0, 2).toUpperCase()}
+          size="lg"
+          className="rounded-control"
+        />
+        <div className="space-y-2">
+          <h3 className="font-display text-xl font-semibold text-primary">
+            {game.name}
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {game.platforms.map((platform) => (
+              <Badge key={platform} tone="neutral">
+                {platform}
+              </Badge>
+            ))}
+            {game.platforms.length === 0 ? (
+              <Badge tone="neutral">Plataforma indisponivel</Badge>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-sm leading-6 text-secondary">
+        {game.summary || 'O backend nao retornou resumo para este candidato.'}
+      </p>
+    </Card>
+  );
+
   return (
     <Card className="space-y-5">
       <div className="space-y-2">
@@ -59,7 +101,7 @@ export function IgdbSearchCard() {
           Busca de jogos
         </h2>
         <p className="text-sm leading-6 text-secondary">
-          O contrato atual retorna um jogo por consulta, com capa e plataformas quando disponiveis.
+          Quando a consulta for ambigua, o contrato atual devolve uma lista curta de candidatos para selecao.
         </p>
       </div>
 
@@ -92,34 +134,78 @@ export function IgdbSearchCard() {
         </div>
       ) : null}
 
-      {result ? (
-        <Card className="space-y-4" tone="neutral">
-          <div className="flex items-start gap-4">
-            <Avatar
-              src={result.coverUrl}
-              alt={result.name}
-              fallback={result.name.slice(0, 2).toUpperCase()}
-              size="lg"
-              className="rounded-control"
-            />
-            <div className="space-y-2">
-              <h3 className="font-display text-xl font-semibold text-primary">
-                {result.name}
-              </h3>
-              <div className="flex flex-wrap gap-2">
-                {result.platforms.map((platform) => (
-                  <Badge key={platform} tone="neutral">
-                    {platform}
-                  </Badge>
-                ))}
-              </div>
+      {result && games.length === 0 ? (
+        <Card tone="neutral" data-testid="igdb-search-empty">
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-primary">Nenhum candidato encontrado</p>
+            <p className="text-sm leading-6 text-secondary">
+              Tente refinar o nome do jogo para encontrar um resultado mais preciso.
+            </p>
+          </div>
+        </Card>
+      ) : null}
+
+      {result && games.length > 1 ? (
+        <Card tone="neutral" data-testid="igdb-search-results">
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-primary">Possiveis resultados</p>
+              <p className="text-sm leading-6 text-secondary">
+                Escolha o candidato que melhor corresponde ao jogo que voce procura.
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              {games.map((game) => {
+                const isSelected = selectedGameId === game.id;
+
+                return (
+                  <button
+                    key={game.id}
+                    type="button"
+                    className={`w-full rounded-control border px-control-x py-control-y text-left transition ${
+                      isSelected
+                        ? 'border-accent-cyan bg-accent-cyan/10'
+                        : 'border-border bg-background-secondary hover:border-accent-cyan/60'
+                    }`}
+                    onClick={() => {
+                      setSelectedGameId(game.id);
+                    }}
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="space-y-1">
+                        <p className="text-sm font-semibold text-primary">{game.name}</p>
+                        <p className="text-xs text-secondary">
+                          {game.platforms.length > 0
+                            ? game.platforms.join(' • ')
+                            : 'Plataforma indisponivel'}
+                        </p>
+                      </div>
+                      <Badge tone={isSelected ? 'accent' : 'neutral'}>
+                        {isSelected ? 'Selecionado' : 'Selecionar'}
+                      </Badge>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           </div>
-
-          <p className="text-sm leading-6 text-secondary">
-            {result.summary || 'O backend nao retornou resumo para esta busca.'}
-          </p>
         </Card>
+      ) : null}
+
+      {selectedGame ? (
+        <div data-testid="igdb-search-selected">
+          <p className="mb-3 text-sm font-medium text-primary">
+            Resultado selecionado
+          </p>
+          {renderGamePreview(selectedGame)}
+        </div>
+      ) : null}
+
+      {result && games.length === 1 && selectedGame ? (
+        <div className="rounded-control border border-status-online/25 bg-[rgba(16,185,129,0.08)] px-control-x py-control-y text-sm text-primary">
+          Busca direta concluida com um candidato unico.
+        </div>
       ) : null}
     </Card>
   );

--- a/frontend/src/schemas/integrations.ts
+++ b/frontend/src/schemas/integrations.ts
@@ -42,12 +42,16 @@ export const igdbSearchRequestSchema = z.object({
     .min(2, 'Digite pelo menos 2 caracteres para buscar no IGDB.'),
 });
 
-export const igdbSearchResponseSchema = z.object({
+export const igdbSearchGameSchema = z.object({
   id: z.number().int(),
   name: z.string().min(1),
   coverUrl: z.string().nullable(),
   platforms: z.array(z.string()),
   summary: z.string().nullable(),
+});
+
+export const igdbSearchResponseSchema = z.object({
+  games: z.array(igdbSearchGameSchema),
 });
 
 export type SteamConnectValues = z.infer<typeof steamConnectRequestSchema>;
@@ -58,4 +62,5 @@ export type EpicConnectResponse = z.infer<typeof epicConnectResponseSchema>;
 export type DiscordOAuthStartResponse = z.infer<typeof discordOAuthStartResponseSchema>;
 export type DiscordOAuthCallbackResponse = z.infer<typeof discordOAuthCallbackResponseSchema>;
 export type IgdbSearchValues = z.infer<typeof igdbSearchRequestSchema>;
+export type IgdbSearchGame = z.infer<typeof igdbSearchGameSchema>;
 export type IgdbSearchResponse = z.infer<typeof igdbSearchResponseSchema>;

--- a/frontend/tests/unit/components/igdb-search-card.test.tsx
+++ b/frontend/tests/unit/components/igdb-search-card.test.tsx
@@ -42,11 +42,15 @@ describe('IgdbSearchCard', () => {
 
   it('searches igdb and renders the returned game', async () => {
     mockedSearchIgdbGame.mockResolvedValue({
-      id: 730,
-      name: 'Counter-Strike 2',
-      coverUrl: 'https://images.ct2.jpg',
-      platforms: ['PC'],
-      summary: 'Competitive FPS',
+      games: [
+        {
+          id: 730,
+          name: 'Counter-Strike 2',
+          coverUrl: 'https://images.ct2.jpg',
+          platforms: ['PC'],
+          summary: 'Competitive FPS',
+        },
+      ],
     });
 
     renderIgdbSearchCard();
@@ -62,5 +66,58 @@ describe('IgdbSearchCard', () => {
 
     expect(await screen.findByText(/counter-strike 2/i)).toBeInTheDocument();
     expect(screen.getByText(/competitive fps/i)).toBeInTheDocument();
+    expect(screen.getByText(/busca direta concluida com um candidato unico/i)).toBeInTheDocument();
+  });
+
+  it('renders multiple candidates and lets the user select one explicitly', async () => {
+    mockedSearchIgdbGame.mockResolvedValue({
+      games: [
+        {
+          id: 1,
+          name: 'DOOM',
+          coverUrl: null,
+          platforms: ['PC'],
+          summary: 'Classic shooter',
+        },
+        {
+          id: 2,
+          name: 'DOOM Eternal',
+          coverUrl: null,
+          platforms: ['PC', 'PlayStation 5'],
+          summary: 'Modern shooter',
+        },
+      ],
+    });
+
+    renderIgdbSearchCard();
+
+    fireEvent.change(screen.getByLabelText(/nome do jogo/i), {
+      target: { value: 'DOOM' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /buscar no igdb/i }));
+
+    expect(await screen.findByTestId('igdb-search-results')).toBeInTheDocument();
+    expect(screen.getByText(/possiveis resultados/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('igdb-search-selected')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /doom eternal/i }));
+
+    expect(await screen.findByTestId('igdb-search-selected')).toBeInTheDocument();
+    expect(screen.getByText(/modern shooter/i)).toBeInTheDocument();
+  });
+
+  it('renders an honest empty state when the backend returns no candidates', async () => {
+    mockedSearchIgdbGame.mockResolvedValue({
+      games: [],
+    });
+
+    renderIgdbSearchCard();
+
+    fireEvent.change(screen.getByLabelText(/nome do jogo/i), {
+      target: { value: 'Unknown Game' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /buscar no igdb/i }));
+
+    expect(await screen.findByTestId('igdb-search-empty')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/services/integrations.test.ts
+++ b/frontend/tests/unit/services/integrations.test.ts
@@ -130,11 +130,15 @@ describe('integrations service', () => {
     mockedApiRequest.mockResolvedValue(
       new Response(
         JSON.stringify({
-          id: 730,
-          name: 'Counter-Strike 2',
-          coverUrl: 'https://images.ct2.jpg',
-          platforms: ['PC'],
-          summary: 'Competitive FPS',
+          games: [
+            {
+              id: 730,
+              name: 'Counter-Strike 2',
+              coverUrl: 'https://images.ct2.jpg',
+              platforms: ['PC'],
+              summary: 'Competitive FPS',
+            },
+          ],
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
@@ -142,7 +146,7 @@ describe('integrations service', () => {
 
     const response = await searchIgdbGame('Counter-Strike 2');
 
-    expect(response.name).toBe('Counter-Strike 2');
+    expect(response.games[0]?.name).toBe('Counter-Strike 2');
     expect(mockedApiRequest).toHaveBeenCalledWith(
       '/integrations/igdb/search?q=Counter-Strike%202',
       { method: 'GET' },


### PR DESCRIPTION
## Resumo
Esta PR corrige a causa raiz da UX fraca da busca manual do IGDB no frontend: o backend restringia a consulta a um único resultado (`limit 1`), o que forçava o frontend a assumir silenciosamente um único match mesmo em buscas ambíguas. A mesma rota pública foi mantida, mas o contrato de resposta do endpoint existente foi ampliado para suportar múltiplos candidatos e permitir seleção explícita no frontend.

## O que foi alterado
- Backend
- A rota pública existente `GET /integrations/igdb/search` foi mantida.
- O contrato de resposta dessa rota foi ampliado para retornar uma lista de candidatos em `games`.
- O client/service de IGDB passou a suportar busca com múltiplos resultados para a busca manual.
- O fluxo interno de enriquecimento automático da Steam foi preservado: ele continua usando apenas o primeiro candidato retornado pelo IGDB.

- Frontend
- O schema e o consumo da busca IGDB foram ajustados para o novo payload com `games`.
- O card de busca do IGDB deixou de assumir um único resultado.
- Quando a busca retorna múltiplos candidatos, a UI exibe a lista e exige seleção explícita.
- Quando a busca retorna um único candidato, a UI mantém preview direto.
- Quando a busca retorna lista vazia, a UI exibe estado vazio honesto.

- Testes
- Testes de backend foram atualizados para cobrir lista vazia, múltiplos candidatos e timeout no contrato atualizado.
- Testes de frontend foram atualizados para cobrir candidato único, busca ambígua com seleção e lista vazia.

## Motivação
A issue `#188` trata especificamente da ambiguidade da busca manual do IGDB no frontend. No estado anterior, a UX era limitada porque o backend já descartava candidatos alternativos antes da resposta, impossibilitando qualquer seleção explícita no cliente. A correção precisava manter a mesma rota pública, mas tornar o contrato de resposta compatível com consultas ambíguas reais.

## Como validar
- Backend
- `cd backend`
- `npm run test -- tests/integration/routes/integrations.routes.test.ts tests/unit/services/integrations.service.test.ts`
- `npm run typecheck`
- `npm run lint`

- Frontend
- `cd frontend`
- `npm run test -- tests/unit/components/igdb-search-card.test.tsx tests/unit/services/integrations.test.ts`
- `npm run typecheck`
- `npm run lint`

## Riscos e impactos
- A rota pública foi mantida, mas o payload da resposta mudou: o endpoint existente deixa de retornar um único jogo e passa a retornar uma lista em `games`.
- Essa mudança impacta consumidores desse endpoint que assumiam o contrato antigo de resultado único.
- O enriquecimento automático da Steam continua usando apenas o primeiro candidato retornado pelo IGDB para preservar o comportamento atual.
- Esta PR resolve a ambiguidade da busca manual do IGDB no frontend, mas não resolve a ambiguidade de capa/import automático.
- A ambiguidade de enrichment visual continua fora do escopo desta issue e permanece relacionada ao backlog da `#189`.
- Não houve validação operacional contra o provider IGDB real nesta rodada; a evidência disponível é de testes focados de backend e frontend.
- O `lint` do backend continua exibindo warnings preexistentes em `backend/src/config/rate-limit.ts`, sem erro novo introduzido por esta PR.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #188