### PR TITLE
feat(profile): reforçar a identidade gamer no header do perfil

### DIFF
--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -14,10 +14,27 @@ type GamerCardProps = {
   actions?: ReactNode;
 };
 
+function formatMemberSince(createdAt: string): string {
+  const joinedAt = new Date(createdAt);
+
+  if (Number.isNaN(joinedAt.getTime())) {
+    return 'Chegou recentemente ao CLUTCH';
+  }
+
+  const formattedMonthYear = new Intl.DateTimeFormat('pt-BR', {
+    month: 'short',
+    year: 'numeric',
+  }).format(joinedAt);
+
+  return `No CLUTCH desde ${formattedMonthYear}`;
+}
+
 export function GamerCard({ profile, actions }: GamerCardProps) {
   const displayName = profile.profile.displayName || profile.username;
   const badgeList = profile.profile.badges.slice(0, 4);
   const initials = profile.username.slice(0, 2).toUpperCase();
+  const accentColor = profile.profile.accentColor ?? '#7C3AED';
+  const memberSinceLabel = formatMemberSince(profile.createdAt);
   const realtimePresence = usePresenceStore((state) =>
     state.connectionStatus === 'connected' ? state.entries[profile.id] : undefined,
   );
@@ -31,61 +48,86 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
     <Card className="overflow-hidden p-0">
       <div
         className="relative h-40 w-full border-b border-border bg-gradient-to-r from-[rgba(124,58,237,0.34)] via-[rgba(6,182,212,0.22)] to-[rgba(10,10,15,0.92)]"
-        style={
-          profile.profile.bannerUrl
+        style={{
+          ...(profile.profile.bannerUrl
             ? {
-                backgroundImage: `linear-gradient(135deg, rgba(124,58,237,0.42), rgba(6,182,212,0.28)), url(${profile.profile.bannerUrl})`,
+                backgroundImage: `linear-gradient(135deg, ${accentColor}, rgba(6,182,212,0.28)), url(${profile.profile.bannerUrl})`,
                 backgroundSize: 'cover',
                 backgroundPosition: 'center',
               }
-            : undefined
-        }
-      />
+            : {
+                backgroundImage: `linear-gradient(135deg, ${accentColor}, rgba(6,182,212,0.28), rgba(10,10,15,0.92))`,
+              }),
+        }}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.16),transparent_32%)]" />
+      </div>
 
-      <div className="space-y-5 p-card">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-4">
+      <div className="space-y-5 px-card pb-card">
+        <div className="-mt-10 flex flex-wrap items-start justify-between gap-4">
+          <div className="flex min-w-0 flex-1 items-end gap-4">
             <Avatar
               src={profile.profile.avatarUrl}
               alt={profile.username}
               fallback={initials}
               size="lg"
-              className="h-16 w-16 text-lg"
+              className="h-20 w-20 shrink-0 border-4 border-background text-xl shadow-[0_18px_40px_rgba(10,10,15,0.34)]"
             />
-            <div className="min-w-0 space-y-1">
-              <h1 className="truncate font-display text-3xl font-semibold text-primary">
-                {displayName}
-              </h1>
-              <p className="truncate text-sm text-secondary">@{profile.username}</p>
-              <PresenceBadge
-                status={effectivePresence.status}
-                currentGame={effectivePresence.currentGame}
-                platform={effectivePresence.platform}
-              />
+            <div className="min-w-0 space-y-3 pb-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs uppercase tracking-[0.35em] text-secondary">
+                  Perfil gamer
+                </span>
+                <span className="text-xs text-secondary">{memberSinceLabel}</span>
+              </div>
+
+              <div className="space-y-1">
+                <h1 className="truncate font-display text-3xl font-semibold text-primary sm:text-4xl">
+                  {displayName}
+                </h1>
+                <p className="truncate text-sm font-medium text-secondary">
+                  @{profile.username}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge tone="accent">Nivel {profile.stats.level}</Badge>
+                {badgeList.map((badge) => (
+                  <Badge key={badge} tone="neutral">
+                    {badge}
+                  </Badge>
+                ))}
+              </div>
             </div>
           </div>
 
-          <div className="flex flex-col items-end gap-3">
-            <Badge tone="accent">Nv. {profile.stats.level}</Badge>
-            {actions}
-          </div>
+          {actions ? (
+            <div className="flex flex-col items-stretch gap-3 pt-10 sm:items-end">
+              {actions}
+            </div>
+          ) : null}
         </div>
 
-        <p className="text-sm leading-6 text-secondary">
-          {profile.profile.bio || 'Sem bio configurada por enquanto.'}
-        </p>
+        <PresenceBadge
+          status={effectivePresence.status}
+          currentGame={effectivePresence.currentGame}
+          platform={effectivePresence.platform}
+        />
 
