### PR TITLE
feat(library): refinar UX visual da biblioteca do usuário

### DIFF
--- a/frontend/src/components/library/game-card.tsx
+++ b/frontend/src/components/library/game-card.tsx
@@ -45,28 +45,44 @@ export function GameCard({ game }: GameCardProps) {
       </div>
 
       <div className="space-y-3 p-card">
-        <div className="space-y-2">
+        <div className="space-y-3">
           <div className="flex items-start justify-between gap-3">
-            <h3 className="line-clamp-2 font-display text-xl font-semibold text-primary">
-              {game.gameName}
-            </h3>
+            <div className="space-y-2">
+              <p className="text-[11px] uppercase tracking-[0.3em] text-secondary">
+                Jogo importado
+              </p>
+              <h3 className="line-clamp-2 font-display text-xl font-semibold text-primary">
+                {game.gameName}
+              </h3>
+            </div>
             <Badge tone="neutral">{game.platform}</Badge>
           </div>
-          <p className="text-sm text-secondary">{formatHoursPlayed(game.hoursPlayed)}</p>
+          <div className="rounded-control border border-border bg-background-secondary/70 px-3 py-2">
+            <p className="text-xs uppercase tracking-[0.24em] text-secondary">
+              Tempo registrado
+            </p>
+            <p className="mt-1 text-sm font-medium text-primary">
+              {formatHoursPlayed(game.hoursPlayed)}
+            </p>
+          </div>
         </div>
 
-        <p className="text-xs uppercase tracking-[0.24em] text-secondary">
-          Ultima atividade:{' '}
-          {game.lastPlayedAt ? (
-            <HydrationSafeTime
-              value={game.lastPlayedAt}
-              options={{ day: '2-digit', month: '2-digit', year: 'numeric' }}
-              fallback="Sem atividade recente"
-            />
-          ) : (
-            'Sem atividade recente'
-          )}
-        </p>
+        <div className="border-t border-border pt-3">
+          <p className="text-xs uppercase tracking-[0.24em] text-secondary">
+            Última atividade
+          </p>
+          <p className="mt-1 text-sm text-primary">
+            {game.lastPlayedAt ? (
+              <HydrationSafeTime
+                value={game.lastPlayedAt}
+                options={{ day: '2-digit', month: '2-digit', year: 'numeric' }}
+                fallback="Sem atividade recente"
+              />
+            ) : (
+              'Sem atividade recente'
+            )}
+          </p>
+        </div>
       </div>
     </Card>
   );

