### PR TITLE
fix(auth): estabilizar refresh silencioso e logout

### DIFF
--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -53,7 +53,7 @@ export function Navbar({
   menuOpen = false,
   onMenuToggle,
 }: NavbarProps) {
-  const { user, status } = useAuth();
+  const { user, status, logout } = useAuth();
   const [isRequestsOpen, setIsRequestsOpen] = useState(false);
   const pendingRequestsQuery = useQuery({
     queryKey: ['friend-requests', user?.id],
@@ -110,6 +110,17 @@ export function Navbar({
           {variant === 'app' ? (
             <>
               <NotificationsBell />
+              <ActionButton
+                type="button"
+                aria-label="Encerrar sessao"
+                className="hidden md:inline-flex"
+                onClick={() => {
+                  void logout();
+                }}
+                disabled={status !== 'authenticated'}
+              >
+                Sair
+              </ActionButton>
               <div className="relative">
                 <ActionButton
                   type="button"

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,18 +1,24 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { logoutAuthSession } from '@/services/session';
 import { useAuthStore } from '@/store/auth-store';
 
 export function useAuth() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const user = useAuthStore((state) => state.user);
   const status = useAuthStore((state) => state.status);
 
   const logout = async () => {
-    await logoutAuthSession();
-    router.replace('/login');
-    router.refresh();
+    try {
+      await logoutAuthSession();
+    } finally {
+      queryClient.clear();
+      router.replace('/login');
+      router.refresh();
+    }
   };
 
   return {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,10 +5,30 @@ type JsonBody = Record<string, unknown>;
 type ApiRequestInit = Omit<RequestInit, 'body'> & {
   body?: BodyInit | JsonBody;
   clearSessionOnUnauthorized?: boolean;
+  retryOnUnauthorized?: boolean;
 };
 
 function isJsonBody(value: ApiRequestInit['body']): value is JsonBody {
   return typeof value === 'object' && value !== null && !(value instanceof FormData);
+}
+
+let refreshSessionPromise: Promise<boolean> | null = null;
+
+async function refreshSessionSilently(): Promise<boolean> {
+  if (!refreshSessionPromise) {
+    refreshSessionPromise = fetch('/api/auth/refresh', {
+      method: 'POST',
+      credentials: 'include',
+      cache: 'no-store',
+    })
+      .then((response) => response.ok)
+      .catch(() => false)
+      .finally(() => {
+        refreshSessionPromise = null;
+      });
+  }
+
+  return refreshSessionPromise;
 }
 
 export async function apiRequest(
@@ -18,6 +38,7 @@ export async function apiRequest(
   const {
     body,
     clearSessionOnUnauthorized = true,
+    retryOnUnauthorized = true,
     headers,
     ...rest
   } = init;
@@ -33,12 +54,27 @@ export async function apiRequest(
     requestBody = body;
   }
 
-  const response = await fetch(`/api${normalizedPath}`, {
-    ...rest,
-    credentials: 'include',
-    headers: requestHeaders,
-    body: requestBody,
-  });
+  async function executeRequest(): Promise<Response> {
+    return fetch(`/api${normalizedPath}`, {
+      ...rest,
+      credentials: 'include',
+      headers: requestHeaders,
+      body: requestBody,
+    });
+  }
+
+  let response = await executeRequest();
+  const shouldAttemptRefresh =
+    retryOnUnauthorized &&
+    normalizedPath !== '/auth/refresh';
+
+  if (response.status === 401 && shouldAttemptRefresh) {
+    const refreshSucceeded = await refreshSessionSilently();
+
+    if (refreshSucceeded) {
+      response = await executeRequest();
+    }
+  }
 
   if (clearSessionOnUnauthorized && response.status === 401) {
     useAuthStore.getState().clearSession();

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -56,6 +56,8 @@ export async function login(input: LoginRequestValues): Promise<LoginSession> {
   const response = await apiRequest('/auth/login', {
     method: 'POST',
     body: credentials,
+    clearSessionOnUnauthorized: false,
+    retryOnUnauthorized: false,
   });
 
   const payload = await readJson(response);
@@ -83,6 +85,8 @@ export async function register(
   const response = await apiRequest('/auth/register', {
     method: 'POST',
     body: registration,
+    clearSessionOnUnauthorized: false,
+    retryOnUnauthorized: false,
   });
 
   const payload = await readJson(response);

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -2,6 +2,7 @@ import { apiRequest } from '@/lib/api';
 import { authSessionSchema, type AuthSession } from '@/schemas/auth';
 import { publishPresenceState } from '@/services/presence';
 import { useAuthStore } from '@/store/auth-store';
+import { usePresenceStore } from '@/store/presence-store';
 
 async function readJson(response: Response): Promise<unknown> {
   const text = await response.text();
@@ -21,6 +22,7 @@ export async function fetchAuthSession(): Promise<AuthSession | null> {
   const response = await apiRequest('/auth/me', {
     method: 'GET',
     clearSessionOnUnauthorized: false,
+    retryOnUnauthorized: false,
   });
 
   if (!response.ok) {
@@ -45,8 +47,11 @@ export async function logoutAuthSession(): Promise<void> {
 
     await apiRequest('/auth/logout', {
       method: 'POST',
+      clearSessionOnUnauthorized: false,
+      retryOnUnauthorized: false,
     });
   } finally {
     useAuthStore.getState().clearSession();
+    usePresenceStore.getState().clearAll();
   }
 }

--- a/frontend/tests/unit/components/navbar.test.tsx
+++ b/frontend/tests/unit/components/navbar.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/components/notifications/notifications-bell', () => ({
 
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedFetchPendingFriendRequests = vi.mocked(fetchPendingFriendRequests);
+const logoutMock = vi.fn();
 
 function renderNavbar() {
   const queryClient = new QueryClient({
@@ -45,6 +46,7 @@ describe('Navbar', () => {
   beforeEach(() => {
     mockedUseAuth.mockReset();
     mockedFetchPendingFriendRequests.mockReset();
+    logoutMock.mockReset();
 
     mockedUseAuth.mockReturnValue({
       status: 'authenticated',
@@ -53,7 +55,7 @@ describe('Navbar', () => {
         username: 'clutchplayer',
         email: 'clutchplayer@clutch.gg',
       },
-      logout: vi.fn(),
+      logout: logoutMock,
     });
   });
 
@@ -94,5 +96,15 @@ describe('Navbar', () => {
       screen.getByLabelText(/busca global ainda nao disponivel/i),
     ).toBeInTheDocument();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('renders a visible logout action in the authenticated shell', () => {
+    mockedFetchPendingFriendRequests.mockResolvedValue([]);
+
+    renderNavbar();
+
+    fireEvent.click(screen.getByRole('button', { name: /encerrar sessao/i }));
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/tests/unit/hooks/use-auth.test.tsx
+++ b/frontend/tests/unit/hooks/use-auth.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '@/hooks/use-auth';
+
+const replaceMock = vi.fn();
+const refreshMock = vi.fn();
+const { logoutAuthSessionMock } = vi.hoisted(() => ({
+  logoutAuthSessionMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock('@/services/session', () => ({
+  logoutAuthSession: logoutAuthSessionMock,
+}));
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+    refreshMock.mockReset();
+    logoutAuthSessionMock.mockReset();
+  });
+
+  it('clears the query cache and redirects on logout', async () => {
+    logoutAuthSessionMock.mockResolvedValue(undefined);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    queryClient.setQueryData(['profile', 'clutchplayer'], { id: 'user-1' });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(logoutAuthSessionMock).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(['profile', 'clutchplayer'])).toBeUndefined();
+    expect(replaceMock).toHaveBeenCalledWith('/login');
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/unit/lib/api.test.ts
+++ b/frontend/tests/unit/lib/api.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import { resetAuthStore, useAuthStore } from '@/store/auth-store';
+
+describe('apiRequest', () => {
+  beforeEach(() => {
+    resetAuthStore();
+    vi.restoreAllMocks();
+  });
+
+  it('renews the session silently and retries the original request once', async () => {
+    let profileCalls = 0;
+    let refreshCalls = 0;
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === '/api/auth/refresh') {
+        refreshCalls += 1;
+        return new Response(JSON.stringify({ message: 'Sessao renovada.' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url === '/api/profiles/clutchplayer') {
+        profileCalls += 1;
+
+        if (profileCalls === 1) {
+          return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const response = await apiRequest('/profiles/clutchplayer');
+
+    expect(response.status).toBe(200);
+    expect(profileCalls).toBe(2);
+    expect(refreshCalls).toBe(1);
+    expect(useAuthStore.getState().status).toBe('loading');
+  });
+
+  it('deduplicates concurrent refresh requests', async () => {
+    const requestAttempts = new Map<string, number>();
+    let refreshCalls = 0;
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === '/api/auth/refresh') {
+        refreshCalls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        return new Response(JSON.stringify({ message: 'Sessao renovada.' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      const attempts = (requestAttempts.get(url) ?? 0) + 1;
+      requestAttempts.set(url, attempts);
+
+      if (attempts === 1) {
+        return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const [friendsResponse, notificationsResponse] = await Promise.all([
+      apiRequest('/friends/user-1'),
+      apiRequest('/notifications/user-1'),
+    ]);
+
+    expect(friendsResponse.status).toBe(200);
+    expect(notificationsResponse.status).toBe(200);
+    expect(refreshCalls).toBe(1);
+    expect(requestAttempts.get('/api/friends/user-1')).toBe(2);
+    expect(requestAttempts.get('/api/notifications/user-1')).toBe(2);
+  });
+
+  it('clears the session only when the silent refresh fails', async () => {
+    useAuthStore.getState().setSession({
+      id: 'user-1',
+      username: 'clutchplayer',
+      email: 'clutchplayer@clutch.gg',
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === '/api/auth/refresh') {
+        return new Response(JSON.stringify({ message: 'Sessao invalida.' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ message: 'Token invalido ou expirado.' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const response = await apiRequest('/posts/feed/user-1');
+
+    expect(response.status).toBe(401);
+    expect(useAuthStore.getState().status).toBe('unauthenticated');
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+
+  it('does not try to refresh when unauthorized retries are disabled', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === '/api/auth/refresh') {
+        throw new Error('refresh should not be called');
+      }
+
+      return new Response(JSON.stringify({ message: 'Credenciais invalidas.' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const response = await apiRequest('/auth/login', {
+      method: 'POST',
+      retryOnUnauthorized: false,
+      clearSessionOnUnauthorized: false,
+    });
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/unit/services/session.test.ts
+++ b/frontend/tests/unit/services/session.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchAuthSession, logoutAuthSession } from '@/services/session';
 import { resetAuthStore, useAuthStore } from '@/store/auth-store';
+import { resetPresenceStore, usePresenceStore } from '@/store/presence-store';
 
 const { apiRequestMock } = vi.hoisted(() => ({
   apiRequestMock: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock('@/services/presence', () => ({
 describe('session service', () => {
   beforeEach(() => {
     resetAuthStore();
+    resetPresenceStore();
     apiRequestMock.mockReset();
     publishPresenceStateMock.mockReset();
   });
@@ -50,6 +52,7 @@ describe('session service', () => {
     expect(apiRequestMock).toHaveBeenCalledWith('/auth/me', {
       method: 'GET',
       clearSessionOnUnauthorized: false,
+      retryOnUnauthorized: false,
     });
   });
 
@@ -78,6 +81,16 @@ describe('session service', () => {
       username: 'clutchplayer',
       email: 'clutchplayer@clutch.gg',
     });
+    usePresenceStore.getState().setConnectionStatus('connected');
+    usePresenceStore.getState().upsertPresence(
+      {
+        userId: 'user-2',
+        status: 'ONLINE',
+        currentGame: null,
+        platform: 'WEB',
+      },
+      Date.now(),
+    );
 
     apiRequestMock.mockResolvedValue(new Response(null, { status: 200 }));
     publishPresenceStateMock.mockResolvedValue(undefined);
@@ -93,8 +106,12 @@ describe('session service', () => {
     );
     expect(apiRequestMock).toHaveBeenCalledWith('/auth/logout', {
       method: 'POST',
+      clearSessionOnUnauthorized: false,
+      retryOnUnauthorized: false,
     });
     expect(useAuthStore.getState().status).toBe('unauthenticated');
     expect(useAuthStore.getState().user).toBeNull();
+    expect(usePresenceStore.getState().connectionStatus).toBe('idle');
+    expect(usePresenceStore.getState().entries).toEqual({});
   });
 });


### PR DESCRIPTION
## Resumo
Esta PR estabiliza o fluxo de sessão no frontend quando o access token expira, sem alterar o contrato atual de autenticação. A causa raiz observada foi a combinação de um access token curto com o wrapper cliente tratando o primeiro `401` como perda definitiva de sessão, mesmo quando o refresh token ainda estava válido.

## O que foi alterado
- Centralização do retry único por `401` no wrapper de API do frontend, com refresh silencioso via `/api/auth/refresh`.
- Deduplicação de refresh concorrente para evitar tempestade de chamadas quando múltiplas requests expiram ao mesmo tempo.
- Ajuste dos serviços de login, registro, sessão e logout para não limparem estado de forma prematura em fluxos que não devem tentar refresh.
- Limpeza explícita de store de presence e cache do TanStack Query no logout.
- Inclusão de ação visível de logout no shell autenticado.
- Cobertura de testes para retry silencioso, concorrência de refresh, limpeza de sessão e logout no hook/navbar.

## Motivação
Em uso real, a experiência quebrava logo após a expiração do access token porque requisições comuns do app recebiam `401` e a sessão cliente era derrubada antes de qualquer tentativa de recuperação silenciosa. O efeito prático era reautenticação desnecessária, glitches de UI e perda de fluidez em ações comuns.

## Como validar
- `cd frontend`
- `npm run test -- tests/unit/lib/api.test.ts tests/unit/services/session.test.ts tests/unit/hooks/use-auth.test.tsx tests/unit/components/navbar.test.tsx tests/unit/components/auth-provider.test.tsx tests/unit/routes/auth-me-route.test.ts tests/unit/routes/auth-refresh-route.test.ts tests/unit/routes/auth-logout-route.test.ts tests/unit/routes/api-proxy-route.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Com o stack local ativo, autenticar no app, manter a sessão ativa até a expiração do access token e confirmar que a próxima navegação/ação recupera a sessão sem bounce para `/login`.
- Acionar `Sair` no shell autenticado e confirmar redirecionamento para `/login` com cache cliente limpo.

## Riscos e impactos
- O contrato de autenticação e os endpoints foram preservados; a mudança está concentrada na estratégia cliente de recuperação após `401`.
- O retry automático ocorre uma única vez por request e não é aplicado ao próprio `/auth/refresh`.
- Requests com corpos não reaproveitáveis além dos formatos já usados no app continuariam sensíveis a retry; nesta PR a cobertura foi feita sobre os formatos atualmente utilizados pelo frontend.
- O TTL do access token no backend não foi alterado nesta rodada; a correção foca em resiliência do fluxo existente.

## Evidências
- Validação local concluída com a suíte focada de auth/session/navigation, `typecheck`, `lint` e `build` do frontend.
- Smoke via API local: registro temporário, `GET /api/auth/me`, `POST /api/auth/logout` e confirmação de `401` após logout.
- Não há evidência anexada de browser session aging completo nesta PR; esse ponto foi coberto por testes focados do wrapper e deve ser revalidado em review funcional.

## Checklist
- [ ] Alteração limitada ao objetivo da PR
- [ ] Sem mudanças desconexas
- [ ] Impactos principais descritos
- [ ] Validação documentada
- [ ] Riscos identificados

Closes #206