### PR TITLE
feat(frontend): tornar a navegacao do app shell mais fluida

### DIFF
--- a/frontend/src/app/(app)/loading.tsx
+++ b/frontend/src/app/(app)/loading.tsx
@@ -1,0 +1,5 @@
+import { AppShellLoadingState } from '@/components/layout/app-shell-loading-state';
+
+export default function AppSegmentLoading() {
+  return <AppShellLoadingState />;
+}

--- a/frontend/src/components/layout/app-shell-loading-state.tsx
+++ b/frontend/src/components/layout/app-shell-loading-state.tsx
@@ -1,0 +1,42 @@
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function AppShellLoadingState() {
+  return (
+    <section
+      className="space-y-section"
+      data-testid="app-shell-loading-state"
+      aria-label="Carregando conteudo do shell"
+    >
+      <Card>
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-10 w-72" />
+          <Skeleton className="h-5 w-full max-w-2xl" />
+        </div>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(18rem,0.8fr)]">
+        <div className="space-y-4">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <Card key={index}>
+              <Skeleton className="h-6 w-40" />
+              <Skeleton className="mt-4 h-5 w-full" />
+              <Skeleton className="mt-2 h-5 w-2/3" />
+              <Skeleton className="mt-5 h-28 w-full" />
+            </Card>
+          ))}
+        </div>
+
+        <Card>
+          <div className="space-y-4">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-28 w-full" />
+          </div>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/layout/app-shell-route-warmup.tsx
+++ b/frontend/src/components/layout/app-shell-route-warmup.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { useAuth } from '@/hooks/use-auth';
+import { fetchFeed } from '@/services/feed';
+import { fetchFriends } from '@/services/friends';
+import { fetchNotifications } from '@/services/notifications';
+import { fetchProfileByUsername } from '@/services/profile';
+
+export function AppShellRouteWarmup() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { status, user } = useAuth();
+  const warmedSessionKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (status !== 'authenticated' || !user) {
+      warmedSessionKeyRef.current = null;
+      return;
+    }
+
+    const sessionKey = `${user.id}:${user.username}`;
+
+    if (warmedSessionKeyRef.current === sessionKey) {
+      return;
+    }
+
+    warmedSessionKeyRef.current = sessionKey;
+
+    const hotRoutes = [
+      '/feed',
+      '/notifications',
+      '/settings',
+      `/${user.username}`,
+    ];
+
+    hotRoutes.forEach((route) => {
+      router.prefetch(route);
+    });
+
+    void Promise.all([
+      queryClient.prefetchInfiniteQuery({
+        queryKey: ['feed', user.id],
+        initialPageParam: undefined as string | undefined,
+        queryFn: ({ pageParam }) =>
+          fetchFeed({
+            userId: user.id,
+            cursor: pageParam,
+          }),
+        getNextPageParam: (lastPage: Awaited<ReturnType<typeof fetchFeed>>) =>
+          lastPage.nextCursor ?? undefined,
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ['notifications', user.id, 'all'],
+        queryFn: () => fetchNotifications({ userId: user.id }),
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ['profile', user.username],
+        queryFn: () => fetchProfileByUsername(user.username),
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ['friends', user.id],
+        queryFn: () => fetchFriends(user.id),
+      }),
+    ]).catch(() => undefined);
+  }, [queryClient, router, status, user]);
+
+  return null;
+}

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import { Navbar } from '@/components/layout/navbar';
+import { AppShellRouteWarmup } from '@/components/layout/app-shell-route-warmup';
 import { Sidebar } from '@/components/layout/sidebar';
 
 type AppShellProps = {
@@ -44,6 +45,8 @@ export function AppShell({ children }: AppShellProps) {
 
   return (
     <div className="min-h-screen bg-background-primary text-primary">
+      <AppShellRouteWarmup />
+
       <Navbar
         variant="app"
         menuOpen={isSidebarOpen}

--- a/frontend/tests/unit/components/app-shell-route-warmup.test.tsx
+++ b/frontend/tests/unit/components/app-shell-route-warmup.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppShellRouteWarmup } from '@/components/layout/app-shell-route-warmup';
+import { useAuth } from '@/hooks/use-auth';
+import { fetchFeed } from '@/services/feed';
+import { fetchFriends } from '@/services/friends';
+import { fetchNotifications } from '@/services/notifications';
+import { fetchProfileByUsername } from '@/services/profile';
+
+const prefetchMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    prefetch: prefetchMock,
+  }),
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/feed', () => ({
+  fetchFeed: vi.fn(),
+}));
+
+vi.mock('@/services/friends', () => ({
+  fetchFriends: vi.fn(),
+}));
+
+vi.mock('@/services/notifications', () => ({
+  fetchNotifications: vi.fn(),
+}));
+
+vi.mock('@/services/profile', () => ({
+  fetchProfileByUsername: vi.fn(),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchFeed = vi.mocked(fetchFeed);
+const mockedFetchFriends = vi.mocked(fetchFriends);
+const mockedFetchNotifications = vi.mocked(fetchNotifications);
+const mockedFetchProfileByUsername = vi.mocked(fetchProfileByUsername);
+
+function renderWarmup() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AppShellRouteWarmup />
+    </QueryClientProvider>,
+  );
+}
+
+describe('AppShellRouteWarmup', () => {
+  beforeEach(() => {
+    prefetchMock.mockReset();
+    mockedUseAuth.mockReset();
+    mockedFetchFeed.mockReset();
+    mockedFetchFriends.mockReset();
+    mockedFetchNotifications.mockReset();
+    mockedFetchProfileByUsername.mockReset();
+
+    mockedFetchFeed.mockResolvedValue({
+      posts: [],
+      nextCursor: null,
+    });
+    mockedFetchFriends.mockResolvedValue([]);
+    mockedFetchNotifications.mockResolvedValue({
+      notifications: [],
+      unreadCount: 0,
+    });
+    mockedFetchProfileByUsername.mockResolvedValue({
+      id: 'user-1',
+      username: 'clutchplayer',
+      createdAt: '2026-04-12T00:00:00.000Z',
+      profile: {
+        displayName: 'Clutch Player',
+        bio: null,
+        avatarUrl: null,
+        bannerUrl: null,
+        accentColor: '#7C3AED',
+        badges: [],
+      },
+      stats: {
+        level: 7,
+        xp: 700,
+        reputation: 12,
+        friendCount: 0,
+        postCount: 0,
+      },
+      presence: {
+        status: 'ONLINE',
+        currentGame: null,
+        gameDetails: null,
+        platform: 'WEB',
+        updatedAt: '2026-04-12T00:00:00.000Z',
+      },
+      platformIntegrations: [],
+      gameLibrary: [],
+    });
+  });
+
+  it('prefetches hot routes and key shell queries for an authenticated user', async () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+
+    renderWarmup();
+
+    await waitFor(() => {
+      expect(prefetchMock).toHaveBeenCalledWith('/feed');
+      expect(prefetchMock).toHaveBeenCalledWith('/notifications');
+      expect(prefetchMock).toHaveBeenCalledWith('/settings');
+      expect(prefetchMock).toHaveBeenCalledWith('/clutchplayer');
+    });
+
+    await waitFor(() => {
+      expect(mockedFetchFeed).toHaveBeenCalledWith({
+        userId: 'user-1',
+        cursor: undefined,
+      });
+      expect(mockedFetchNotifications).toHaveBeenCalledWith({ userId: 'user-1' });
+      expect(mockedFetchProfileByUsername).toHaveBeenCalledWith('clutchplayer');
+      expect(mockedFetchFriends).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  it('does not prefetch while the session is still loading', () => {
+    mockedUseAuth.mockReturnValue({
+      status: 'loading',
+      user: null,
+      logout: vi.fn(),
+    });
+
+    renderWarmup();
+
+    expect(prefetchMock).not.toHaveBeenCalled();
+    expect(mockedFetchFeed).not.toHaveBeenCalled();
+    expect(mockedFetchNotifications).not.toHaveBeenCalled();
+    expect(mockedFetchProfileByUsername).not.toHaveBeenCalled();
+    expect(mockedFetchFriends).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/components/ui-feedback.test.tsx
+++ b/frontend/tests/unit/components/ui-feedback.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { AppErrorState } from '@/components/ui/app-error-state';
 import { AppLoadingScreen } from '@/components/ui/app-loading-screen';
 import { AppNotFoundState } from '@/components/ui/app-not-found-state';
+import { AppShellLoadingState } from '@/components/layout/app-shell-loading-state';
 import { ErrorBoundary } from '@/components/ui/error-boundary';
 import { ToastProvider, useToast } from '@/components/ui/toaster';
 
@@ -35,6 +36,12 @@ describe('UI feedback foundation', () => {
     render(<AppLoadingScreen />);
 
     expect(screen.getByTestId('app-loading-screen')).toBeInTheDocument();
+  });
+
+  it('renders the shell-local loading state', () => {
+    render(<AppShellLoadingState />);
+
+    expect(screen.getByTestId('app-shell-loading-state')).toBeInTheDocument();
   });
 
   it('renders the global not found state', () => {


### PR DESCRIPTION
## Resumo
Esta PR reduz a sensação de loading global nas áreas autenticadas do CLUTCH e aquece a navegação entre as rotas mais usadas do shell. O foco foi manter a continuidade visual do app shell e antecipar dados/rotas quentes sem misturar cache otimista ou mudanças de contrato.

## O que foi alterado
- Adição de `loading.tsx` no grupo `src/app/(app)` para que transições internas usem fallback local do shell, em vez de depender apenas do loading global da aplicação.
- Criação de um estado de loading próprio do shell autenticado, preservando a estrutura visual enquanto o segmento interno resolve a navegação.
- Inclusão de um warmup discreto no `AppShell` para prefetchar rotas quentes do produto (`/feed`, `/notifications`, `/settings`, `/:username`).
- Prefetch das queries que mais impactam a sensação de fluidez no shell atual: feed inicial, notificações, perfil atual e lista de amigos exibida no perfil.
- Testes unitários cobrindo o warmup do shell e a renderização do fallback local.

## Motivação
O shell autenticado já persistia no layout `(app)`, mas faltava um fallback segmentado para evitar a percepção de tela inteira carregando durante transições internas. Também faltava aquecimento intencional das rotas e queries mais quentes, o que mantinha a primeira navegação entre áreas principais mais pesada do que deveria para uma experiência de rede social.

## Como validar
- `cd frontend`
- `npm run test -- tests/unit/components/app-shell-route-warmup.test.tsx tests/unit/components/ui-feedback.test.tsx tests/unit/components/sidebar.test.tsx tests/unit/components/navbar.test.tsx tests/unit/components/feed-page-content.test.tsx tests/unit/components/notifications-page-content.test.tsx tests/unit/components/profile-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Com o stack local ativo, autenticar no app e navegar entre `/feed`, `/notifications`, `/settings` e `/:username`, confirmando que o shell permanece visível e que o loading de tela inteira deixa de ser o fallback principal nessas transições.

## Riscos e impactos
- O backend e os contratos consumidos pelo frontend foram preservados.
- O aquecimento de queries adiciona tráfego inicial controlado após a autenticação para priorizar fluidez nas áreas mais usadas do shell.
- A lista dedicada de amigos continua inexistente como rota própria; nesta PR o aquecimento cobre apenas a lista exibida dentro do perfil atual.
- Política de cache social mais agressiva e mutações otimistas continuam fora de escopo e seguem separadas na #202.

## Evidências
- Validação local concluída com testes unitários focados, `typecheck`, `lint` e `build` do frontend.
- Smoke autenticado no stack local com registro temporário e acesso bem-sucedido a `/feed`, `/notifications`, `/settings` e `/:username`, todos retornando `200`.
- Não há gravação visual anexada nesta PR.

## Checklist
- [ ] Alteração limitada ao objetivo da PR
- [ ] Sem mudanças desconexas
- [ ] Impactos principais descritos
- [ ] Validação documentada
- [ ] Riscos identificados

Closes #203