-        <PlatformBadges integrations={profile.platformIntegrations} />
-
-        {badgeList.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-2">
-            {badgeList.map((badge) => (
-              <Badge key={badge} tone="neutral">
-                {badge}
-              </Badge>
-            ))}
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(260px,0.65fr)]">
+          <div className="space-y-2 rounded-control border border-border bg-background-tertiary/40 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+              Identidade
+            </p>
+            <p className="text-sm leading-6 text-secondary">
+              {profile.profile.bio || 'Esse jogador ainda nao adicionou uma bio.'}
+            </p>
           </div>
-        ) : null}
+
+          <div className="rounded-control border border-border bg-background-tertiary/40 px-4 py-4">
+            <PlatformBadges integrations={profile.platformIntegrations} />
+          </div>
+        </div>
       </div>
     </Card>
   );

--- a/frontend/src/components/profile/platform-badges.tsx
+++ b/frontend/src/components/profile/platform-badges.tsx
@@ -5,18 +5,51 @@ type PlatformBadgesProps = {
   integrations: ProfileResponse['platformIntegrations'];
 };
 
+const platformLabelByCode: Record<
+  ProfileResponse['platformIntegrations'][number]['platform'],
+  string
+> = {
+  STEAM: 'Steam',
+  EPIC: 'Epic Games',
+  DISCORD: 'Discord',
+  XBOX: 'Xbox',
+  PSN: 'PlayStation Network',
+  RIOT: 'Riot',
+  ANILIST: 'AniList',
+  MYANIMELIST: 'MyAnimeList',
+};
+
 export function PlatformBadges({ integrations }: PlatformBadgesProps) {
-  if (integrations.length === 0) {
-    return <Badge tone="neutral">Sem integracoes conectadas</Badge>;
-  }
+  const platformCodes = Array.from(
+    new Set(integrations.map((integration) => integration.platform)),
+  );
+  const platformCountLabel =
+    platformCodes.length === 1
+      ? '1 plataforma conectada'
+      : `${platformCodes.length} plataformas conectadas`;
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      {integrations.map((integration) => (
-        <Badge key={integration.platform} tone="accent">
-          {integration.platform}
-        </Badge>
-      ))}
+    <div className="space-y-3" data-testid="profile-platform-badges">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+          Plataformas conectadas
+        </p>
+        <span className="text-xs text-secondary">{platformCountLabel}</span>
+      </div>
+
+      {platformCodes.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {platformCodes.map((platformCode) => (
+            <Badge key={platformCode} tone="accent">
+              {platformLabelByCode[platformCode]}
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm leading-6 text-secondary">
+          Sem plataformas conectadas visiveis neste perfil.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/profile/presence-badge.tsx
+++ b/frontend/src/components/profile/presence-badge.tsx
@@ -27,20 +27,50 @@ const labelByStatus: Record<ProfilePresenceStatus, string> = {
   OFFLINE: 'Offline',
 };
 
+function resolvePrimaryDetail(
+  status: ProfilePresenceStatus,
+  currentGame: string | null,
+): string {
+  if (status === 'IN_GAME' && currentGame) {
+    return `Jogando ${currentGame}`;
+  }
+
+  if (status === 'ONLINE') {
+    return 'Disponivel para jogar';
+  }
+
+  if (status === 'AFK') {
+    return 'Ausente no momento';
+  }
+
+  return 'Sem atividade ativa';
+}
+
+function resolveSecondaryDetail(
+  status: ProfilePresenceStatus,
+  platform: string | null,
+): string {
+  if (platform) {
+    return `Plataforma atual: ${platform}`;
+  }
+
+  if (status === 'OFFLINE') {
+    return 'Nenhuma sessao publica no momento';
+  }
+
+  return 'Sem plataforma informada';
+}
+
 export function PresenceBadge({
   status,
   currentGame,
   platform,
 }: PresenceBadgeProps) {
-  const detail =
-    status === 'IN_GAME' && currentGame
-      ? `Jogando ${currentGame}`
-      : platform
-        ? `Disponivel em ${platform}`
-        : 'Sem atividade ativa';
+  const primaryDetail = resolvePrimaryDetail(status, currentGame);
+  const secondaryDetail = resolveSecondaryDetail(status, platform);
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-center gap-3 rounded-control border border-border bg-background-tertiary/70 px-3 py-3">
       <Badge tone={toneByStatus[status]}>
         <motion.span
           initial={{ opacity: 0.55 }}
@@ -51,7 +81,14 @@ export function PresenceBadge({
         />
         {labelByStatus[status]}
       </Badge>
-      <span className="text-sm text-secondary">{detail}</span>
+      <div className="min-w-0 space-y-1">
+        <p className="truncate text-sm font-medium text-primary">
+          {primaryDetail}
+        </p>
+        <p className="truncate text-xs uppercase tracking-[0.28em] text-secondary">
+          {secondaryDetail}
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { GamerCard } from '@/components/profile/gamer-card';
 import { type ProfileResponse } from '@/schemas/profile';
@@ -56,6 +56,16 @@ describe('GamerCard', () => {
 
     expect(screen.getByText(/in game/i)).toBeInTheDocument();
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
+    expect(screen.getByText(/plataforma atual: pc/i)).toBeInTheDocument();
+    expect(screen.getByText(/nivel 18/i)).toBeInTheDocument();
+    expect(screen.getByText(/founder/i)).toBeInTheDocument();
+    const platformsSection = screen.getByTestId('profile-platform-badges');
+    expect(
+      within(platformsSection).getByText(/^plataformas conectadas$/i),
+    ).toBeInTheDocument();
+    expect(
+      within(platformsSection).getByText(/sem plataformas conectadas visiveis neste perfil/i),
+    ).toBeInTheDocument();
   });
 
   it('falls back to the backend snapshot when realtime is not connected', () => {
@@ -70,9 +80,42 @@ describe('GamerCard', () => {
       123,
     );
 
-    render(<GamerCard profile={profileFixture} />);
+    render(
+      <GamerCard
+        profile={{
+          ...profileFixture,
+          profile: {
+            ...profileFixture.profile,
+            bio: null,
+          },
+        }}
+      />,
+    );
 
     expect(screen.getByText(/offline/i)).toBeInTheDocument();
     expect(screen.getByText(/sem atividade ativa/i)).toBeInTheDocument();
+    expect(screen.getByText(/nenhuma sessao publica no momento/i)).toBeInTheDocument();
+    expect(screen.getByText(/esse jogador ainda nao adicionou uma bio/i)).toBeInTheDocument();
+  });
+
+  it('renders connected platforms with friendlier labels from the profile contract', () => {
+    render(
+      <GamerCard
+        profile={{
+          ...profileFixture,
+          platformIntegrations: [
+            { platform: 'STEAM', metadata: null },
+            { platform: 'DISCORD', metadata: null },
+          ],
+        }}
+      />,
+    );
+
+    const platformsSection = screen.getByTestId('profile-platform-badges');
+    expect(
+      within(platformsSection).getByText(/2 plataformas conectadas/i),
+    ).toBeInTheDocument();
+    expect(within(platformsSection).getByText(/^steam$/i)).toBeInTheDocument();
+    expect(within(platformsSection).getByText(/^discord$/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Resumo
Esta PR reforça a identidade gamer no header do perfil público usando apenas o contrato atual de `GET /profiles/:username`. A mudança reorganiza a hierarquia visual do bloco principal do jogador, melhora a leitura de presença/atividade e torna as plataformas conectadas mais legíveis sem redesenhar a página inteira.

## O que foi alterado
- Header do perfil
- Reorganizado o `GamerCard` para aproximar nome, username, nível, badges existentes e tempo de entrada no CLUTCH no mesmo bloco de identidade.
- Ajustado o hero do header para aproveitar `accentColor` e `bannerUrl` já existentes, sem depender de novos dados.
- Presença e atividade atual
- Refinado o `PresenceBadge` para separar status, atividade principal e plataforma atual em uma leitura mais clara.
- Mantido o fallback honesto quando não houver atividade ou plataforma disponível.
- Plataformas conectadas
- Refinado o bloco `PlatformBadges` com rótulos mais legíveis, contagem derivada e empty state honesto.
- Testes
- Atualizados os testes unitários do `GamerCard` para cobrir a nova hierarquia, presença mais legível e estados de plataformas conectadas/vazias.

## Motivação
O header do perfil já tinha os dados corretos, mas ainda comunicava a identidade gamer de forma fragmentada. Esta rodada trata só a camada de apresentação do header, destacando melhor os sinais já existentes de perfil, presença e integrações, sem inventar backend novo nem avançar para as próximas issues do perfil.

## Como validar
- `cd frontend`
- `npm run test -- tests/unit/components/gamer-card.test.tsx tests/unit/components/profile-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Smoke HTTP local executado nesta rodada:
- `GET http://localhost/clutchplayer` deve responder `200`
- `GET http://localhost/clutchplayer/library` deve responder `200`

## Riscos e impactos
- A mudança é restrita ao header do perfil público; não altera contratos do backend nem o restante da página.
- O texto de presença ficou mais rico, mas continua limitado ao que o contrato atual realmente fornece (`status`, `currentGame` e `platform`).
- Esta PR não cobre os próximos refinamentos previstos em `#216`, `#217` e `#218`.
- O smoke desta rodada validou a rota pública do perfil no stack local ativo, mas não houve automação de navegador para confirmar o DOM hidratado após o fetch client-side.

## Evidências
- Testes focados executados com sucesso:
- `tests/unit/components/gamer-card.test.tsx`
- `tests/unit/components/profile-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Smoke HTTP local:
- `GET /clutchplayer` -> `200`
- `GET /clutchplayer/library` -> `200`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #215