### PR TITLE
fix(integrations): investigar discrepância entre Steam importado e library exibida

### DIFF
--- a/backend/src/core/repositories/profile.repository.ts
+++ b/backend/src/core/repositories/profile.repository.ts
@@ -27,7 +27,6 @@ export const profileRepository = {
         },
         gameLibrary: {
           orderBy: { lastPlayedAt: 'desc' },
-          take: 10,
         },
       },
     });
@@ -76,7 +75,6 @@ export const profileRepository = {
         },
         gameLibrary: {
           orderBy: { lastPlayedAt: 'desc' },
-          take: 10,
           select: {
             gameName: true,
             coverUrl: true,

--- a/backend/tests/integration/routes/profile.routes.test.ts
+++ b/backend/tests/integration/routes/profile.routes.test.ts
@@ -62,6 +62,26 @@ describe('Profile Routes', () => {
       expect(response.statusCode).toBe(404);
       await app.close();
     });
+
+    it('retorna toda a gameLibrary sem truncar em 10 itens', async () => {
+      vi.mocked(profileRepository.findFullProfileByUsername).mockResolvedValue({
+        ...mockFullProfile,
+        gameLibrary: Array.from({ length: 12 }, (_, index) => ({
+          gameName: `Game ${index + 1}`,
+          coverUrl: null,
+          platform: 'STEAM',
+          hoursPlayed: index,
+          lastPlayedAt: null,
+        })),
+      });
+
+      const app = await buildApp();
+      const response = await app.inject({ method: 'GET', url: '/profiles/clutchplayer' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().gameLibrary).toHaveLength(12);
+      await app.close();
+    });
   });
 
   describe('PATCH /profiles/:username', () => {

--- a/backend/tests/unit/repositories/profile.repository.test.ts
+++ b/backend/tests/unit/repositories/profile.repository.test.ts
@@ -87,6 +87,25 @@ describe('profileRepository', () => {
 
       expect(result).toBeNull();
     });
+
+    it('nao trunca silenciosamente a gameLibrary no payload do profile', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockFullProfile as never);
+
+      await profileRepository.findFullProfileByUsername('clutchplayer');
+
+      expect(prisma.user.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            gameLibrary: expect.objectContaining({
+              orderBy: { lastPlayedAt: 'desc' },
+            }),
+          }),
+        }),
+      );
+
+      const profileQuery = vi.mocked(prisma.user.findUnique).mock.calls[0]?.[0];
+      expect(profileQuery?.select?.gameLibrary).not.toHaveProperty('take');
+    });
   });
 
   // ── updateByUserId ─────────────────────────────────────────

--- a/frontend/tests/unit/components/library-page-content.test.tsx
+++ b/frontend/tests/unit/components/library-page-content.test.tsx
@@ -133,6 +133,27 @@ describe('LibraryPageContent', () => {
     expect(screen.getAllByTestId('library-game-card')).toHaveLength(4);
   });
 
+  it('renders every library item returned by the profile contract, including more than 10 games', async () => {
+    mockedFetchProfile.mockResolvedValue({
+      ...profileFixture,
+      gameLibrary: Array.from({ length: 12 }, (_, index) => ({
+        gameName: `Game ${index + 1}`,
+        coverUrl: null,
+        platform: 'STEAM',
+        hoursPlayed: index + 1,
+        lastPlayedAt: `2026-03-${String(index + 1).padStart(2, '0')}T10:00:00.000Z`,
+      })),
+    });
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-grid')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByTestId('library-game-card')).toHaveLength(12);
+  });
+
   it('filters the library by platform', async () => {
     mockedFetchProfile.mockResolvedValue(profileFixture);
 


### PR DESCRIPTION
## Resumo
Esta PR corrige a discrepância entre a quantidade de jogos reportada pela integração Steam e a quantidade exibida em profile/library. A causa raiz identificada foi um truncamento silencioso no backend: a query de `gameLibrary` dentro do profile aplicava `take: 10`, o que limitava o payload devolvido por `GET /profiles/:username` mesmo quando a importação persistia mais jogos.

## O que foi alterado
- Backend
- Remoção do limite artificial de 10 itens na query de `gameLibrary` usada pelo payload de profile.
- Atualização dos testes de repository e rota de profile para garantir que a resposta não seja truncada silenciosamente.

- Frontend
- Nenhuma mudança funcional de runtime.
- Adição de teste para provar que a tela da library já renderiza todos os itens quando o payload do profile chega completo.

## Motivação
A issue `#182` pede identificar a camada raiz da discrepância entre “quantidade importada” e “quantidade exibida”. A auditoria do fluxo mostrou que o import/upsert da Steam não era a evidência principal do truncamento observado na UI. O problema estava no payload do profile devolvido pelo backend, que já chegava limitado a 10 jogos.

## Como validar
- Backend
- `cd backend`
- `npm run test -- tests/unit/repositories/profile.repository.test.ts tests/integration/routes/profile.routes.test.ts`
- `npm run typecheck`
- `npm run lint`

- Frontend
- `cd frontend`
- `npm run test -- tests/unit/components/library-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`

## Riscos e impactos
- A correção é principalmente de backend, porque remove o truncamento do payload de `GET /profiles/:username`.
- O tamanho da resposta de profile pode crescer para usuários com bibliotecas maiores.
- Esta PR não altera o fluxo de importação Steam em si.
- Esta PR não resolve enrichment visual, capa correta ou qualquer tema da `#189`.
- Não houve validação operacional com conta Steam real nesta rodada; a evidência é de auditoria de código e testes focados.
- O `lint` do backend continua exibindo warnings preexistentes em `backend/src/config/rate-limit.ts`, sem erro novo desta PR.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #182