### PR TITLE
feat(frontend): alinhe cache social e contadores derivados

### DIFF
--- a/frontend/src/components/feed/reaction-bar.tsx
+++ b/frontend/src/components/feed/reaction-bar.tsx
@@ -3,6 +3,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import {
+  applyFeedReactionDelta,
+  restoreQuerySnapshots,
+  snapshotQueryGroups,
+} from '@/lib/query/social-cache';
 import { type InteractionType } from '@/schemas/feed';
 import { FeedRequestError, togglePostInteraction } from '@/services/feed';
 
@@ -44,9 +49,49 @@ export function ReactionBar({
 
   const toggleReactionMutation = useMutation({
     mutationFn: togglePostInteraction,
-    onSuccess: async ({ added }, variables) => {
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({
+        queryKey: ['feed'],
+      });
+
+      const feedSnapshots = snapshotQueryGroups(queryClient, [['feed']]);
+      const previousReactionCount = reactionCount;
+      const previousSelectedTypes = [...selectedTypes];
+      const optimisticAdded = !selectedTypes.includes(variables.type);
+      const delta = optimisticAdded ? 1 : -1;
+
       setServerError(null);
-      setReactionCount((current) => Math.max(0, current + (added ? 1 : -1)));
+      setReactionCount((current) => Math.max(0, current + delta));
+      setSelectedTypes((current) => {
+        const next = new Set(current);
+
+        if (optimisticAdded) {
+          next.add(variables.type);
+        } else {
+          next.delete(variables.type);
+        }
+
+        return Array.from(next);
+      });
+      applyFeedReactionDelta(queryClient, postId, delta);
+
+      return {
+        feedSnapshots,
+        optimisticAdded,
+        previousReactionCount,
+        previousSelectedTypes,
+      };
+    },
+    onSuccess: ({ added }, variables, context) => {
+      setServerError(null);
+
+      if (context && added !== context.optimisticAdded) {
+        const correction = added ? 2 : -2;
+
+        setReactionCount((current) => Math.max(0, current + correction));
+        applyFeedReactionDelta(queryClient, postId, correction);
+      }
+
       setSelectedTypes((current) => {
         const next = new Set(current);
 
@@ -58,18 +103,26 @@ export function ReactionBar({
 
         return Array.from(next);
       });
-
-      await queryClient.invalidateQueries({
-        queryKey: ['feed'],
-      });
     },
-    onError: (error) => {
+    onError: (error, _variables, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.feedSnapshots);
+        setReactionCount(context.previousReactionCount);
+        setSelectedTypes(context.previousSelectedTypes);
+      }
+
       if (error instanceof FeedRequestError) {
         setServerError(error.message);
         return;
       }
 
       setServerError('Nao foi possivel reagir a este post agora.');
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['feed'],
+        refetchType: 'inactive',
+      });
     },
   });
 

--- a/frontend/src/components/friends/friend-button.tsx
+++ b/frontend/src/components/friends/friend-button.tsx
@@ -6,6 +6,14 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/toaster';
 import { useAuth } from '@/hooks/use-auth';
 import {
+  applyAcceptedFriendRequest,
+  applyProfileFriendCountDelta,
+  applyRemovedFriend,
+  buildOptimisticFriendSummary,
+  restoreQuerySnapshots,
+  snapshotQueryGroups,
+} from '@/lib/query/social-cache';
+import {
   acceptFriendRequest,
   fetchFriends,
   fetchPendingFriendRequests,
@@ -56,30 +64,17 @@ export function FriendButton({ targetUserId }: FriendButtonProps) {
     }
   }, [incomingRequest, isFriend]);
 
