### PR TITLE
feat(profile): reorganiza estatísticas e biblioteca recente do perfil

### DIFF
--- a/frontend/src/components/profile/game-library-preview.tsx
+++ b/frontend/src/components/profile/game-library-preview.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { type ProfileResponse } from '@/schemas/profile';
 
@@ -8,20 +9,85 @@ type GameLibraryPreviewProps = {
   games: ProfileResponse['gameLibrary'];
 };
 
+function resolveTimestamp(value: string | null): number {
+  if (!value) {
+    return 0;
+  }
+
+  const parsedValue = new Date(value).getTime();
+
+  return Number.isNaN(parsedValue) ? 0 : parsedValue;
+}
+
+function sortRecentGames(games: ProfileResponse['gameLibrary']): ProfileResponse['gameLibrary'] {
+  return [...games].sort((left, right) => {
+    const recentDifference = resolveTimestamp(right.lastPlayedAt) - resolveTimestamp(left.lastPlayedAt);
+
+    if (recentDifference !== 0) {
+      return recentDifference;
+    }
+
+    const hoursDifference = (right.hoursPlayed ?? -1) - (left.hoursPlayed ?? -1);
+
+    if (hoursDifference !== 0) {
+      return hoursDifference;
+    }
+
+    return left.gameName.localeCompare(right.gameName, 'pt-BR');
+  });
+}
+
+function formatHoursPlayed(hoursPlayed: number | null): string {
+  if (typeof hoursPlayed !== 'number' || !Number.isFinite(hoursPlayed)) {
+    return 'Horas indisponiveis';
+  }
+
+  return `${Math.round(hoursPlayed).toLocaleString('pt-BR')}h jogadas`;
+}
+
+function formatLastPlayedAt(lastPlayedAt: string | null): string {
+  const timestamp = resolveTimestamp(lastPlayedAt);
+
+  if (timestamp === 0) {
+    return 'Sem atividade recente';
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(timestamp));
+}
+
 export function GameLibraryPreview({ games, username }: GameLibraryPreviewProps) {
-  const visibleGames = games.slice(0, 6);
+  const visibleGames = sortRecentGames(games).slice(0, 4);
+  const platformCount = new Set(games.map((game) => game.platform)).size;
+  const trackedHours = games.reduce((sum, game) => {
+    if (typeof game.hoursPlayed !== 'number' || !Number.isFinite(game.hoursPlayed)) {
+      return sum;
+    }
+
+    return sum + game.hoursPlayed;
+  }, 0);
+  const hasTrackedHours = games.some((game) => {
+    return typeof game.hoursPlayed === 'number' && Number.isFinite(game.hoursPlayed);
+  });
 
   return (
-    <Card>
-      <div className="space-y-4">
+    <Card data-testid="game-library-preview">
+      <div className="space-y-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
+          <div className="space-y-2">
             <p className="text-xs uppercase tracking-[0.35em] text-secondary">
               Biblioteca
             </p>
             <h3 className="mt-2 font-display text-2xl font-semibold text-primary">
-              Jogos recentes
+              Biblioteca recente
             </h3>
+            <p className="text-sm leading-6 text-secondary">
+              Recorte rapido da biblioteca publicada neste perfil com os dados ja presentes no
+              payload atual.
+            </p>
           </div>
           <Link
             href={`/${username}/library`}
@@ -31,24 +97,43 @@ export function GameLibraryPreview({ games, username }: GameLibraryPreviewProps)
           </Link>
         </div>
 
+        <div className="flex flex-wrap gap-2">
+          <Badge tone="neutral">
+            {`${games.length.toLocaleString('pt-BR')} ${games.length === 1 ? 'jogo' : 'jogos'} no payload atual`}
+          </Badge>
+          <Badge tone="neutral">
+            {`${platformCount.toLocaleString('pt-BR')} ${platformCount === 1 ? 'plataforma' : 'plataformas'}`}
+          </Badge>
+          <Badge tone="neutral">
+            {hasTrackedHours
+              ? `${Math.round(trackedHours).toLocaleString('pt-BR')}h registradas`
+              : 'Horas ainda indisponiveis'}
+          </Badge>
+        </div>
+
         {visibleGames.length === 0 ? (
-          <p className="rounded-control border border-border bg-background-tertiary/65 px-4 py-3 text-sm text-secondary">
-            Este perfil ainda nao possui jogos cadastrados na biblioteca.
-          </p>
+          <div className="rounded-control border border-border bg-background-tertiary/65 px-4 py-4 text-sm text-secondary">
+            <p className="font-medium text-primary">Ainda nao ha jogos visiveis nesta biblioteca.</p>
+            <p className="mt-2 leading-6">
+              Quando as integracoes atuais enviarem jogos para o profile, o resumo recente aparece
+              aqui sem exigir contrato adicional.
+            </p>
+          </div>
         ) : (
-          <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <ul className="grid gap-3 sm:grid-cols-2">
             {visibleGames.map((game, index) => (
               <li
                 key={`${game.platform}-${game.gameName}`}
+                data-testid="profile-library-game"
                 className="overflow-hidden rounded-control border border-border bg-background-tertiary/70"
               >
-                <div className="relative h-28 w-full">
+                <div className="relative h-32 w-full">
                   {game.coverUrl ? (
                     <Image
                       src={game.coverUrl}
                       alt={game.gameName}
                       fill
-                      sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                      sizes="(min-width: 1280px) 27vw, (min-width: 640px) 50vw, 100vw"
                       priority={index === 0}
                       className="object-cover"
                     />
@@ -58,13 +143,35 @@ export function GameLibraryPreview({ games, username }: GameLibraryPreviewProps)
                     </div>
                   )}
                 </div>
-                <div className="space-y-1 px-3 py-3">
-                  <p className="truncate text-sm font-semibold text-primary">
-                    {game.gameName}
-                  </p>
-                  <p className="text-xs uppercase tracking-[0.24em] text-secondary">
-                    {game.platform}
-                  </p>
+                <div className="space-y-3 px-4 py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="line-clamp-2 text-sm font-semibold leading-6 text-primary">
+                      {game.gameName}
+                    </p>
+                    <Badge tone="neutral" className="shrink-0">
+                      {game.platform}
+                    </Badge>
+                  </div>
+
+                  <div className="grid gap-3 text-sm text-secondary sm:grid-cols-2">
+                    <div className="space-y-1">
+                      <p className="text-[11px] uppercase tracking-[0.24em] text-secondary">
+                        Horas
+                      </p>
+                      <p className="font-medium text-primary">
+                        {formatHoursPlayed(game.hoursPlayed)}
+                      </p>
+                    </div>
+
+                    <div className="space-y-1">
+                      <p className="text-[11px] uppercase tracking-[0.24em] text-secondary">
+                        Ultima atividade
+                      </p>
+                      <p className="font-medium text-primary">
+                        {formatLastPlayedAt(game.lastPlayedAt)}
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </li>
             ))}

--- a/frontend/src/components/profile/profile-page-content.tsx
+++ b/frontend/src/components/profile/profile-page-content.tsx
@@ -80,14 +80,16 @@ export function ProfilePageContent({ username }: ProfilePageContentProps) {
         profile={profileQuery.data}
         actions={<FriendButton targetUserId={profileQuery.data.id} />}
       />
-      <ProfileStats stats={profileQuery.data.stats} />
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]">
+        <ProfileStats stats={profileQuery.data.stats} />
+        <GameLibraryPreview
+          username={profileQuery.data.username}
+          games={profileQuery.data.gameLibrary}
+        />
+      </div>
       <FriendsList
         userId={profileQuery.data.id}
         title={`Amigos de @${profileQuery.data.username}`}
-      />
-      <GameLibraryPreview
-        username={profileQuery.data.username}
-        games={profileQuery.data.gameLibrary}
       />
     </div>
   );

--- a/frontend/src/components/profile/profile-stats.tsx
+++ b/frontend/src/components/profile/profile-stats.tsx
@@ -5,36 +5,92 @@ type ProfileStatsProps = {
   stats: ProfileResponse['stats'];
 };
 
-type StatItem = {
-  label: string;
-  value: number;
-};
+function formatStatValue(value: number): string | null {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  return value.toLocaleString('pt-BR');
+}
 
 export function ProfileStats({ stats }: ProfileStatsProps) {
-  const items: StatItem[] = [
-    { label: 'Amigos', value: stats.friendCount },
-    { label: 'Posts', value: stats.postCount },
-    { label: 'Reputacao', value: stats.reputation },
-    { label: 'Nivel', value: stats.level },
-    { label: 'XP', value: stats.xp },
-  ];
+  const reputation = formatStatValue(stats.reputation);
+  const level = formatStatValue(stats.level);
+  const xp = formatStatValue(stats.xp);
+  const friendCount = formatStatValue(stats.friendCount);
+  const postCount = formatStatValue(stats.postCount);
 
   return (
-    <Card>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-        {items.map((item) => (
-          <div
-            key={item.label}
-            className="rounded-control border border-border bg-background-tertiary/70 px-4 py-3"
-          >
-            <p className="text-xs uppercase tracking-[0.3em] text-secondary">
-              {item.label}
-            </p>
-            <p className="mt-2 font-display text-xl font-semibold text-primary">
-              {item.value.toLocaleString('pt-BR')}
+    <Card data-testid="profile-stats">
+      <div className="space-y-5">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Resumo social
+          </p>
+          <div className="space-y-1">
+            <h2 className="font-display text-2xl font-semibold text-primary">
+              Estatisticas que sustentam a identidade do perfil
+            </h2>
+            <p className="text-sm leading-6 text-secondary">
+              Progressao, reputacao e alcance social visivel com os dados ja publicados neste
+              perfil.
             </p>
           </div>
-        ))}
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.08fr)_minmax(0,0.92fr)]">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-control border border-border bg-background-tertiary/75 px-5 py-5">
+              <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                Reputacao
+              </p>
+              <p className="mt-3 font-display text-4xl font-semibold text-primary">
+                {reputation ?? 'Indisponivel'}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-secondary">
+                Sinal acumulado de reconhecimento social no ecossistema atual do CLUTCH.
+              </p>
+            </div>
+
+            <div className="rounded-control border border-border bg-background-tertiary/75 px-5 py-5">
+              <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                Progressao
+              </p>
+              <p className="mt-3 font-display text-4xl font-semibold text-primary">
+                {level ? `Nivel ${level}` : 'Nivel indisponivel'}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-secondary">
+                {xp ? `${xp} XP acumulados no perfil atual.` : 'XP indisponivel no payload atual.'}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+            <div className="rounded-control border border-border bg-background-secondary/80 px-4 py-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                Amigos
+              </p>
+              <p className="mt-2 font-display text-2xl font-semibold text-primary">
+                {friendCount ?? 'Indisponivel'}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-secondary">
+                Relacoes publicas visiveis para leitura rapida do circulo social.
+              </p>
+            </div>
+
+            <div className="rounded-control border border-border bg-background-secondary/80 px-4 py-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                Posts
+              </p>
+              <p className="mt-2 font-display text-2xl font-semibold text-primary">
+                {postCount ?? 'Indisponivel'}
+              </p>
+              <p className="mt-1 text-sm leading-6 text-secondary">
+                Atividade publicada que ajuda a contextualizar a presenca do jogador.
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </Card>
   );

--- a/frontend/tests/unit/components/game-library-preview.test.tsx
+++ b/frontend/tests/unit/components/game-library-preview.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GameLibraryPreview } from '@/components/profile/game-library-preview';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type GameFixture = ProfileResponse['gameLibrary'];
+
+describe('GameLibraryPreview', () => {
+  it('sorts the preview by recency and exposes social metadata already present in the contract', () => {
+    const games: GameFixture = [
+      {
+        gameName: 'Old Ranked Match',
+        coverUrl: null,
+        platform: 'PC',
+        hoursPlayed: 40,
+        lastPlayedAt: '2026-03-20T10:00:00.000Z',
+      },
+      {
+        gameName: 'Most Recent Session',
+        coverUrl: null,
+        platform: 'STEAM',
+        hoursPlayed: 12,
+        lastPlayedAt: '2026-03-30T10:00:00.000Z',
+      },
+      {
+        gameName: 'Hours Only',
+        coverUrl: null,
+        platform: 'STEAM',
+        hoursPlayed: 90,
+        lastPlayedAt: null,
+      },
+    ];
+
+    render(<GameLibraryPreview username="clutchplayer" games={games} />);
+
+    expect(screen.getByTestId('game-library-preview')).toBeInTheDocument();
+    expect(screen.getByText(/3 jogos no payload atual/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 plataformas/i)).toBeInTheDocument();
+    expect(screen.getByText(/142h registradas/i)).toBeInTheDocument();
+
+    const cards = screen.getAllByTestId('profile-library-game');
+    expect(
+      within(cards[0] as HTMLElement).getByText(/most recent session/i),
+    ).toBeInTheDocument();
+    expect(within(cards[0] as HTMLElement).getByText(/30 de mar\. de 2026/i)).toBeInTheDocument();
+    expect(within(cards[1] as HTMLElement).getByText(/old ranked match/i)).toBeInTheDocument();
+    expect(within(cards[2] as HTMLElement).getByText(/hours only/i)).toBeInTheDocument();
+    expect(within(cards[2] as HTMLElement).getByText(/sem atividade recente/i)).toBeInTheDocument();
+  });
+
+  it('renders an honest empty state when no games are available', () => {
+    render(<GameLibraryPreview username="clutchplayer" games={[]} />);
+
+    expect(
+      screen.getByText(/ainda nao ha jogos visiveis nesta biblioteca/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/horas ainda indisponiveis/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProfilePageContent } from '@/components/profile/profile-page-content';
 import {
@@ -124,12 +124,20 @@ describe('ProfilePageContent', () => {
       screen.getByRole('heading', { name: /clutch player/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
+    const statsSection = screen.getByTestId('profile-stats');
+    const libraryPreview = screen.getByTestId('game-library-preview');
+    expect(statsSection).toBeInTheDocument();
+    expect(libraryPreview).toBeInTheDocument();
+    expect(within(statsSection).getByText(/^reputacao$/i)).toBeInTheDocument();
     expect(screen.getByTestId('friend-button')).toHaveTextContent('friend-button:user-1');
     expect(screen.getByTestId('friends-list')).toHaveTextContent('friends-list:user-1');
     expect(screen.getByRole('link', { name: /ver biblioteca completa/i })).toHaveAttribute(
       'href',
       '/clutchplayer/library',
     );
+    expect(within(libraryPreview).getByText(/1 jogo no payload atual/i)).toBeInTheDocument();
+    const libraryCard = within(libraryPreview).getByTestId('profile-library-game');
+    expect(within(libraryCard).getByText(/120h jogadas/i)).toBeInTheDocument();
   });
 
   it('renders not found state', async () => {

--- a/frontend/tests/unit/components/profile-stats.test.tsx
+++ b/frontend/tests/unit/components/profile-stats.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProfileStats } from '@/components/profile/profile-stats';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type StatsFixture = ProfileResponse['stats'];
+
+describe('ProfileStats', () => {
+  it('highlights reputation, progression and social counters with the current contract', () => {
+    const stats: StatsFixture = {
+      reputation: 215,
+      level: 18,
+      xp: 4820,
+      friendCount: 2,
+      postCount: 7,
+    };
+
+    render(<ProfileStats stats={stats} />);
+
+    expect(screen.getByTestId('profile-stats')).toBeInTheDocument();
+    expect(screen.getByText(/resumo social/i)).toBeInTheDocument();
+    expect(screen.getByText(/^215$/)).toBeInTheDocument();
+    expect(screen.getByText(/nivel 18/i)).toBeInTheDocument();
+    expect(screen.getByText(/4.820 xp acumulados/i)).toBeInTheDocument();
+    expect(screen.getByText(/^2$/)).toBeInTheDocument();
+    expect(screen.getByText(/^7$/)).toBeInTheDocument();
+  });
+
+  it('renders an honest fallback when runtime values are not finite', () => {
+    const stats: StatsFixture = {
+      reputation: Number.NaN,
+      level: Number.NaN,
+      xp: Number.NaN,
+      friendCount: Number.NaN,
+      postCount: Number.NaN,
+    };
+
+    render(<ProfileStats stats={stats} />);
+
+    expect(screen.getAllByText(/^Indisponivel$/)).toHaveLength(3);
+    expect(screen.getByText(/nivel indisponivel/i)).toBeInTheDocument();
+    expect(screen.getByText(/xp indisponivel no payload atual/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Resumo
Esta PR reforça o resumo social do perfil público sem reabrir o header da #215 e sem alterar o contrato de `GET /profiles/:username`. O foco está em dar mais hierarquia às estatísticas já existentes e tornar a biblioteca recente mais legível como extensão da identidade do jogador.

## O que foi alterado
- Reorganização de `ProfileStats` para separar progressão, reputação e contadores sociais com pesos visuais diferentes.
- Reagrupamento de `ProfilePageContent` para aproximar estatísticas e biblioteca recente logo abaixo do header.
- Evolução de `GameLibraryPreview` para:
  - priorizar jogos mais recentes com fallback determinístico por horas e ordem alfabética
  - exibir horas jogadas e última atividade com base apenas em `gameLibrary`
  - mostrar resumo rápido de jogos, plataformas e horas já presentes no payload
  - degradar de forma honesta quando a biblioteca estiver vazia ou parcial
- Criação de testes unitários focados para `ProfileStats` e `GameLibraryPreview`.
- Atualização do teste de integração local de `ProfilePageContent` para cobrir a nova leitura do resumo.

## Motivação
O perfil já exibia estatísticas e biblioteca recente, mas ambos os blocos ainda estavam fracos como resumo social do jogador: todas as métricas tinham o mesmo peso visual e a biblioteca recente desperdiçava metadados já disponíveis no contrato. A mudança busca melhorar leitura e utilidade social sem inventar backend nem abrir escopo para outras issues do perfil.

## Como validar
- `cd frontend`
- `npm ci`
- `npm run test -- tests/unit/components/profile-page-content.test.tsx tests/unit/components/profile-stats.test.tsx tests/unit/components/game-library-preview.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Opcional para popular o perfil demo no ambiente local: `docker exec clutch_backend npm run db:seed`
- Depois da seed, abrir `/clutchplayer` e revisar a faixa abaixo do header:
  - estatísticas reorganizadas
  - preview da biblioteca com horas e última atividade
  - empty state honesto quando não houver jogos

## Riscos e impactos
- Baixo risco de contrato: a PR não altera backend nem schemas do profile.
- Há mudança de composição no corpo do perfil ao aproximar stats e biblioteca recente; qualquer ajuste adicional de microcopy ou ritmo visual fora desse recorte deve ficar para #217/#218.
- O preview da biblioteca passa a ordenar localmente por `lastPlayedAt`, com fallback por `hoursPlayed` e nome. Isso muda apenas a apresentação do resumo, não o payload nem a página completa da biblioteca.
- A verificação visual manual em navegador permaneceu limitada nesta sessão por timeout do stack local em dev; a validação funcional ficou coberta por testes e pelo smoke do payload do profile no backend.

## Evidências
- Testes executados com sucesso:
  - `npm run test -- tests/unit/components/profile-page-content.test.tsx tests/unit/components/profile-stats.test.tsx tests/unit/components/game-library-preview.test.tsx`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Smoke operacional executado:
  - `docker exec clutch_backend npm run db:seed`
  - `GET /profiles/clutchplayer` no backend retornando `200` com `stats` e `gameLibrary`
- Não há evidências visuais anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #216