### PR TITLE
feat(integrations): add Discord presence ingestion boundary

### DIFF
--- a/backend/src/api/routes/integrations.routes.ts
+++ b/backend/src/api/routes/integrations.routes.ts
@@ -1,5 +1,11 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import {
+  DISCORD_PRESENCE_INGEST_TOKEN_HEADER,
+  hasValidDiscordPresenceIngestToken,
+  isDiscordPresenceIngestConfigured,
+} from '../../config/discord-presence';
+import { createIntegrationError } from '../../infra/integrations/integration.errors';
 import { isIntegrationError } from '../../core/services/integrations.service';
 
 const steamConnectSchema = z.object({
@@ -21,6 +27,13 @@ const discordCallbackSchema = z.object({
     message: 'Callback Discord inválido.',
   },
 );
+
+const discordPresenceIngestSchema = z.object({
+  externalId: z.string().min(1, 'Discord externalId é obrigatório.'),
+  status: z.enum(['ONLINE', 'IN_GAME', 'AFK', 'OFFLINE']),
+  currentGame: z.string().max(100).nullable().optional(),
+  gameDetails: z.record(z.unknown()).nullable().optional(),
+});
 
 function replyWithIntegrationError(
   request: { id: string; method: string; url: string; log: FastifyInstance['log'] },
@@ -146,6 +159,62 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(200).send(resultPayload);
       } catch (error) {
         const integrationError = replyWithIntegrationError(request, error, { logFailure: false });
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
+      }
+    },
+  );
+
+  // ── POST /integrations/discord/presence ────────────────
+  app.post(
+    '/discord/presence',
+    async (request, reply) => {
+      if (!isDiscordPresenceIngestConfigured()) {
+        const integrationError = replyWithIntegrationError(
+          request,
+          createIntegrationError(
+            'discord',
+            503,
+            'misconfigured',
+            'Ingestão de presença Discord indisponível no runtime atual.',
+          ),
+          { logFailure: false },
+        );
+
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
+      }
+
+      if (!hasValidDiscordPresenceIngestToken(request.headers[DISCORD_PRESENCE_INGEST_TOKEN_HEADER])) {
+        const integrationError = replyWithIntegrationError(
+          request,
+          createIntegrationError(
+            'discord',
+            401,
+            'invalid_credentials',
+            'Integração Discord não autorizada.',
+          ),
+          { logFailure: false },
+        );
+
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
+      }
+
+      const result = discordPresenceIngestSchema.safeParse(request.body);
+      if (!result.success) {
+        return reply.status(400).send({ message: result.error.errors[0]?.message ?? 'Dados inválidos.' });
+      }
+
+      try {
+        const resultPayload = await app.discordPresenceService.ingestPresence({
+          externalId: result.data.externalId,
+          status: result.data.status,
+          currentGame: result.data.currentGame,
+          gameDetails: result.data.gameDetails as Record<string, unknown> | null | undefined,
+          requestId: request.id,
+        });
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error);
         return reply.status(integrationError.statusCode).send(integrationError.payload);
       }
     },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,6 +38,10 @@ import {
   createDiscordOAuthService,
   type DiscordOAuthService,
 } from './core/services/discord-oauth.service';
+import {
+  createDiscordPresenceService,
+  type DiscordPresenceService,
+} from './core/services/discord-presence.service';
 import { ensureMediaUploadsDirectory } from './config/media-upload';
 import type Redis from 'ioredis';
 
@@ -50,6 +54,7 @@ export type BuildAppOptions = {
   rateLimitRedis?: Redis | null;
   integrationsService?: IntegrationsService;
   discordOAuthService?: DiscordOAuthService;
+  discordPresenceService?: DiscordPresenceService;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -74,6 +79,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   });
   const integrationsService = options.integrationsService ?? createIntegrationsService();
   const discordOAuthService = options.discordOAuthService ?? createDiscordOAuthService();