--- a/frontend/src/components/library/library-filters.tsx
+++ b/frontend/src/components/library/library-filters.tsx
@@ -6,11 +6,16 @@ import { cn } from '@/lib/utils/cn';
 export type LibrarySortOption = 'most-played' | 'recent' | 'alphabetical';
 
 type LibraryFiltersProps = {
-  platforms: string[];
+  platforms: Array<{
+    value: string;
+    count: number;
+  }>;
   selectedPlatform: string;
   selectedSort: LibrarySortOption;
   onPlatformChange: (platform: string) => void;
   onSortChange: (sort: LibrarySortOption) => void;
+  onReset: () => void;
+  hasActiveRefinements: boolean;
 };
 
 const sortOptions: Array<{ value: LibrarySortOption; label: string }> = [
@@ -25,18 +30,37 @@ export function LibraryFilters({
   selectedSort,
   onPlatformChange,
   onSortChange,
+  onReset,
+  hasActiveRefinements,
 }: LibraryFiltersProps) {
   return (
-    <Card className="space-y-4">
+    <Card className="space-y-5 xl:sticky xl:top-24">
       <div className="space-y-2">
-        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Filtros</p>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Refinar vista</p>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!hasActiveRefinements}
+            onClick={onReset}
+          >
+            Limpar tudo
+          </Button>
+        </div>
+        <p className="text-sm leading-6 text-secondary">
+          Ajuste plataforma e ordenação sem alterar o contrato do profile.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.35em] text-secondary">Plataforma</p>
         <div className="flex flex-wrap gap-2">
           {platforms.map((platform) => {
-            const isActive = selectedPlatform === platform;
+            const isActive = selectedPlatform === platform.value;
 
             return (
               <button
-                key={platform}
+                key={platform.value}
                 type="button"
                 className={cn(
                   'inline-flex items-center rounded-pill border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.24em] transition',
@@ -45,31 +69,36 @@ export function LibraryFilters({
                     : 'border-border bg-background-secondary text-secondary hover:text-primary',
                 )}
                 onClick={() => {
-                  onPlatformChange(platform);
+                  onPlatformChange(platform.value);
                 }}
               >
-                {platform === 'ALL' ? 'Todas' : platform}
+                {platform.value === 'ALL' ? 'Todas' : platform.value} ({platform.count})
               </button>
             );
           })}
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge tone="accent">Ordenacao</Badge>
-        {sortOptions.map((option) => (
-          <Button
-            key={option.value}
-            type="button"
-            size="sm"
-            variant={selectedSort === option.value ? 'primary' : 'secondary'}
-            onClick={() => {
-              onSortChange(option.value);
-            }}
-          >
-            {option.label}
-          </Button>
-        ))}
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge tone="accent">Ordenação</Badge>
+          <p className="text-sm text-secondary">Defina como a lista deve ganhar prioridade.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {sortOptions.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              size="sm"
+              variant={selectedSort === option.value ? 'primary' : 'secondary'}
+              onClick={() => {
+                onSortChange(option.value);
+              }}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
       </div>
     </Card>
   );

--- a/frontend/src/components/library/library-page-content.tsx
+++ b/frontend/src/components/library/library-page-content.tsx
@@ -10,6 +10,7 @@ import {
 import { LibrarySearch } from '@/components/library/library-search';
 import { LibraryStats } from '@/components/library/library-stats';
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { fetchProfileByUsername, ProfileRequestError } from '@/services/profile';
 
@@ -114,12 +115,16 @@ function LibraryErrorState({ message }: { message: string }) {
 
 function LibraryEmptyState({
   hasGames,
+  hasActiveRefinements,
+  onReset,
 }: {
   hasGames: boolean;
+  hasActiveRefinements: boolean;
+  onReset: () => void;
 }) {
   return (
     <Card data-testid="library-empty">
-      <div className="space-y-3">
+      <div className="space-y-4">
         <p className="text-xs uppercase tracking-[0.35em] text-secondary">Biblioteca</p>
         <h2 className="font-display text-2xl font-semibold text-primary">
           {hasGames ? 'Nenhum jogo corresponde aos filtros atuais' : 'Biblioteca vazia'}
@@ -129,6 +134,13 @@ function LibraryEmptyState({
             ? 'Ajuste a busca, a plataforma ou a ordenacao para ver outros jogos.'
             : 'Este perfil ainda nao possui jogos importados pelas integracoes atuais.'}
         </p>
+        {hasActiveRefinements ? (
+          <div>
+            <Button variant="secondary" size="sm" onClick={onReset}>
+              Limpar refinamentos
+            </Button>
+          </div>
+        ) : null}
       </div>
     </Card>
   );
@@ -149,7 +161,18 @@ export function LibraryPageContent({ username }: LibraryPageContentProps) {
   }, [profileQuery.data?.gameLibrary]);
 
   const platforms = useMemo(() => {
-    return ['ALL', ...Array.from(new Set(allGames.map((game) => game.platform))).sort()];
+    const counts = allGames.reduce<Record<string, number>>((accumulator, game) => {
+      accumulator[game.platform] = (accumulator[game.platform] ?? 0) + 1;
+
+      return accumulator;
+    }, {});
+
+    return [
+      { value: 'ALL', count: allGames.length },
+      ...Object.entries(counts)
+        .sort(([left], [right]) => left.localeCompare(right, 'pt-BR'))
+        .map(([value, count]) => ({ value, count })),
+    ];
   }, [allGames]);
 
   const filteredGames = useMemo(() => {
@@ -167,6 +190,25 @@ export function LibraryPageContent({ username }: LibraryPageContentProps) {
 
     return sortLibraryGames(visibleGames, sortBy);
   }, [allGames, searchValue, selectedPlatform, sortBy]);
+
+  const hasActiveRefinements =
+    searchValue.trim().length > 0 || selectedPlatform !== 'ALL' || sortBy !== 'most-played';
+
+  const activeRefinements = [
+    searchValue.trim().length > 0 ? `Busca: ${searchValue.trim()}` : null,
+    selectedPlatform !== 'ALL' ? `Plataforma: ${selectedPlatform}` : null,
+    sortBy !== 'most-played'
+      ? `Ordenação: ${
+          sortBy === 'recent' ? 'Mais recentes' : 'Alfabética'
+        }`
+      : null,
+  ].filter((value): value is string => value !== null);
+
+  const resetRefinements = () => {
+    setSearchValue('');
+    setSelectedPlatform('ALL');
+    setSortBy('most-played');
+  };
 
   if (profileQuery.isPending) {
     return <LibraryLoadingState />;
@@ -186,18 +228,65 @@ export function LibraryPageContent({ username }: LibraryPageContentProps) {
       <SectionHeading
         eyebrow="Biblioteca"
         title={`Biblioteca de @${profileQuery.data.username}`}
-        description="A biblioteca usa apenas o gameLibrary retornado pelo profile atual, com busca, filtro e ordenacao locais."
+        description="Explore a biblioteca carregada pelo profile atual com busca, filtros e ordenação locais, sem alterar os dados importados."
         level="h1"
+        actions={
+          hasActiveRefinements ? (
+            <Button variant="secondary" size="sm" onClick={resetRefinements}>
+              Limpar refinamentos
+            </Button>
+          ) : undefined
+        }
       />
 
       <LibraryStats games={allGames} />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
         <div className="space-y-4">
-          <LibrarySearch value={searchValue} onChange={setSearchValue} />
+          <LibrarySearch
+            value={searchValue}
+            onChange={setSearchValue}
+            onClear={() => {
+              setSearchValue('');
+            }}
+          />
+
+          <Card data-testid="library-summary">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+                  Visão atual
+                </p>
+                <p className="font-display text-2xl font-semibold text-primary">
+                  Exibindo {filteredGames.length} de {allGames.length} jogos
+                </p>
+                <p className="text-sm leading-6 text-secondary">
+                  {hasActiveRefinements
+                    ? 'Os resultados abaixo refletem os refinamentos ativos nesta tela.'
+                    : 'A lista abaixo mostra a biblioteca completa disponível no profile atual.'}
+                </p>
+              </div>
+              {activeRefinements.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {activeRefinements.map((refinement) => (
+                    <span
+                      key={refinement}
+                      className="rounded-pill border border-border bg-background-secondary px-3 py-1 text-xs font-medium text-secondary"
+                    >
+                      {refinement}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </Card>
 
           {filteredGames.length === 0 ? (
-            <LibraryEmptyState hasGames={allGames.length > 0} />
+            <LibraryEmptyState
+              hasGames={allGames.length > 0}
+              hasActiveRefinements={hasActiveRefinements}
+              onReset={resetRefinements}
+            />
           ) : (
             <div
               className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
@@ -219,6 +308,8 @@ export function LibraryPageContent({ username }: LibraryPageContentProps) {
           selectedSort={sortBy}
           onPlatformChange={setSelectedPlatform}
           onSortChange={setSortBy}
+          onReset={resetRefinements}
+          hasActiveRefinements={hasActiveRefinements}
         />
       </div>
     </div>

--- a/frontend/src/components/library/library-search.tsx
+++ b/frontend/src/components/library/library-search.tsx
@@ -1,27 +1,48 @@
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
 type LibrarySearchProps = {
   value: string;
   onChange: (value: string) => void;
+  onClear: () => void;
 };
 
-export function LibrarySearch({ value, onChange }: LibrarySearchProps) {
+export function LibrarySearch({ value, onChange, onClear }: LibrarySearchProps) {
   return (
     <Card>
-      <label className="space-y-2">
-        <span className="text-xs uppercase tracking-[0.35em] text-secondary">
-          Buscar jogo
-        </span>
-        <input
-          type="search"
-          value={value}
-          placeholder="Ex.: Counter-Strike 2"
-          className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
-          onChange={(event) => {
-            onChange(event.target.value);
-          }}
-        />
-      </label>
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Buscar na biblioteca
+          </p>
+          <p className="text-sm leading-6 text-secondary">
+            A busca filtra localmente os jogos carregados pelo profile atual.
+          </p>
+        </div>
+
+        <label className="block">
+          <span className="sr-only">Buscar jogo</span>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              type="search"
+              value={value}
+              placeholder="Ex.: Counter-Strike 2"
+              className="h-11 w-full rounded-control border border-border bg-background-secondary px-control-x text-sm text-primary transition focus:border-accent-cyan focus:outline-none focus:ring-2 focus:ring-accent-cyan/30"
+              onChange={(event) => {
+                onChange(event.target.value);
+              }}
+            />
+            <Button
+              variant="secondary"
+              size="md"
+              disabled={value.trim().length === 0}
+              onClick={onClear}
+            >
+              Limpar busca
+            </Button>
+          </div>
+        </label>
+      </div>
     </Card>
   );
 }

--- a/frontend/src/components/library/library-stats.tsx
+++ b/frontend/src/components/library/library-stats.tsx
@@ -23,29 +23,38 @@ export function LibraryStats({ games }: LibraryStatsProps) {
 
   return (
     <Card>
-      <div className="flex flex-wrap items-start gap-4">
-        <div className="min-w-[8rem] space-y-1">
-          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Jogos</p>
-          <p className="font-display text-3xl font-semibold text-primary">{games.length}</p>
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Resumo da biblioteca</p>
+          <p className="text-sm leading-6 text-secondary">
+            Visão rápida dos jogos já carregados no payload atual do perfil.
+          </p>
         </div>
 
-        <div className="min-w-[8rem] space-y-1">
-          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Horas</p>
-          <p className="font-display text-3xl font-semibold text-primary">{formatHours(games)}</p>
-        </div>
+        <div className="flex flex-wrap items-start gap-4">
+          <div className="min-w-[8rem] space-y-1">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">Jogos</p>
+            <p className="font-display text-3xl font-semibold text-primary">{games.length}</p>
+          </div>
 
-        <div className="flex-1 space-y-2">
-          <p className="text-xs uppercase tracking-[0.35em] text-secondary">Plataformas</p>
-          <div className="flex flex-wrap gap-2">
-            {connectedPlatforms.size > 0 ? (
-              Array.from(connectedPlatforms).sort().map((platform) => (
-                <Badge key={platform} tone="neutral">
-                  {platform}
-                </Badge>
-              ))
-            ) : (
-              <Badge tone="neutral">Sem plataformas</Badge>
-            )}
+          <div className="min-w-[8rem] space-y-1">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">Horas</p>
+            <p className="font-display text-3xl font-semibold text-primary">{formatHours(games)}</p>
+          </div>
+
+          <div className="flex-1 space-y-2">
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">Plataformas</p>
+            <div className="flex flex-wrap gap-2">
+              {connectedPlatforms.size > 0 ? (
+                Array.from(connectedPlatforms).sort().map((platform) => (
+                  <Badge key={platform} tone="neutral">
+                    {platform}
+                  </Badge>
+                ))
+              ) : (
+                <Badge tone="neutral">Sem plataformas</Badge>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/tests/unit/components/library-page-content.test.tsx
+++ b/frontend/tests/unit/components/library-page-content.test.tsx
@@ -130,6 +130,7 @@ describe('LibraryPageContent', () => {
     expect(screen.getByText(/biblioteca de @clutchplayer/i)).toBeInTheDocument();
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getByText('1157h')).toBeInTheDocument();
+    expect(screen.getByText(/exibindo 4 de 4 jogos/i)).toBeInTheDocument();
     expect(screen.getAllByTestId('library-game-card')).toHaveLength(4);
   });
 
@@ -163,12 +164,13 @@ describe('LibraryPageContent', () => {
       expect(screen.getByTestId('library-grid')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'STEAM' }));
+    fireEvent.click(screen.getByRole('button', { name: /steam \(2\)/i }));
 
     await waitFor(() => {
       expect(screen.getAllByTestId('library-game-card')).toHaveLength(2);
     });
 
+    expect(screen.getByText(/plataforma: steam/i)).toBeInTheDocument();
     expect(screen.getByText('Counter-Strike 2')).toBeInTheDocument();
     expect(screen.getByText('Dota 2')).toBeInTheDocument();
     expect(screen.queryByText('Fortnite')).not.toBeInTheDocument();
@@ -247,6 +249,37 @@ describe('LibraryPageContent', () => {
     expect(
       screen.getByText(/nenhum jogo corresponde aos filtros atuais/i),
     ).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /limpar refinamentos/i })).toHaveLength(2);
+  });
+
+  it('clears active refinements and restores the full library grid', async () => {
+    mockedFetchProfile.mockResolvedValue(profileFixture);
+
+    renderWithQuery(<LibraryPageContent username="clutchplayer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-grid')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/counter-strike 2/i), {
+      target: { value: 'fort' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /epic \(1\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: /alfabetica/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/busca: fort/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /limpar refinamentos/i })[0] as HTMLElement);
+
+    await waitFor(() => {
+      expect(screen.getByText(/exibindo 4 de 4 jogos/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByTestId('library-game-card')).toHaveLength(4);
+    expect(screen.queryByText(/busca: fort/i)).not.toBeInTheDocument();
   });
 
   it('keeps sorting deterministic when hours and last activity are missing', async () => {


### PR DESCRIPTION
﻿## Resumo
Esta PR refina a UX visual da biblioteca do usuário com ajustes pontuais de hierarquia, microcopy e clareza dos controles existentes. A mudança fica inteiramente no frontend, preserva o contrato atual baseado em `GET /profiles/:username` e não altera dados, importação ou enriquecimento visual já estabilizados nas issues anteriores.

## O que foi alterado
- Frontend
- Reorganização da hierarquia da library para destacar melhor o resumo da tela, o estado atual dos resultados e os refinamentos ativos.
- Ajuste dos componentes de busca e filtros para deixar mais claro que a busca, a plataforma e a ordenação são refinamentos locais sobre o payload atual do profile.
- Adição de ações rápidas para limpar busca e refinamentos sem criar fluxos novos.
- Refinamento do empty state filtrado para orientar melhor a recuperação do resultado.
- Ajustes de microcopy e leitura visual dos cards da library, sem alterar o comportamento dos dados exibidos.

- Testes
- Atualização dos testes da library para cobrir resumo contextual, contagem nos filtros e restauração da lista após limpar refinamentos.

## Motivação
Depois dos merges de `#182` e `#189`, a library ficou consistente em dados e capas, mas a UX ainda estava seca em pontos específicos: controles pouco orientados, pouca visibilidade do contexto atual da lista e estado vazio filtrado sem ação clara. Esta PR trata apenas esse polish focalizado da superfície da library.

## Como validar
- `cd frontend`
- `npm run test -- tests/unit/components/library-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`

## Riscos e impactos
- A mudança é restrita ao frontend e à superfície da library.
- O contrato atual do backend foi preservado; não houve mudança em `GET /profiles/:username`.
- Busca, filtro e ordenação continuam locais, sem alteração funcional de dados.
- Não houve redesign amplo do app; a PR ajusta apenas hierarquia visual, microcopy e feedbacks locais da library.
- Não houve smoke manual nesta rodada; a evidência disponível é de testes focados, `typecheck` e `lint`.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #190