-  const commonSuccessHandler = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({
-        queryKey: ['friends', currentUserId],
-      }),
-      queryClient.invalidateQueries({
-        queryKey: ['friend-requests', currentUserId],
-      }),
-      queryClient.invalidateQueries({
-        queryKey: ['profile'],
-      }),
-    ]);
-  };
-
   const sendRequestMutation = useMutation({
     mutationFn: sendFriendRequest,
-    onSuccess: async () => {
+    onMutate: () => {
       setLocalPending(true);
+    },
+    onSuccess: () => {
       showToast({
         title: 'Pedido enviado',
         description: 'O usuario foi notificado sobre o convite de amizade.',
         tone: 'success',
       });
-      await commonSuccessHandler();
     },
     onError: (error) => {
       if (error instanceof FriendsRequestError && error.status === 409) {
@@ -91,6 +86,8 @@ export function FriendButton({ targetUserId }: FriendButtonProps) {
         });
         return;
       }
+
+      setLocalPending(false);
 
       showToast({
         title: 'Nao foi possivel enviar o pedido',
@@ -104,16 +101,54 @@ export function FriendButton({ targetUserId }: FriendButtonProps) {
 
   const acceptRequestMutation = useMutation({
     mutationFn: acceptFriendRequest,
-    onSuccess: async () => {
+    onMutate: async () => {
+      await Promise.all([
+        queryClient.cancelQueries({
+          queryKey: ['friends', currentUserId],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ['friend-requests', currentUserId],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ['profile'],
+        }),
+      ]);
+
+      const snapshots = snapshotQueryGroups(queryClient, [
+        ['friends', currentUserId],
+        ['friend-requests', currentUserId],
+        ['profile'],
+      ]);
+
+      if (currentUserId && incomingRequest) {
+        applyAcceptedFriendRequest(
+          queryClient,
+          currentUserId,
+          incomingRequest,
+          buildOptimisticFriendSummary(queryClient, {
+            id: currentUserId,
+            username: user?.username ?? '',
+          }),
+        );
+        applyProfileFriendCountDelta(queryClient, [currentUserId, targetUserId], 1);
+      }
+
       setLocalPending(false);
+
+      return { snapshots };
+    },
+    onSuccess: () => {
       showToast({
         title: 'Amizade confirmada',
         description: 'A amizade foi aceita com sucesso.',
         tone: 'success',
       });
-      await commonSuccessHandler();
     },
-    onError: (error) => {
+    onError: (error, _requestId, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.snapshots);
+      }
+
       showToast({
         title: 'Nao foi possivel aceitar o pedido',
         description: error instanceof FriendsRequestError
@@ -122,26 +157,68 @@ export function FriendButton({ targetUserId }: FriendButtonProps) {
         tone: 'error',
       });
     },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['profile'],
+        refetchType: 'active',
+      });
+    },
   });
 
   const removeFriendMutation = useMutation({
     mutationFn: removeFriend,
-    onSuccess: async () => {
+    onMutate: async () => {
+      await Promise.all([
+        queryClient.cancelQueries({
+          queryKey: ['friends', currentUserId],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ['friends', targetUserId],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ['profile'],
+        }),
+      ]);
+
+      const snapshots = snapshotQueryGroups(queryClient, [
+        ['friends', currentUserId],
+        ['friends', targetUserId],
+        ['profile'],
+      ]);
+
+      if (currentUserId) {
+        applyRemovedFriend(queryClient, currentUserId, targetUserId);
+        applyProfileFriendCountDelta(queryClient, [currentUserId, targetUserId], -1);
+      }
+
       setLocalPending(false);
+
+      return { snapshots };
+    },
+    onSuccess: () => {
       showToast({
         title: 'Amizade removida',
         description: 'O perfil voltou a ficar fora da sua lista de amigos.',
         tone: 'success',
       });
-      await commonSuccessHandler();
     },
-    onError: (error) => {
+    onError: (error, _friendId, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.snapshots);
+      }
+
       showToast({
         title: 'Nao foi possivel remover a amizade',
         description: error instanceof FriendsRequestError
           ? error.message
           : 'Tente novamente em alguns instantes.',
         tone: 'error',
+      });
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['profile'],
+        refetchType: 'active',
       });
     },
   });

--- a/frontend/src/components/friends/friend-request-card.tsx
+++ b/frontend/src/components/friends/friend-request-card.tsx
@@ -6,6 +6,13 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
 import { useToast } from '@/components/ui/toaster';
+import {
+  applyAcceptedFriendRequest,
+  applyProfileFriendCountDelta,
+  buildOptimisticFriendSummary,
+  restoreQuerySnapshots,
+  snapshotQueryGroups,
+} from '@/lib/query/social-cache';
 import { type PendingFriendRequest } from '@/schemas/friends';
 import {
   acceptFriendRequest,
@@ -15,11 +22,13 @@ import {
 type FriendRequestCardProps = {
   request: PendingFriendRequest;
   receiverUserId: string;
+  receiverUsername: string;
 };
 
 export function FriendRequestCard({
   request,
   receiverUserId,
+  receiverUsername,
 }: FriendRequestCardProps) {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
@@ -31,31 +40,62 @@ export function FriendRequestCard({
 
   const acceptMutation = useMutation({
     mutationFn: acceptFriendRequest,
-    onSuccess: async () => {
+    onMutate: async () => {
+      await Promise.all([
+        queryClient.cancelQueries({
+          queryKey: ['friend-requests', receiverUserId],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ['friends', receiverUserId],
+        }),
+        queryClient.cancelQueries({
+          queryKey: ['profile'],
+        }),
+      ]);
+
+      const snapshots = snapshotQueryGroups(queryClient, [
+        ['friend-requests', receiverUserId],
+        ['friends', receiverUserId],
+        ['profile'],
+      ]);
+
+      applyAcceptedFriendRequest(
+        queryClient,
+        receiverUserId,
+        request,
+        buildOptimisticFriendSummary(queryClient, {
+          id: receiverUserId,
+          username: receiverUsername,
+        }),
+      );
+      applyProfileFriendCountDelta(queryClient, [receiverUserId, request.sender.id], 1);
+
+      return { snapshots };
+    },
+    onSuccess: () => {
       showToast({
         title: 'Pedido aceito',
         description: 'A amizade ja pode aparecer nas superfices sociais do app.',
         tone: 'success',
       });
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ['friend-requests', receiverUserId],
-        }),
-        queryClient.invalidateQueries({
-          queryKey: ['friends', receiverUserId],
-        }),
-        queryClient.invalidateQueries({
-          queryKey: ['profile'],
-        }),
-      ]);
     },
-    onError: (error) => {
+    onError: (error, _requestId, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.snapshots);
+      }
+
       showToast({
         title: 'Nao foi possivel aceitar o pedido',
         description: error instanceof FriendsRequestError
           ? error.message
           : 'Tente novamente em alguns instantes.',
         tone: 'error',
+      });
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['profile'],
+        refetchType: 'active',
       });
     },
   });

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -176,6 +176,7 @@ export function Navbar({
                                 key={request.id}
                                 request={request}
                                 receiverUserId={user?.id ?? ''}
+                                receiverUsername={user?.username ?? ''}
                               />
                             ))}
                           </div>