+  const discordPresenceService = options.discordPresenceService ?? createDiscordPresenceService();
   const resolvedRateLimitRedis =
     options.rateLimitRedis !== undefined
       ? options.rateLimitRedis
@@ -87,6 +93,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   app.decorate('refreshTokenService', refreshTokenService);
   app.decorate('integrationsService', integrationsService);
   app.decorate('discordOAuthService', discordOAuthService);
+  app.decorate('discordPresenceService', discordPresenceService);
 
   await app.register(
     fastifyRateLimit,

--- a/backend/src/config/discord-presence.ts
+++ b/backend/src/config/discord-presence.ts
@@ -1,0 +1,49 @@
+import { timingSafeEqual } from 'node:crypto';
+
+export const DISCORD_PRESENCE_INGEST_TOKEN_HEADER = 'x-clutch-discord-ingest-token';
+
+function normalizeHeaderValue(value: string | string[] | undefined): string | null {
+  if (typeof value === 'string') {
+    const normalizedValue = value.trim();
+    return normalizedValue.length > 0 ? normalizedValue : null;
+  }
+
+  if (Array.isArray(value)) {
+    const [firstValue] = value;
+    if (typeof firstValue === 'string') {
+      const normalizedValue = firstValue.trim();
+      return normalizedValue.length > 0 ? normalizedValue : null;
+    }
+  }
+
+  return null;
+}
+
+export function resolveDiscordPresenceIngestToken(): string | null {
+  const configuredToken = process.env['DISCORD_PRESENCE_INGEST_TOKEN']?.trim();
+  return configuredToken && configuredToken.length > 0 ? configuredToken : null;
+}
+
+export function isDiscordPresenceIngestConfigured(): boolean {
+  return resolveDiscordPresenceIngestToken() !== null;
+}
+
+export function hasValidDiscordPresenceIngestToken(
+  providedToken: string | string[] | undefined,
+): boolean {
+  const configuredToken = resolveDiscordPresenceIngestToken();
+  const normalizedProvidedToken = normalizeHeaderValue(providedToken);
+
+  if (!configuredToken || !normalizedProvidedToken) {
+    return false;
+  }
+
+  const configuredBuffer = Buffer.from(configuredToken, 'utf8');
+  const providedBuffer = Buffer.from(normalizedProvidedToken, 'utf8');
+
+  if (configuredBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(configuredBuffer, providedBuffer);
+}

--- a/backend/src/core/services/discord-presence.service.ts
+++ b/backend/src/core/services/discord-presence.service.ts
@@ -1,0 +1,192 @@
+/* eslint-disable no-unused-vars */
+import { PresenceStatus } from '@prisma/client';
+import { prisma } from '../../infra/database/client';
+import {
+  createIntegrationError,
+  type IntegrationError,
+} from '../../infra/integrations/integration.errors';
+import {
+  friendRepository,
+} from '../repositories/friend.repository';
+import {
+  presenceRepository,
+  type PresenceData,
+} from '../repositories/presence.repository';
+import { writeBackendRuntimeLog } from '../../config/logging';
+
+type DiscordPresenceIngestInput = {
+  externalId: string;
+  status: PresenceStatus;
+  currentGame?: string | null;
+  gameDetails?: Record<string, unknown> | null;
+  requestId?: string;
+};
+
+type DiscordPresencePersistence = {
+  findLinkedUserIdByExternalId(externalId: string): Promise<string | null>;
+  findFriendIdsByUserId(userId: string): Promise<string[]>;
+  setPresence(
+    userId: string,
+    input: {
+      status: PresenceStatus;
+      currentGame?: string | null;
+      gameDetails?: Record<string, unknown> | null;
+      platform?: string | null;
+    },
+  ): Promise<PresenceData>;
+  publishScopedUpdate(presence: PresenceData, recipientIds: string[]): Promise<void>;
+};
+
+function createPrismaDiscordPresencePersistence(): DiscordPresencePersistence {
+  return {
+    async findLinkedUserIdByExternalId(externalId): Promise<string | null> {
+      const integration = await prisma.platformIntegration.findFirst({
+        where: {
+          platform: 'DISCORD',
+          externalId,
+          isActive: true,
+        },
+        select: {
+          userId: true,
+        },
+      });
+
+      return integration?.userId ?? null;
+    },
+    async findFriendIdsByUserId(userId): Promise<string[]> {
+      return friendRepository.findFriendIdsByUserId(userId);
+    },
+    async setPresence(userId, input): Promise<PresenceData> {
+      return presenceRepository.set(userId, input);
+    },
+    async publishScopedUpdate(presence, recipientIds): Promise<void> {
+      await presenceRepository.publishScopedUpdate(presence, recipientIds);
+    },
+  };
+}
+
+function normalizeDiscordPresenceError(error: unknown): IntegrationError {
+  if (error instanceof Error && error.name === 'IntegrationError') {
+    return error as IntegrationError;
+  }
+
+  return createIntegrationError(
+    'discord',
+    503,
+    'upstream_unavailable',
+    'Presença Discord indisponível no momento.',
+  );
+}
+
+function buildPresencePayload(input: DiscordPresenceIngestInput): {
+  status: PresenceStatus;
+  currentGame: string | null;
+  gameDetails: Record<string, unknown> | null;
+  platform: 'DISCORD' | null;
+} {
+  const shouldClearActivity = input.status === 'OFFLINE';
+
+  return {
+    status: input.status,
+    currentGame: shouldClearActivity ? null : input.currentGame ?? null,
+    gameDetails: shouldClearActivity ? null : input.gameDetails ?? null,
+    platform: shouldClearActivity ? null : 'DISCORD',
+  };
+}
+
+export type DiscordPresenceService = ReturnType<typeof createDiscordPresenceService>;
+
+export function createDiscordPresenceService(dependencies?: {
+  persistence?: DiscordPresencePersistence;
+}): {
+  ingestPresence: (input: DiscordPresenceIngestInput) => Promise<{
+    message: string;
+    userId: string;
+    externalId: string;
+    status: PresenceStatus;
+    platform: 'DISCORD' | null;
+    updatedAt: string;
+  }>;
+} {
+  const persistence = dependencies?.persistence ?? createPrismaDiscordPresencePersistence();
+
+  return {
+    async ingestPresence(input): Promise<{
+      message: string;
+      userId: string;
+      externalId: string;
+      status: PresenceStatus;
+      platform: 'DISCORD' | null;
+      updatedAt: string;
+    }> {
+      writeBackendRuntimeLog(
+        'info',
+        'integration_discord_presence_ingest_received',
+        'Discord presence ingest received.',
+        {
+          requestId: input.requestId,
+          provider: 'discord',
+          externalId: input.externalId,
+          status: input.status,
+        },
+      );
+
+      try {
+        const userId = await persistence.findLinkedUserIdByExternalId(input.externalId);
+
+        if (!userId) {
+          throw createIntegrationError(
+            'discord',
+            404,
+            'not_connected',
+            'Conta Discord não vinculada a um usuário CLUTCH.',
+          );
+        }
+
+        const normalizedPresence = buildPresencePayload(input);
+        const presence = await persistence.setPresence(userId, normalizedPresence);
+        const friendIds = await persistence.findFriendIdsByUserId(userId);
+        await persistence.publishScopedUpdate(presence, friendIds);
+
+        writeBackendRuntimeLog(
+          'info',
+          'integration_discord_presence_ingest_succeeded',
+          'Discord presence ingest succeeded.',
+          {
+            requestId: input.requestId,
+            provider: 'discord',
+            externalId: input.externalId,
+            userId,
+            status: presence.status,
+          },
+        );
+
+        return {
+          message: 'Presença Discord atualizada.',
+          userId,
+          externalId: input.externalId,
+          status: presence.status,
+          platform: normalizedPresence.platform,
+          updatedAt: presence.updatedAt,
+        };
+      } catch (error) {
+        const integrationError = normalizeDiscordPresenceError(error);
+
+        writeBackendRuntimeLog(
+          'warn',
+          'integration_discord_presence_ingest_failed',
+          'Discord presence ingest failed.',
+          {
+            requestId: input.requestId,
+            provider: 'discord',
+            externalId: input.externalId,
+            reason: integrationError.reason,
+            status: integrationError.statusCode,
+          },
+        );
+
+        throw integrationError;
+      }
+    },
+  };
+}

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -2,6 +2,7 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import type { JwtPayload, VerifiedJwtPayload } from '../config/jwt';
 import type { DiscordOAuthService } from '../core/services/discord-oauth.service';
+import type { DiscordPresenceService } from '../core/services/discord-presence.service';
 import type { IntegrationsService } from '../core/services/integrations.service';
 import type { RefreshTokenService } from '../core/services/refresh-token.service';
 
@@ -18,6 +19,7 @@ declare module 'fastify' {
     refreshTokenService: RefreshTokenService;
     integrationsService: IntegrationsService;
     discordOAuthService: DiscordOAuthService;
+    discordPresenceService: DiscordPresenceService;
   }
 
   interface FastifyRequest {

--- a/backend/tests/integration/routes/integrations.routes.test.ts
+++ b/backend/tests/integration/routes/integrations.routes.test.ts
@@ -1,8 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildApp, generateTestToken } from '../../helpers/build-app';
 import {
   createIntegrationError,
-  type IntegrationError,
 } from '@/infra/integrations/integration.errors';
 
 const createMockIntegrationsService = () => ({
@@ -17,9 +16,25 @@ const createMockDiscordOAuthService = () => ({
   completeCallback: vi.fn(),
 });
 
+const createMockDiscordPresenceService = () => ({
+  ingestPresence: vi.fn(),
+});
+
 describe('Integrations Routes', () => {
+  const previousDiscordPresenceToken = process.env['DISCORD_PRESENCE_INGEST_TOKEN'];
+
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env['DISCORD_PRESENCE_INGEST_TOKEN'] = 'discord-presence-secret';
+  });
+
+  afterEach(() => {
+    if (typeof previousDiscordPresenceToken === 'string') {
+      process.env['DISCORD_PRESENCE_INGEST_TOKEN'] = previousDiscordPresenceToken;
+      return;
+    }
+
+    delete process.env['DISCORD_PRESENCE_INGEST_TOKEN'];
   });
 
   describe('POST /integrations/steam/connect', () => {
@@ -386,6 +401,148 @@ describe('Integrations Routes', () => {
       expect(response.statusCode).toBe(400);
       expect(response.json()).toMatchObject({
         message: 'Autorização Discord inválida ou expirada.',
+      });
+      await app.close();
+    });
+  });
+
+  describe('POST /integrations/discord/presence', () => {
+    it('retorna 503 quando o runtime nao esta configurado para ingestao', async () => {
+      delete process.env['DISCORD_PRESENCE_INGEST_TOKEN'];
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      const discordPresenceService = createMockDiscordPresenceService();
+      const app = await buildApp({ integrationsService, discordOAuthService, discordPresenceService });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/discord/presence',
+        payload: {
+          externalId: 'discord-user-id',
+          status: 'ONLINE',
+        },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(discordPresenceService.ingestPresence).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 401 quando o segredo interno nao confere', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      const discordPresenceService = createMockDiscordPresenceService();
+      const app = await buildApp({ integrationsService, discordOAuthService, discordPresenceService });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/discord/presence',
+        headers: {
+          'x-clutch-discord-ingest-token': 'wrong-secret',
+        },
+        payload: {
+          externalId: 'discord-user-id',
+          status: 'ONLINE',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(discordPresenceService.ingestPresence).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 400 quando o payload e invalido', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      const discordPresenceService = createMockDiscordPresenceService();
+      const app = await buildApp({ integrationsService, discordOAuthService, discordPresenceService });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/discord/presence',
+        headers: {
+          'x-clutch-discord-ingest-token': 'discord-presence-secret',
+        },
+        payload: {
+          externalId: '',
+          status: 'ONLINE',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(discordPresenceService.ingestPresence).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna 200 quando a presenca Discord e ingerida com sucesso', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      const discordPresenceService = createMockDiscordPresenceService();
+      discordPresenceService.ingestPresence.mockResolvedValue({
+        message: 'Presença Discord atualizada.',
+        userId: 'user-id-1',
+        externalId: 'discord-user-id',
+        status: 'IN_GAME',
+        platform: 'DISCORD',
+        updatedAt: '2026-04-13T18:40:00.000Z',
+      });
+
+      const app = await buildApp({ integrationsService, discordOAuthService, discordPresenceService });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/discord/presence',
+        headers: {
+          'x-clutch-discord-ingest-token': 'discord-presence-secret',
+        },
+        payload: {
+          externalId: 'discord-user-id',
+          status: 'IN_GAME',
+          currentGame: 'Valorant',
+          gameDetails: { activityType: 'PLAYING' },
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(discordPresenceService.ingestPresence).toHaveBeenCalledWith({
+        externalId: 'discord-user-id',
+        status: 'IN_GAME',
+        currentGame: 'Valorant',
+        gameDetails: { activityType: 'PLAYING' },
+        requestId: expect.any(String),
+      });
+      expect(response.json()).toMatchObject({
+        userId: 'user-id-1',
+        platform: 'DISCORD',
+      });
+      await app.close();
+    });
+
+    it('traduz ausencia de vinculo Discord para 404', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const discordOAuthService = createMockDiscordOAuthService();
+      const discordPresenceService = createMockDiscordPresenceService();
+      discordPresenceService.ingestPresence.mockRejectedValue(
+        createIntegrationError('discord', 404, 'not_connected', 'Conta Discord não vinculada a um usuário CLUTCH.'),
+      );
+
+      const app = await buildApp({ integrationsService, discordOAuthService, discordPresenceService });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/discord/presence',
+        headers: {
+          'x-clutch-discord-ingest-token': 'discord-presence-secret',
+        },
+        payload: {
+          externalId: 'discord-user-id',
+          status: 'ONLINE',
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toMatchObject({
+        message: 'Conta Discord não vinculada a um usuário CLUTCH.',
       });
       await app.close();
     });

--- a/backend/tests/unit/config/discord-presence.test.ts
+++ b/backend/tests/unit/config/discord-presence.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  hasValidDiscordPresenceIngestToken,
+  isDiscordPresenceIngestConfigured,
+  resolveDiscordPresenceIngestToken,
+} from '@/config/discord-presence';
+
+describe('discord-presence config', () => {
+  const previousToken = process.env['DISCORD_PRESENCE_INGEST_TOKEN'];
+
+  afterEach(() => {
+    if (typeof previousToken === 'string') {
+      process.env['DISCORD_PRESENCE_INGEST_TOKEN'] = previousToken;
+      return;
+    }
+
+    delete process.env['DISCORD_PRESENCE_INGEST_TOKEN'];
+  });
+
+  it('resolve token configurado no runtime', () => {
+    process.env['DISCORD_PRESENCE_INGEST_TOKEN'] = 'discord-secret';
+
+    expect(resolveDiscordPresenceIngestToken()).toBe('discord-secret');
+    expect(isDiscordPresenceIngestConfigured()).toBe(true);
+  });
+
+  it('retorna null quando token nao esta configurado', () => {
+    delete process.env['DISCORD_PRESENCE_INGEST_TOKEN'];
+
+    expect(resolveDiscordPresenceIngestToken()).toBeNull();
+    expect(isDiscordPresenceIngestConfigured()).toBe(false);
+  });
+
+  it('valida segredo com comparacao segura', () => {
+    process.env['DISCORD_PRESENCE_INGEST_TOKEN'] = 'discord-secret';
+
+    expect(hasValidDiscordPresenceIngestToken('discord-secret')).toBe(true);
+    expect(hasValidDiscordPresenceIngestToken('wrong-secret')).toBe(false);
+    expect(hasValidDiscordPresenceIngestToken(undefined)).toBe(false);
+  });
+});

--- a/backend/tests/unit/services/discord-presence.service.test.ts
+++ b/backend/tests/unit/services/discord-presence.service.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDiscordPresenceService } from '@/core/services/discord-presence.service';
+
+describe('discord-presence.service', () => {
+  it('normaliza a presenca Discord e publica o update para amigos', async () => {
+    const persistence = {
+      findLinkedUserIdByExternalId: vi.fn().mockResolvedValue('user-id-1'),
+      findFriendIdsByUserId: vi.fn().mockResolvedValue(['friend-id-1', 'friend-id-2']),
+      setPresence: vi.fn().mockResolvedValue({
+        userId: 'user-id-1',
+        status: 'IN_GAME',
+        currentGame: 'Valorant',
+        gameDetails: { activityType: 'PLAYING' },
+        platform: 'DISCORD',
+        updatedAt: '2026-04-13T18:30:00.000Z',
+      }),
+      publishScopedUpdate: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const service = createDiscordPresenceService({ persistence });
+
+    const result = await service.ingestPresence({
+      externalId: 'discord-user-1',
+      status: 'IN_GAME',
+      currentGame: 'Valorant',
+      gameDetails: { activityType: 'PLAYING' },
+      requestId: 'req-1',
+    });
+
+    expect(persistence.findLinkedUserIdByExternalId).toHaveBeenCalledWith('discord-user-1');
+    expect(persistence.setPresence).toHaveBeenCalledWith('user-id-1', {
+      status: 'IN_GAME',
+      currentGame: 'Valorant',
+      gameDetails: { activityType: 'PLAYING' },
+      platform: 'DISCORD',
+    });
+    expect(persistence.findFriendIdsByUserId).toHaveBeenCalledWith('user-id-1');
+    expect(persistence.publishScopedUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-id-1',
+        status: 'IN_GAME',
+      }),
+      ['friend-id-1', 'friend-id-2'],
+    );
+    expect(result).toMatchObject({
+      message: 'Presença Discord atualizada.',
+      userId: 'user-id-1',
+      externalId: 'discord-user-1',
+      status: 'IN_GAME',
+      platform: 'DISCORD',
+    });
+  });
+
+  it('limpa a atividade quando o provider marca a presenca como offline', async () => {
+    const persistence = {
+      findLinkedUserIdByExternalId: vi.fn().mockResolvedValue('user-id-1'),
+      findFriendIdsByUserId: vi.fn().mockResolvedValue([]),
+      setPresence: vi.fn().mockResolvedValue({
+        userId: 'user-id-1',
+        status: 'OFFLINE',
+        currentGame: null,
+        gameDetails: null,
+        platform: null,
+        updatedAt: '2026-04-13T18:31:00.000Z',
+      }),
+      publishScopedUpdate: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const service = createDiscordPresenceService({ persistence });
+
+    await service.ingestPresence({
+      externalId: 'discord-user-1',
+      status: 'OFFLINE',
+      currentGame: 'Nao deveria persistir',
+      gameDetails: { shouldBeCleared: true },
+    });
+
+    expect(persistence.setPresence).toHaveBeenCalledWith('user-id-1', {
+      status: 'OFFLINE',
+      currentGame: null,
+      gameDetails: null,
+      platform: null,
+    });
+  });
+
+  it('retorna erro coerente quando a conta Discord nao esta vinculada', async () => {
+    const persistence = {
+      findLinkedUserIdByExternalId: vi.fn().mockResolvedValue(null),
+      findFriendIdsByUserId: vi.fn(),
+      setPresence: vi.fn(),
+      publishScopedUpdate: vi.fn(),
+    };
+
+    const service = createDiscordPresenceService({ persistence });
+
+    await expect(
+      service.ingestPresence({
+        externalId: 'discord-user-missing',
+        status: 'ONLINE',
+      }),
+    ).rejects.toMatchObject({
+      name: 'IntegrationError',
+      statusCode: 404,
+      reason: 'not_connected',
+      clientMessage: 'Conta Discord não vinculada a um usuário CLUTCH.',
+    });
+
+    expect(persistence.setPresence).not.toHaveBeenCalled();
+    expect(persistence.publishScopedUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/settings/discord-integration-card.tsx
+++ b/frontend/src/components/settings/discord-integration-card.tsx
@@ -49,10 +49,10 @@ export function DiscordIntegrationCard({
         <div className="space-y-2">
           <p className="text-xs uppercase tracking-[0.35em] text-secondary">Discord</p>
           <h2 className="font-display text-2xl font-semibold text-primary">
-            Vinculo OAuth do Discord
+            Vinculo Discord e presence bridge
           </h2>
           <p className="text-sm leading-6 text-secondary">
-            Inicia o fluxo OAuth real pelo backend e conclui a vinculacao no retorno do provedor.
+            Vincula a conta Discord pelo backend e habilita a ingestao de presenca normalizada quando o bridge estiver ativo.
           </p>
         </div>
         <Badge tone={isConnected ? 'success' : 'neutral'}>
@@ -62,7 +62,7 @@ export function DiscordIntegrationCard({
 
       <p className="text-sm text-secondary">
         {isConnected
-          ? `Conta vinculada: ${linkedAccountLabel ?? 'Discord conectado.'}`
+          ? `Conta vinculada: ${linkedAccountLabel ?? 'Discord conectado.'} O estado de presenca passa a poder ser refletido no CLUTCH sem acoplamento direto no frontend.`
           : 'Ainda nao ha integracao Discord ativa neste perfil.'}
       </p>
 
@@ -89,7 +89,7 @@ export function DiscordIntegrationCard({
       </div>
 
       <p className="text-xs leading-5 text-secondary">
-        O frontend conclui o callback em rota dedicada do App Router. Se o backend Discord nao estiver configurado no runtime atual, a UI exibe indisponibilidade sem expor detalhes internos.
+        O frontend conclui o callback em rota dedicada do App Router. A presenca continua chegando pela API do CLUTCH; o browser nao fala diretamente com o Discord.
       </p>
     </Card>
   );

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -49,7 +49,7 @@ describe('IntegrationsPageContent', () => {
     mockedFetchProfileByUsername.mockReset();
   });
 
-  it('renders integrations status including discord oauth state', async () => {
+  it('renders integrations status including discord connection state', async () => {
     mockedUseAuth.mockReturnValue({
       status: 'authenticated',
       user: {
@@ -116,7 +116,10 @@ describe('IntegrationsPageContent', () => {
     expect(screen.getByText(/biblioteca steam/i)).toBeInTheDocument();
     expect(screen.getByText(/biblioteca epic games/i)).toBeInTheDocument();
     expect(screen.getByText(/^discord$/i)).toBeInTheDocument();
-    expect(screen.getByText(/vinculo oauth do discord/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /vinculo discord e presence bridge/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reconectar discord/i })).toBeInTheDocument();
     expect(screen.getByText(/conta vinculada: clutch guild/i)).toBeInTheDocument();
     expect(screen.queryByText(/ainda fora do contrato frontend atual/i)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Resumo
Esta PR fecha a fronteira backend-side da `#205` para ingestao de presenca do Discord sem acoplar o frontend diretamente ao provider. A entrega adiciona uma rota interna protegida por segredo de runtime, resolve o usuario CLUTCH pelo `externalId` ja vinculado via OAuth Discord e reaproveita o pipeline atual de persistencia/publicacao de presence.

## O que foi alterado
- Backend
- Adicionada a configuracao de ingestao por `DISCORD_PRESENCE_INGEST_TOKEN` e o header interno `x-clutch-discord-ingest-token`.
- Adicionada a rota `POST /integrations/discord/presence` com validacao de segredo, schema de body e traducao coerente de erros.
- Adicionado um service dedicado para normalizar a presenca recebida do Discord, resolver o usuario CLUTCH pelo `externalId`, persistir em `user_presence` e publicar o update para amigos pelo pipeline atual.
- Registrado o novo service no `buildApp` e na tipagem do Fastify.
- Adicionados testes unitarios de config e service, alem de cobertura HTTP da nova rota.
- Frontend
- Ajustada a copy do card de integracao do Discord para deixar explicito que o browser continua consumindo apenas a presenca do CLUTCH e que a ponte com o provider fica backend-side.

## Motivacao
O repositorio ja tinha Discord OAuth e modelo generico de presence, mas ainda nao possuia uma borda de ingestao para receber presenca externa de forma controlada. Sem essa camada, qualquer proximo passo com bot/bridge do Discord tenderia a empurrar regra de provider para a UI ou a criar um fluxo paralelo de presence fora do modelo atual do CLUTCH.

## Como validar
- Backend
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test -- tests/unit/config/discord-presence.test.ts tests/unit/services/discord-presence.service.test.ts tests/integration/routes/integrations.routes.test.ts`
- Frontend
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test -- tests/unit/components/discord-integration-card.test.tsx`
- Smoke HTTP
- Enviar `POST /integrations/discord/presence` com `x-clutch-discord-ingest-token` valido e `externalId` vinculado; o retorno esperado e `200` com `userId`, `externalId`, `status`, `platform` e `updatedAt`.
- Enviar o mesmo endpoint com `externalId` sem vinculo ativo; o retorno esperado e `404` com `reason` traduzido para `not_connected` e mensagem coerente.
- Enviar o mesmo endpoint com header invalido; o retorno esperado e `401`.

## Riscos e impactos
- A rota publica do backend ganha uma nova borda interna em `/integrations/discord/presence`; isso aumenta a superficie da API, mas ela permanece protegida por segredo de runtime e nao exposta ao frontend como contrato de produto.
- Esta PR nao entrega o bot/bridge real do Discord, snapshot inicial nem backfill. Ela apenas fecha a fronteira backend-side para o provider externo publicar presenca no modelo atual do CLUTCH.
- A resolucao depende de a conta Discord ja estar vinculada em `platform_integrations` com `externalId` ativo.
- O backend lint continua emitindo warnings preexistentes em `src/config/rate-limit.ts`, fora do escopo desta PR.
- O smoke local da rota ainda mostra erros de conexao do singleton Redis fora do ambiente ideal de infraestrutura; isso nao impediu build, testes nem a validacao da borda HTTP.

## Evidencias
- Testes focados executados com sucesso:
- `tests/unit/config/discord-presence.test.ts`
- `tests/unit/services/discord-presence.service.test.ts`
- `tests/integration/routes/integrations.routes.test.ts`
- `tests/unit/components/discord-integration-card.test.tsx`
- Smoke HTTP executado com os seguintes resultados:
- `200` para `externalId` vinculado
- `404` para `externalId` sem vinculo
- `401` para header invalido
- Logs emitidos no fluxo de sucesso/falha com eventos estruturados `integration_discord_presence_ingest_received`, `integration_discord_presence_ingest_succeeded` e `integration_discord_presence_ingest_failed`.

## Checklist
- [x] Alteracao limitada ao objetivo da PR
- [x] Sem mudancas desconexas
- [x] Impactos principais descritos
- [x] Validacao documentada
- [x] Riscos identificados

Closes #205