### PR TITLE
fix(integrations): corrigir enriquecimento visual de jogos importados na library

### DIFF
--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -49,7 +49,7 @@ type IntegrationsPersistence = {
 
 export type IntegrationsService = ReturnType<typeof createIntegrationsService>;
 
-function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
+export function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
   return {
     async upsertPlatformIntegration(userId, platform, data): Promise<void> {
       await prisma.platformIntegration.upsert({
@@ -114,7 +114,9 @@ function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
         },
         update: {
           hoursPlayed: game.playtime_forever / 60,
-          coverUrl,
+          ...(typeof coverUrl === 'string' && coverUrl.length > 0
+            ? { coverUrl }
+            : {}),
         },
       });
     },
@@ -136,7 +138,9 @@ function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
         },
         update: {
           gameName: game.title,
-          coverUrl: game.coverUrl,
+          ...(typeof game.coverUrl === 'string' && game.coverUrl.length > 0
+            ? { coverUrl: game.coverUrl }
+            : {}),
         },
       });
     },
@@ -228,7 +232,8 @@ export function createIntegrationsService(dependencies?: {
       const games = await steamClient.getOwnedGames(integration.externalId);
 
       for (const game of games) {
-        await persistence.upsertSteamLibraryGame(userId, game, null);
+        const coverUrl = await resolveIgdbCover(game.name, igdbClient);
+        await persistence.upsertSteamLibraryGame(userId, game, coverUrl);
       }
 
       return {

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -11,12 +11,26 @@ vi.mock('@/infra/cache/redis', () => ({
 import axios from 'axios';
 import { redis } from '@/infra/cache/redis';
 import {
+  createPrismaIntegrationsPersistence,
   createIntegrationsService,
 } from '@/core/services/integrations.service';
 import { IntegrationError } from '@/infra/integrations/integration.errors';
 import { epicService } from '@/infra/integrations/epic/epic.service';
 import { igdbService } from '@/infra/integrations/igdb/igdb.service';
 import { steamService } from '@/infra/integrations/steam/steam.service';
+import { prisma } from '@/infra/database/client';
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    platformIntegration: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    userGameLibrary: {
+      upsert: vi.fn(),
+    },
+  },
+}));
 
 const originalEnv = { ...process.env };
 
@@ -121,6 +135,60 @@ describe('integrations service layer', () => {
       statusCode: 404,
       reason: 'not_connected',
     });
+  });
+
+  it('sincroniza Steam tentando manter capas enriquecidas disponiveis', async () => {
+    const persistence = {
+      upsertPlatformIntegration: vi.fn(),
+      findPlatformIntegration: vi.fn().mockResolvedValue({
+        externalId: '76561198000000000',
+      }),
+      upsertSteamLibraryGame: vi.fn().mockResolvedValue(undefined),
+      upsertEpicLibraryGame: vi.fn(),
+    };
+
+    const service = createIntegrationsService({
+      steamClient: {
+        validateSteamId: vi.fn(),
+        getOwnedGames: vi.fn().mockResolvedValue(mockSteamGames),
+      },
+      igdbClient: {
+        searchGames: vi.fn(),
+        searchGame: vi.fn()
+          .mockResolvedValueOnce({
+            id: 730,
+            name: 'Counter-Strike 2',
+            coverUrl: 'https://cdn.example/cs2.jpg',
+            platforms: ['PC'],
+            summary: null,
+          })
+          .mockResolvedValueOnce(null),
+      },
+      epicClient: {
+        validateToken: vi.fn(),
+        getLibrary: vi.fn(),
+      },
+      persistence,
+    });
+
+    const result = await service.syncSteamLibrary('user-id-1');
+
+    expect(result).toMatchObject({
+      synced: 2,
+      message: '2 jogos sincronizados.',
+    });
+    expect(persistence.upsertSteamLibraryGame).toHaveBeenNthCalledWith(
+      1,
+      'user-id-1',
+      mockSteamGames[0],
+      'https://cdn.example/cs2.jpg',
+    );
+    expect(persistence.upsertSteamLibraryGame).toHaveBeenNthCalledWith(
+      2,
+      'user-id-1',
+      mockSteamGames[1],
+      null,
+    );
   });
 
   it('marca Epic como indisponivel quando o adapter nao existe no runtime atual', async () => {
@@ -280,6 +348,46 @@ describe('igdbService', () => {
     expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('Authorization');
     expect(stdoutWriteSpy.mock.calls[0]?.[0]).not.toContain('https://');
     stdoutWriteSpy.mockRestore();
+  });
+});
+
+describe('createPrismaIntegrationsPersistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserva a cover existente da Steam quando a sincronizacao nao encontra imagem confiavel', async () => {
+    vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({} as never);
+    const persistence = createPrismaIntegrationsPersistence();
+
+    await persistence.upsertSteamLibraryGame(
+      'user-id-1',
+      mockSteamGames[0]!,
+      null,
+    );
+
+    expect(prisma.userGameLibrary.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {
+          hoursPlayed: mockSteamGames[0]!.playtime_forever / 60,
+        },
+      }),
+    );
+  });
+
+  it('preserva a cover existente da Epic quando o adapter retorna cover nula', async () => {
+    vi.mocked(prisma.userGameLibrary.upsert).mockResolvedValue({} as never);
+    const persistence = createPrismaIntegrationsPersistence();
+
+    await persistence.upsertEpicLibraryGame('user-id-1', mockEpicGames[0]!);
+
+    expect(prisma.userGameLibrary.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: {
+          gameName: mockEpicGames[0]!.title,
+        },
+      }),
+    );
   });
 });
 

--- a/frontend/src/components/library/game-card.tsx
+++ b/frontend/src/components/library/game-card.tsx
@@ -34,6 +34,7 @@ export function GameCard({ game }: GameCardProps) {
             src={game.coverUrl}
             alt={game.gameName}
             fill
+            sizes="(min-width: 1280px) 33vw, (min-width: 640px) 50vw, 100vw"
             className="object-cover"
           />
         ) : (

--- a/frontend/src/components/profile/game-library-preview.tsx
+++ b/frontend/src/components/profile/game-library-preview.tsx
@@ -37,7 +37,7 @@ export function GameLibraryPreview({ games, username }: GameLibraryPreviewProps)
           </p>
         ) : (
           <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {visibleGames.map((game) => (
+            {visibleGames.map((game, index) => (
               <li
                 key={`${game.platform}-${game.gameName}`}
                 className="overflow-hidden rounded-control border border-border bg-background-tertiary/70"
@@ -48,6 +48,8 @@ export function GameLibraryPreview({ games, username }: GameLibraryPreviewProps)
                       src={game.coverUrl}
                       alt={game.gameName}
                       fill
+                      sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                      priority={index === 0}
                       className="object-cover"
                     />
                   ) : (


### PR DESCRIPTION
﻿## Resumo
Esta PR corrige a origem backend-side das capas ausentes ou inconsistentes em jogos importados e ajusta a renderização otimizada dessas capas nos componentes de library/profile. A causa raiz principal identificada foi que `syncSteamLibrary` regravava jogos com `coverUrl: null`, apagando capas já enriquecidas, e que updates de Steam/Epic sobrescreviam uma capa existente quando a nova sincronização não trazia imagem confiável.

## O que foi alterado
- Backend
- `syncSteamLibrary` passou a tentar enriquecer capas via IGDB, em vez de regravar todos os jogos com `coverUrl: null`.
- A persistência de jogos Steam e Epic deixou de sobrescrever `coverUrl` existente quando a nova sincronização retorna `null`.
- O fluxo continua aceitando `null` como fallback honesto quando não houver imagem confiável.

- Frontend
- Ajuste dos componentes de capa de jogos importados em library/profile para usar `sizes` coerente com o layout real nos `Image` com `fill`.
- Priorização apenas da primeira capa do preview do profile, compatível com a versão real do Next usada no projeto (`15.5.14`), onde `priority` continua disponível.
- O fallback `Sem capa` foi preservado sem alteração de comportamento.

## Motivação
A issue `#189` trata enriquecimento visual de jogos importados, não contagem da library nem polish de UI. A auditoria mostrou que o problema principal não estava na renderização local da library/profile, mas na origem do dado persistido: sincronizações posteriores podiam apagar uma capa já válida. Além disso, havia warnings reais de `next/image` diretamente nos componentes de capa de library/profile, que podiam ser corrigidos sem ampliar escopo.

## Como validar
- Backend
- `cd backend`
- `npm run test -- tests/unit/services/integrations.service.test.ts tests/integration/routes/integrations.routes.test.ts tests/integration/routes/profile.routes.test.ts`
- `npm run typecheck`
- `npm run lint`

- Frontend
- `cd frontend`
- `npm run test -- tests/unit/components/library-page-content.test.tsx tests/unit/components/profile-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`

## Riscos e impactos
- A correção principal é de backend, sem mudança de contrato público.
- O enriquecimento automático da Steam continua dependente do primeiro candidato retornado pelo IGDB no fluxo automático.
- A integração Epic continua limitada ao `coverUrl` fornecido pelo adapter atual; quando ele não trouxer imagem confiável, a PR apenas preserva a capa já conhecida.
- Esta PR não resolve contagem da library, nem redesign, nem o backlog de polish da `#190`.
- Não houve validação operacional com providers reais nesta rodada; a evidência é de auditoria de código e testes focados.
- Os ajustes de frontend ficaram restritos aos componentes de capa de library/profile; warnings equivalentes em outras superfícies continuam fora do escopo.
- O `lint` do backend continua exibindo warnings preexistentes em `backend/src/config/rate-limit.ts`, sem erro novo desta PR.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #189