--- a/frontend/src/components/notifications/notifications-bell.tsx
+++ b/frontend/src/components/notifications/notifications-bell.tsx
@@ -7,6 +7,12 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/use-auth';
 import {
+  applyAllNotificationsRead,
+  applyNotificationRead,
+  restoreQuerySnapshots,
+  snapshotQueryGroups,
+} from '@/lib/query/social-cache';
+import {
   fetchNotifications,
   markAllNotificationsAsRead,
   markNotificationAsRead,
@@ -26,30 +32,57 @@ export function NotificationsBell() {
     refetchInterval: 30_000,
   });
 
-  const invalidateNotifications = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'all'] }),
-      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'unread'] }),
-    ]);
-  };
-
   const markOneMutation = useMutation({
     mutationFn: markNotificationAsRead,
-    onMutate: (notificationId) => {
+    onMutate: async (notificationId) => {
       setActiveNotificationId(notificationId);
+
+      await queryClient.cancelQueries({
+        queryKey: ['notifications', userId],
+      });
+
+      const snapshots = snapshotQueryGroups(queryClient, [['notifications', userId]]);
+      applyNotificationRead(queryClient, userId as string, notificationId);
+
+      return { snapshots };
     },
-    onSuccess: async () => {
-      await invalidateNotifications();
+    onError: (_error, _notificationId, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.snapshots);
+      }
     },
-    onSettled: () => {
+    onSettled: async () => {
       setActiveNotificationId(null);
+
+      await queryClient.invalidateQueries({
+        queryKey: ['notifications', userId],
+        refetchType: 'inactive',
+      });
     },
   });
 
   const markAllMutation = useMutation({
     mutationFn: markAllNotificationsAsRead,
-    onSuccess: async () => {
-      await invalidateNotifications();
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ['notifications', userId],
+      });
+
+      const snapshots = snapshotQueryGroups(queryClient, [['notifications', userId]]);
+      applyAllNotificationsRead(queryClient, userId as string);
+
+      return { snapshots };
+    },
+    onError: (_error, _variables, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.snapshots);
+      }
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['notifications', userId],
+        refetchType: 'inactive',
+      });
     },
   });
 

--- a/frontend/src/components/notifications/notifications-page-content.tsx
+++ b/frontend/src/components/notifications/notifications-page-content.tsx
@@ -8,6 +8,12 @@ import { SectionHeading } from '@/components/ui/section-heading';
 import { useToast } from '@/components/ui/toaster';
 import { useAuth } from '@/hooks/use-auth';
 import {
+  applyAllNotificationsRead,
+  applyNotificationRead,
+  restoreQuerySnapshots,
+  snapshotQueryGroups,
+} from '@/lib/query/social-cache';
+import {
   fetchNotifications,
   markAllNotificationsAsRead,
   markNotificationAsRead,
@@ -74,24 +80,30 @@ export function NotificationsPageContent() {
     refetchInterval: 30_000,
   });
 
-  const invalidateNotifications = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'all'] }),
-      queryClient.invalidateQueries({ queryKey: ['notifications', userId, 'unread'] }),
-    ]);
-  };
-
   const markOneMutation = useMutation({
     mutationFn: markNotificationAsRead,
-    onSuccess: async () => {
+    onMutate: async (notificationId) => {
+      await queryClient.cancelQueries({
+        queryKey: ['notifications', userId],
+      });
+
+      const snapshots = snapshotQueryGroups(queryClient, [['notifications', userId]]);
+      applyNotificationRead(queryClient, userId as string, notificationId);
+
+      return { snapshots };
+    },
+    onSuccess: () => {
       showToast({
         title: 'Notificacao atualizada',
         description: 'A notificacao foi marcada como lida.',
         tone: 'success',
       });
-      await invalidateNotifications();
     },
-    onError: (error) => {
+    onError: (error, _notificationId, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.snapshots);
+      }
+
       const description = error instanceof NotificationsRequestError
         ? error.message
         : 'Tente novamente em alguns instantes.';
@@ -102,19 +114,38 @@ export function NotificationsPageContent() {
         tone: 'error',
       });
     },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['notifications', userId],
+        refetchType: 'inactive',
+      });
+    },
   });
 
   const markAllMutation = useMutation({
     mutationFn: markAllNotificationsAsRead,
-    onSuccess: async () => {
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ['notifications', userId],
+      });
+
+      const snapshots = snapshotQueryGroups(queryClient, [['notifications', userId]]);
+      applyAllNotificationsRead(queryClient, userId as string);
+
+      return { snapshots };
+    },
+    onSuccess: () => {
       showToast({
         title: 'Inbox atualizado',
         description: 'Todas as notificacoes foram marcadas como lidas.',
         tone: 'success',
       });
-      await invalidateNotifications();
     },
-    onError: (error) => {
+    onError: (error, _variables, context) => {
+      if (context) {
+        restoreQuerySnapshots(queryClient, context.snapshots);
+      }
+
       const description = error instanceof NotificationsRequestError
         ? error.message
         : 'Tente novamente em alguns instantes.';
@@ -123,6 +154,12 @@ export function NotificationsPageContent() {
         title: 'Nao foi possivel limpar o inbox',
         description,
         tone: 'error',
+      });
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['notifications', userId],
+        refetchType: 'inactive',
       });
     },
   });

--- a/frontend/src/lib/query/social-cache.ts
+++ b/frontend/src/lib/query/social-cache.ts
@@ -1,0 +1,293 @@
+import type { InfiniteData, QueryClient, QueryKey } from '@tanstack/react-query';
+import type { FeedResponse } from '@/schemas/feed';
+import type { FriendSummary, PendingFriendRequest } from '@/schemas/friends';
+import type { NotificationsResponse } from '@/schemas/notifications';
+import type { ProfileResponse } from '@/schemas/profile';
+
+type QuerySnapshot = {
+  queryKey: QueryKey;
+  data: unknown;
+};
+
+type FeedInfiniteData = InfiniteData<FeedResponse, string | undefined>;
+
+function mapFeedPages(
+  data: FeedInfiniteData | undefined,
+  transform: (post: FeedResponse['posts'][number]) => FeedResponse['posts'][number],
+): FeedInfiniteData | undefined {
+  if (!data) {
+    return data;
+  }
+
+  let changed = false;
+
+  const pages = data.pages.map((page) => {
+    const posts = page.posts.map((post) => {
+      const nextPost = transform(post);
+
+      if (nextPost !== post) {
+        changed = true;
+      }
+
+      return nextPost;
+    });
+
+    return changed ? { ...page, posts } : page;
+  });
+
+  return changed ? { ...data, pages } : data;
+}
+
+function buildFriendSummaryFromRequest(request: PendingFriendRequest): FriendSummary {
+  return {
+    id: request.sender.id,
+    username: request.sender.username,
+    profile: request.sender.profile
+      ? {
+          displayName: request.sender.profile.displayName,
+          avatarUrl: request.sender.profile.avatarUrl,
+          accentColor: null,
+        }
+      : null,
+    presence: null,
+  };
+}
+
+function buildFriendSummaryFromProfile(profile: ProfileResponse): FriendSummary {
+  return {
+    id: profile.id,
+    username: profile.username,
+    profile: {
+      displayName: profile.profile.displayName,
+      avatarUrl: profile.profile.avatarUrl,
+      accentColor: profile.profile.accentColor,
+    },
+    presence: null,
+  };
+}
+
+function findCachedProfile(
+  queryClient: QueryClient,
+  userId: string,
+): ProfileResponse | null {
+  const match = queryClient
+    .getQueriesData<ProfileResponse>({ queryKey: ['profile'] })
+    .find(([, data]) => data?.id === userId);
+
+  return match?.[1] ?? null;
+}
+
+export function buildOptimisticFriendSummary(
+  queryClient: QueryClient,
+  user: {
+    id: string;
+    username: string;
+  },
+): FriendSummary {
+  const cachedProfile = findCachedProfile(queryClient, user.id);
+
+  if (cachedProfile) {
+    return buildFriendSummaryFromProfile(cachedProfile);
+  }
+
+  return {
+    id: user.id,
+    username: user.username,
+    profile: null,
+    presence: null,
+  };
+}
+
+export function snapshotQueryGroups(
+  queryClient: QueryClient,
+  queryKeys: QueryKey[],
+): QuerySnapshot[] {
+  return queryKeys.flatMap((queryKey) =>
+    queryClient.getQueriesData({ queryKey }).map(([matchedKey, data]) => ({
+      queryKey: matchedKey,
+      data,
+    })),
+  );
+}
+
+export function restoreQuerySnapshots(
+  queryClient: QueryClient,
+  snapshots: QuerySnapshot[],
+): void {
+  snapshots.forEach(({ queryKey, data }) => {
+    queryClient.setQueryData(queryKey, data);
+  });
+}
+
+export function applyFeedReactionDelta(
+  queryClient: QueryClient,
+  postId: string,
+  delta: number,
+): void {
+  queryClient.setQueriesData<FeedInfiniteData>({ queryKey: ['feed'] }, (data) =>
+    mapFeedPages(data, (post) => {
+      if (post.id !== postId) {
+        return post;
+      }
+
+      return {
+        ...post,
+        _count: {
+          ...post._count,
+          interactions: Math.max(0, post._count.interactions + delta),
+        },
+      };
+    }),
+  );
+}
+
+export function applyNotificationRead(
+  queryClient: QueryClient,
+  userId: string,
+  notificationId: string,
+): void {
+  queryClient
+    .getQueriesData<NotificationsResponse>({ queryKey: ['notifications', userId] })
+    .forEach(([queryKey, data]) => {
+      if (!data) {
+        return;
+      }
+
+      const target = data.notifications.find(
+        (notification) => notification.id === notificationId,
+      );
+
+      if (!target || target.isRead) {
+        return;
+      }
+
+      const scope = queryKey[2];
+      const unreadCount = Math.max(0, data.unreadCount - 1);
+      const notifications =
+        scope === 'unread'
+          ? data.notifications.filter((notification) => notification.id !== notificationId)
+          : data.notifications.map((notification) =>
+              notification.id === notificationId
+                ? { ...notification, isRead: true }
+                : notification,
+            );
+
+      queryClient.setQueryData<NotificationsResponse>(queryKey, {
+        ...data,
+        notifications,
+        unreadCount,
+      });
+    });
+}
+
+export function applyAllNotificationsRead(
+  queryClient: QueryClient,
+  userId: string,
+): void {
+  queryClient
+    .getQueriesData<NotificationsResponse>({ queryKey: ['notifications', userId] })
+    .forEach(([queryKey, data]) => {
+      if (!data || data.unreadCount === 0) {
+        return;
+      }
+
+      const scope = queryKey[2];
+
+      queryClient.setQueryData<NotificationsResponse>(queryKey, {
+        ...data,
+        notifications:
+          scope === 'unread'
+            ? []
+            : data.notifications.map((notification) => ({
+                ...notification,
+                isRead: true,
+              })),
+        unreadCount: 0,
+      });
+    });
+}
+
+export function applyAcceptedFriendRequest(
+  queryClient: QueryClient,
+  receiverUserId: string,
+  request: PendingFriendRequest,
+  receiverSummary?: FriendSummary,
+): void {
+  queryClient.setQueriesData<PendingFriendRequest[]>(
+    { queryKey: ['friend-requests', receiverUserId] },
+    (data) => data?.filter((entry) => entry.id !== request.id) ?? data,
+  );
+
+  queryClient.setQueriesData<FriendSummary[]>(
+    { queryKey: ['friends', receiverUserId] },
+    (data) => {
+      if (!data) {
+        return data;
+      }
+
+      if (data.some((friend) => friend.id === request.sender.id)) {
+        return data;
+      }
+
+      return [...data, buildFriendSummaryFromRequest(request)];
+    },
+  );
+
+  if (receiverSummary) {
+    queryClient.setQueriesData<FriendSummary[]>(
+      { queryKey: ['friends', request.sender.id] },
+      (data) => {
+        if (!data) {
+          return data;
+        }
+
+        if (data.some((friend) => friend.id === receiverSummary.id)) {
+          return data;
+        }
+
+        return [...data, receiverSummary];
+      },
+    );
+  }
+}
+
+export function applyRemovedFriend(
+  queryClient: QueryClient,
+  currentUserId: string,
+  targetUserId: string,
+): void {
+  queryClient.setQueriesData<FriendSummary[]>(
+    { queryKey: ['friends', currentUserId] },
+    (data) => data?.filter((friend) => friend.id !== targetUserId) ?? data,
+  );
+
+  queryClient.setQueriesData<FriendSummary[]>(
+    { queryKey: ['friends', targetUserId] },
+    (data) => data?.filter((friend) => friend.id !== currentUserId) ?? data,
+  );
+}
+
+export function applyProfileFriendCountDelta(
+  queryClient: QueryClient,
+  userIds: string[],
+  delta: number,
+): void {
+  const targetIds = new Set(userIds);
+
+  queryClient.setQueriesData<ProfileResponse>(
+    { queryKey: ['profile'] },
+    (data) => {
+      if (!data || !targetIds.has(data.id)) {
+        return data;
+      }
+
+      return {
+        ...data,
+        stats: {
+          ...data.stats,
+          friendCount: Math.max(0, data.stats.friendCount + delta),
+        },
+      };
+    },
+  );
+}

--- a/frontend/tests/unit/components/friend-button.test.tsx
+++ b/frontend/tests/unit/components/friend-button.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FriendButton } from '@/components/friends/friend-button';
 import { ToastProvider } from '@/components/ui/toaster';
 import { useAuth } from '@/hooks/use-auth';
+import { type ProfileResponse } from '@/schemas/profile';
 import {
   acceptFriendRequest,
   fetchFriends,
@@ -41,6 +42,58 @@ const mockedSendFriendRequest = vi.mocked(sendFriendRequest);
 const mockedAcceptFriendRequest = vi.mocked(acceptFriendRequest);
 const mockedRemoveFriend = vi.mocked(removeFriend);
 
+function createProfileFixture({
+  id,
+  username,
+  friendCount,
+}: {
+  id: string;
+  username: string;
+  friendCount: number;
+}): ProfileResponse {
+  return {
+    id,
+    username,
+    createdAt: '2026-03-29T22:15:00.000Z',
+    profile: {
+      displayName: username,
+      bio: null,
+      avatarUrl: null,
+      bannerUrl: null,
+      accentColor: '#7C3AED',
+      badges: [],
+    },
+    stats: {
+      level: 10,
+      xp: 1000,
+      reputation: 200,
+      friendCount,
+      postCount: 3,
+    },
+    presence: {
+      status: 'ONLINE',
+      currentGame: null,
+      gameDetails: null,
+      platform: 'PC',
+      updatedAt: '2026-03-29T22:15:00.000Z',
+    },
+    platformIntegrations: [],
+    gameLibrary: [],
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 function renderFriendButton(targetUserId = 'user-2') {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -56,6 +109,8 @@ function renderFriendButton(targetUserId = 'user-2') {
       </QueryClientProvider>
     </ToastProvider>,
   );
+
+  return { queryClient };
 }
 
 describe('FriendButton', () => {
@@ -87,14 +142,19 @@ describe('FriendButton', () => {
   });
 
   it('sends a friend request from the default state', async () => {
-    mockedSendFriendRequest.mockResolvedValue({
-      id: 'request-1',
-      status: 'PENDING',
-    });
+    const deferred = createDeferred<{ id: string; status: 'PENDING' }>();
+    mockedSendFriendRequest.mockReturnValue(deferred.promise);
 
     renderFriendButton();
 
     fireEvent.click(await screen.findByRole('button', { name: /adicionar amigo/i }));
+
+    expect(await screen.findByRole('button', { name: /pedido enviado/i })).toBeDisabled();
+
+    deferred.resolve({
+      id: 'request-1',
+      status: 'PENDING',
+    });
 
     await waitFor(() => {
       expect(mockedSendFriendRequest).toHaveBeenCalled();
@@ -120,11 +180,49 @@ describe('FriendButton', () => {
         },
       },
     ]);
-    mockedAcceptFriendRequest.mockResolvedValue(undefined);
+    const deferred = createDeferred<void>();
+    mockedAcceptFriendRequest.mockReturnValue(deferred.promise);
 
-    renderFriendButton();
+    const { queryClient } = renderFriendButton();
+    queryClient.setQueryData(
+      ['profile', 'clutchplayer'],
+      createProfileFixture({
+        id: 'user-1',
+        username: 'clutchplayer',
+        friendCount: 2,
+      }),
+    );
+    queryClient.setQueryData(
+      ['profile', 'pixelsamurai'],
+      createProfileFixture({
+        id: 'user-2',
+        username: 'pixelsamurai',
+        friendCount: 4,
+      }),
+    );
+    queryClient.setQueryData(['friends', 'user-2'], []);
 
     fireEvent.click(await screen.findByRole('button', { name: /aceitar pedido/i }));
+
+    expect(await screen.findByRole('button', { name: /^amigos$/i })).toBeDisabled();
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<ProfileResponse>(['profile', 'clutchplayer'])?.stats.friendCount,
+      ).toBe(3);
+      expect(
+        queryClient.getQueryData<ProfileResponse>(['profile', 'pixelsamurai'])?.stats.friendCount,
+      ).toBe(5);
+      expect(queryClient.getQueryData<Array<{ id: string }>>(['friends', 'user-2'])).toEqual([
+        expect.objectContaining({
+          id: 'user-1',
+          username: 'clutchplayer',
+        }),
+      ]);
+    });
+
+    await act(async () => {
+      deferred.resolve();
+    });
 
     await waitFor(() => {
       expect(mockedAcceptFriendRequest).toHaveBeenCalled();
@@ -150,12 +248,52 @@ describe('FriendButton', () => {
         },
       },
     ]);
-    mockedRemoveFriend.mockResolvedValue(undefined);
+    const deferred = createDeferred<void>();
+    mockedRemoveFriend.mockReturnValue(deferred.promise);
 
-    renderFriendButton();
+    const { queryClient } = renderFriendButton();
+    queryClient.setQueryData(
+      ['profile', 'clutchplayer'],
+      createProfileFixture({
+        id: 'user-1',
+        username: 'clutchplayer',
+        friendCount: 3,
+      }),
+    );
+    queryClient.setQueryData(
+      ['profile', 'pixelsamurai'],
+      createProfileFixture({
+        id: 'user-2',
+        username: 'pixelsamurai',
+        friendCount: 6,
+      }),
+    );
+    queryClient.setQueryData(['friends', 'user-2'], [
+      {
+        id: 'user-1',
+        username: 'clutchplayer',
+        profile: null,
+        presence: null,
+      },
+    ]);
 
     expect(await screen.findByRole('button', { name: /^amigos$/i })).toBeDisabled();
     fireEvent.click(screen.getByRole('button', { name: /remover/i }));
+
+    expect(await screen.findByRole('button', { name: /adicionar amigo/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<ProfileResponse>(['profile', 'clutchplayer'])?.stats.friendCount,
+      ).toBe(2);
+      expect(
+        queryClient.getQueryData<ProfileResponse>(['profile', 'pixelsamurai'])?.stats.friendCount,
+      ).toBe(5);
+      expect(queryClient.getQueryData(['friends', 'user-2'])).toEqual([]);
+    });
+
+    await act(async () => {
+      deferred.resolve();
+    });
 
     await waitFor(() => {
       expect(mockedRemoveFriend).toHaveBeenCalled();

--- a/frontend/tests/unit/components/friend-request-card.test.tsx
+++ b/frontend/tests/unit/components/friend-request-card.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FriendRequestCard } from '@/components/friends/friend-request-card';
 import { ToastProvider } from '@/components/ui/toaster';
+import { type ProfileResponse } from '@/schemas/profile';
 import { acceptFriendRequest } from '@/services/friends';
 
 vi.mock('@/services/friends', () => ({
@@ -21,6 +22,58 @@ vi.mock('@/services/friends', () => ({
 
 const mockedAcceptFriendRequest = vi.mocked(acceptFriendRequest);
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function createProfileFixture({
+  id,
+  username,
+  friendCount,
+}: {
+  id: string;
+  username: string;
+  friendCount: number;
+}): ProfileResponse {
+  return {
+    id,
+    username,
+    createdAt: '2026-03-29T22:15:00.000Z',
+    profile: {
+      displayName: username,
+      bio: null,
+      avatarUrl: null,
+      bannerUrl: null,
+      accentColor: '#7C3AED',
+      badges: [],
+    },
+    stats: {
+      level: 10,
+      xp: 1000,
+      reputation: 200,
+      friendCount,
+      postCount: 3,
+    },
+    presence: {
+      status: 'ONLINE',
+      currentGame: null,
+      gameDetails: null,
+      platform: 'PC',
+      updatedAt: '2026-03-29T22:15:00.000Z',
+    },
+    platformIntegrations: [],
+    gameLibrary: [],
+  };
+}
+
 function renderFriendRequestCard() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -34,6 +87,7 @@ function renderFriendRequestCard() {
       <QueryClientProvider client={queryClient}>
         <FriendRequestCard
           receiverUserId="user-1"
+          receiverUsername="clutchplayer"
           request={{
             id: 'request-1',
             createdAt: '2026-03-31T10:00:00.000Z',
@@ -50,6 +104,8 @@ function renderFriendRequestCard() {
       </QueryClientProvider>
     </ToastProvider>,
   );
+
+  return { queryClient };
 }
 
 describe('FriendRequestCard', () => {
@@ -58,11 +114,47 @@ describe('FriendRequestCard', () => {
   });
 
   it('accepts a pending request', async () => {
-    mockedAcceptFriendRequest.mockResolvedValue(undefined);
+    const deferred = createDeferred<void>();
+    mockedAcceptFriendRequest.mockReturnValue(deferred.promise);
 
-    renderFriendRequestCard();
+    const { queryClient } = renderFriendRequestCard();
+    queryClient.setQueryData(
+      ['profile', 'clutchplayer'],
+      createProfileFixture({
+        id: 'user-1',
+        username: 'clutchplayer',
+        friendCount: 1,
+      }),
+    );
+    queryClient.setQueryData(
+      ['profile', 'pixelsamurai'],
+      createProfileFixture({
+        id: 'user-2',
+        username: 'pixelsamurai',
+        friendCount: 4,
+      }),
+    );
+    queryClient.setQueryData(['friends', 'user-2'], []);
 
     fireEvent.click(screen.getByRole('button', { name: /aceitar pedido/i }));
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<ProfileResponse>(['profile', 'clutchplayer'])?.stats.friendCount,
+      ).toBe(2);
+      expect(
+        queryClient.getQueryData<ProfileResponse>(['profile', 'pixelsamurai'])?.stats.friendCount,
+      ).toBe(5);
+      expect(queryClient.getQueryData<Array<{ id: string }>>(['friends', 'user-2'])).toEqual([
+        expect.objectContaining({
+          id: 'user-1',
+          username: 'clutchplayer',
+        }),
+      ]);
+    });
+
+    await act(async () => {
+      deferred.resolve();
+    });
 
     await waitFor(() => {
       expect(mockedAcceptFriendRequest).toHaveBeenCalled();

--- a/frontend/tests/unit/components/notifications-social-sync.test.tsx
+++ b/frontend/tests/unit/components/notifications-social-sync.test.tsx
@@ -1,0 +1,177 @@
+import React, { type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationsBell } from '@/components/notifications/notifications-bell';
+import { NotificationsPageContent } from '@/components/notifications/notifications-page-content';
+import { ToastProvider } from '@/components/ui/toaster';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchNotifications,
+  markNotificationAsRead,
+  NotificationsRequestError,
+} from '@/services/notifications';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/notifications', () => ({
+  fetchNotifications: vi.fn(),
+  markNotificationAsRead: vi.fn(),
+  markAllNotificationsAsRead: vi.fn(),
+  NotificationsRequestError: class NotificationsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'NotificationsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchNotifications = vi.mocked(fetchNotifications);
+const mockedMarkNotificationAsRead = vi.mocked(markNotificationAsRead);
+
+function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </ToastProvider>,
+  );
+}
+
+describe('Notifications social cache sync', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchNotifications.mockReset();
+    mockedMarkNotificationAsRead.mockReset();
+
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        username: 'clutchplayer',
+        email: 'clutchplayer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+    mockedFetchNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'notification-1',
+          userId: 'user-1',
+          actorId: 'user-2',
+          type: 'FRIEND_REQUEST',
+          payload: {
+            requestId: 'request-1',
+            senderId: 'user-2',
+          },
+          isRead: false,
+          createdAt: '2026-03-31T10:00:00.000Z',
+        },
+      ],
+      unreadCount: 1,
+    });
+  });
+
+  it('updates bell and page immediately when a notification is marked as read', async () => {
+    const deferred = createDeferred<{
+      id: string;
+      userId: string;
+      actorId: string | null;
+      type: 'FRIEND_REQUEST';
+      payload: { requestId: string; senderId: string };
+      isRead: boolean;
+      createdAt: string;
+    }>();
+    mockedMarkNotificationAsRead.mockReturnValue(deferred.promise);
+
+    renderWithQuery(
+      <>
+        <NotificationsBell />
+        <NotificationsPageContent />
+      </>,
+    );
+
+    await screen.findByText(/seu inbox social/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /marcar como lida/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /open notifications preview/i })).toHaveTextContent(
+        '0',
+      );
+    });
+    expect(screen.getByText(/^lida$/i)).toBeInTheDocument();
+
+    await act(async () => {
+      deferred.resolve({
+        id: 'notification-1',
+        userId: 'user-1',
+        actorId: 'user-2',
+        type: 'FRIEND_REQUEST',
+        payload: {
+          requestId: 'request-1',
+          senderId: 'user-2',
+        },
+        isRead: true,
+        createdAt: '2026-03-31T10:00:00.000Z',
+      });
+    });
+
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(/notificacao atualizada/i);
+  });
+
+  it('rolls back the unread count when marking a notification as read fails', async () => {
+    const deferred = createDeferred<never>();
+    mockedMarkNotificationAsRead.mockReturnValue(deferred.promise);
+
+    renderWithQuery(
+      <>
+        <NotificationsBell />
+        <NotificationsPageContent />
+      </>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /marcar como lida/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /open notifications preview/i })).toHaveTextContent(
+        '0',
+      );
+    });
+
+    await act(async () => {
+      deferred.reject(new NotificationsRequestError(503, 'Inbox indisponivel.'));
+    });
+
+    expect(await screen.findByTestId('toast-item')).toHaveTextContent(
+      /nao foi possivel atualizar a notificacao/i,
+    );
+    expect(screen.getByRole('button', { name: /open notifications preview/i })).toHaveTextContent(
+      '1',
+    );
+  });
+});

--- a/frontend/tests/unit/components/reaction-bar.test.tsx
+++ b/frontend/tests/unit/components/reaction-bar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReactionBar } from '@/components/feed/reaction-bar';
 import { FeedRequestError, togglePostInteraction } from '@/services/feed';
@@ -19,6 +19,18 @@ vi.mock('@/services/feed', () => ({
 }));
 
 const mockedTogglePostInteraction = vi.mocked(togglePostInteraction);
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
 
 function renderReactionBar(canInteract = true) {
   const queryClient = new QueryClient({
@@ -48,11 +60,24 @@ describe('ReactionBar', () => {
     mockedTogglePostInteraction.mockReset();
   });
 
-  it('toggles a reaction and updates the total count', async () => {
-    mockedTogglePostInteraction.mockResolvedValue({ added: true });
+  it('updates the reaction count immediately before the server resolves', async () => {
+    const deferred = createDeferred<{ added: boolean }>();
+    mockedTogglePostInteraction.mockReturnValue(deferred.promise);
     const { invalidateQueriesSpy } = renderReactionBar();
 
     fireEvent.click(screen.getByRole('button', { name: /gg/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/3 reacoes no total/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /gg/i })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+
+    await act(async () => {
+      deferred.resolve({ added: true });
+    });
 
     await waitFor(() => {
       expect(mockedTogglePostInteraction).toHaveBeenCalled();
@@ -63,30 +88,37 @@ describe('ReactionBar', () => {
     });
 
     expect(await screen.findByText(/3 reacoes no total/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /gg/i })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
 
     await waitFor(() => {
       expect(invalidateQueriesSpy).toHaveBeenCalledWith({
         queryKey: ['feed'],
+        refetchType: 'inactive',
       });
     });
   });
 
-  it('renders backend errors from reaction toggle', async () => {
-    mockedTogglePostInteraction.mockRejectedValue(
-      new FeedRequestError(400, 'Voce nao pode reagir ao proprio post.'),
-    );
+  it('restores the previous count when the optimistic reaction fails', async () => {
+    const deferred = createDeferred<{ added: boolean }>();
+    mockedTogglePostInteraction.mockReturnValue(deferred.promise);
 
     renderReactionBar();
 
     fireEvent.click(screen.getByRole('button', { name: /gg/i }));
 
+    await waitFor(() => {
+      expect(screen.getByText(/3 reacoes no total/i)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      deferred.reject(new FeedRequestError(400, 'Voce nao pode reagir ao proprio post.'));
+    });
+
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /voce nao pode reagir ao proprio post/i,
     );
+    await waitFor(() => {
+      expect(screen.getByText(/2 reacoes no total/i)).toBeInTheDocument();
+    });
   });
 
   it('disables reaction buttons when the user cannot interact', () => {


### PR DESCRIPTION
## Resumo
Melhora a camada social do frontend com updates otimistas para reações, notificações e amizade, além de alinhar os contadores derivados de perfil que ainda dependiam apenas de revalidação posterior. A PR reduz saltos visuais após mutações comuns e mantém rollback consistente quando a operação falha.

## O que foi alterado
- Centralizei utilitários de cache social para snapshot, rollback e patch granular de feed, notificações, amizade e perfil.
- Atualizei `ReactionBar` para refletir likes/reactions imediatamente e restaurar o estado local em caso de erro.
- Sincronizei bell e página de notificações com marcação otimista de leitura e reconciliação em background.
- Ajustei `FriendButton` e `FriendRequestCard` para atualizar amizade, requests e `friendCount` do perfil sem depender apenas de `invalidateQueries(['profile'])`.
- Completei a sincronização bidirecional da lista de amigos quando o outro lado já está em cache.
- Ampliei a cobertura de testes para updates otimistas, rollback e contadores derivados de perfil.

## Motivação
Depois da estabilização de auth e shell, o maior problema perceptível restante estava na camada de dados social: ações como curtir, aceitar amizade ou marcar notificações ainda geravam espera visível ou contadores incoerentes até a próxima revalidação. Esta PR fecha essa lacuna mantendo o backend como fonte da verdade e usando reconciliação posterior apenas como fallback.

## Como validar
- `cd frontend`
- `npm run test -- tests/unit/components/reaction-bar.test.tsx tests/unit/components/notifications-bell.test.tsx tests/unit/components/notifications-page-content.test.tsx tests/unit/components/notifications-social-sync.test.tsx tests/unit/components/friend-button.test.tsx tests/unit/components/friend-request-card.test.tsx tests/unit/components/navbar.test.tsx tests/unit/components/profile-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Validar manualmente com dois usuários autenticados:
- enviar pedido de amizade
- aceitar no perfil do outro usuário
- conferir `friendCount` imediato nos dois perfis
- remover amizade e conferir retorno imediato dos contadores
- marcar notificação como lida e observar sincronização entre bell e página
- reagir a um post e observar atualização imediata com rollback em erro

## Riscos e impactos
- A alteração fica restrita ao frontend e preserva os contratos atuais do backend.
- Contadores e listas já em cache passam a ser patched localmente; superfícies ainda não carregadas continuam dependendo do primeiro fetch, o que é esperado.
- `invalidateQueries(['profile'])` foi mantido como reconciliação em background para reduzir risco de divergência silenciosa.
- O smoke manual autenticado confirmou `friendCount` imediato em aceite e remoção; a repetição isolada do badge de requests encontrou ruído operacional do ambiente local ao reutilizar usuários, sem indicar regressão funcional do fluxo principal.

## Evidências
- Testes focados da camada social passaram localmente.
- `npm run typecheck`, `npm run lint` e `npm run build` passaram localmente.
- Smoke manual autenticado confirmou `friendCount` de `0 -> 1 -> 0` no perfil do remetente e no perfil do receptor durante aceite e remoção de amizade.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #202