### PR TITLE
fix(presence): enriquece a microcopy de status em perfil e amizades

### DIFF
--- a/frontend/src/components/friends/friends-list.tsx
+++ b/frontend/src/components/friends/friends-list.tsx
@@ -58,37 +58,37 @@ function describeRealtimeState(connectionStatus: string, errorMessage: string | 
     case 'connected':
       return {
         tone: 'success' as const,
-        label: 'Realtime ativo',
-        detail: 'A ordenacao usa atualizacoes em tempo real.',
+        label: 'Presenca ao vivo',
+        detail: 'Status e ordenacao refletem atualizacoes em tempo real.',
       };
     case 'connecting':
       return {
         tone: 'neutral' as const,
-        label: 'Conectando realtime',
-        detail: 'A lista usa o snapshot do backend ate a conexao estabilizar.',
+        label: 'Sincronizando presenca',
+        detail: 'Exibindo o snapshot mais recente ate o realtime estabilizar.',
       };
     case 'reconnecting':
       return {
         tone: 'warning' as const,
-        label: 'Reconectando realtime',
-        detail: 'A lista voltou temporariamente para o snapshot do backend.',
+        label: 'Reconectando presenca',
+        detail: 'Mantendo o snapshot atual enquanto as atualizacoes ao vivo retornam.',
       };
     case 'auth_error':
       return {
         tone: 'warning' as const,
-        label: 'Sessao do realtime expirou',
-        detail: errorMessage ?? 'A sessao sera restaurada antes de reabrir o realtime.',
+        label: 'Sessao de presenca expirada',
+        detail: errorMessage ?? 'A sessao sera renovada antes de retomar as atualizacoes ao vivo.',
       };
     case 'error':
       return {
         tone: 'warning' as const,
-        label: 'Realtime indisponivel',
+        label: 'Atualizacoes ao vivo indisponiveis',
         detail: errorMessage ?? 'Exibindo o snapshot mais recente do backend.',
       };
     default:
       return {
         tone: 'neutral' as const,
-        label: 'Realtime inativo',
+        label: 'Presenca ao vivo inativa',
         detail: 'Exibindo o snapshot mais recente do backend.',
       };
   }
@@ -177,7 +177,7 @@ export function FriendsList({
                 ? friend.profile.displayName
                 : friend.username;
             const avatarFallback = friend.username.slice(0, 2).toUpperCase();
-            const effectivePresence = resolvePresence(friend, presenceEntries[friend.id]);
+            const effectivePresence = resolvePresence(friend, realtimeEntries[friend.id]);
 
             return (
               <div

--- a/frontend/src/components/profile/presence-badge.tsx
+++ b/frontend/src/components/profile/presence-badge.tsx
@@ -22,8 +22,8 @@ const toneByStatus: Record<
 
 const labelByStatus: Record<ProfilePresenceStatus, string> = {
   ONLINE: 'Online',
-  IN_GAME: 'In game',
-  AFK: 'AFK',
+  IN_GAME: 'Jogando',
+  AFK: 'Ausente',
   OFFLINE: 'Offline',
 };
 
@@ -35,30 +35,34 @@ function resolvePrimaryDetail(
     return `Jogando ${currentGame}`;
   }
 
+  if (status === 'IN_GAME') {
+    return 'Em partida agora';
+  }
+
   if (status === 'ONLINE') {
-    return 'Disponivel para jogar';
+    return 'Disponivel para jogar agora';
   }
 
   if (status === 'AFK') {
-    return 'Ausente no momento';
+    return 'Em pausa no momento';
   }
 
-  return 'Sem atividade ativa';
+  return 'Sem sessao publica ativa';
 }
 
 function resolveSecondaryDetail(
   status: ProfilePresenceStatus,
   platform: string | null,
 ): string {
-  if (platform) {
-    return `Plataforma atual: ${platform}`;
+  if (platform && status !== 'OFFLINE') {
+    return `Via ${platform}`;
   }
 
   if (status === 'OFFLINE') {
-    return 'Nenhuma sessao publica no momento';
+    return 'Nenhuma plataforma publica ativa';
   }
 
-  return 'Sem plataforma informada';
+  return 'Sem plataforma publica informada';
 }
 
 export function PresenceBadge({
@@ -70,7 +74,10 @@ export function PresenceBadge({
   const secondaryDetail = resolveSecondaryDetail(status, platform);
 
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-control border border-border bg-background-tertiary/70 px-3 py-3">
+    <div
+      data-testid="presence-badge"
+      className="flex flex-wrap items-center gap-3 rounded-control border border-border bg-background-tertiary/70 px-3 py-3"
+    >
       <Badge tone={toneByStatus[status]}>
         <motion.span
           initial={{ opacity: 0.55 }}

--- a/frontend/tests/unit/components/friends-list.test.tsx
+++ b/frontend/tests/unit/components/friends-list.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FriendsList } from '@/components/friends/friends-list';
 import { fetchFriends } from '@/services/friends';
@@ -57,9 +57,15 @@ describe('FriendsList', () => {
     renderFriendsList();
 
     const items = await screen.findAllByTestId('friend-list-item');
-    expect(items[0]).toHaveTextContent(/in game/i);
-    expect(items[1]).toHaveTextContent(/online/i);
-    expect(items[2]).toHaveTextContent(/offline/i);
+    expect(
+      within(within(items[0] as HTMLElement).getByTestId('presence-badge')).getByText(/^jogando$/i),
+    ).toBeInTheDocument();
+    expect(
+      within(within(items[1] as HTMLElement).getByTestId('presence-badge')).getByText(/^online$/i),
+    ).toBeInTheDocument();
+    expect(
+      within(within(items[2] as HTMLElement).getByTestId('presence-badge')).getByText(/^offline$/i),
+    ).toBeInTheDocument();
   });
 
   it('reorders the list when realtime presence overrides the fetched snapshot', async () => {
@@ -92,9 +98,13 @@ describe('FriendsList', () => {
     renderFriendsList();
 
     const items = await screen.findAllByTestId('friend-list-item');
-    expect(items[0]).toHaveTextContent(/offline/i);
-    expect(items[0]).toHaveTextContent(/jogando marvel rivals/i);
-    expect(items[1]).toHaveTextContent(/online/i);
+    const firstPresenceBadge = within(items[0] as HTMLElement).getByTestId('presence-badge');
+    const secondPresenceBadge = within(items[1] as HTMLElement).getByTestId('presence-badge');
+
+    expect(within(firstPresenceBadge).getByText(/^jogando$/i)).toBeInTheDocument();
+    expect(within(firstPresenceBadge).getByText(/jogando marvel rivals/i)).toBeInTheDocument();
+    expect(within(firstPresenceBadge).getByText(/^via pc$/i)).toBeInTheDocument();
+    expect(within(secondPresenceBadge).getByText(/^online$/i)).toBeInTheDocument();
   });
 
   it('falls back to the backend snapshot when realtime is disconnected', async () => {
@@ -126,9 +136,14 @@ describe('FriendsList', () => {
 
     renderFriendsList();
 
-    expect((await screen.findAllByText(/realtime indisponivel/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/atualizacoes ao vivo indisponiveis/i)).length).toBeGreaterThan(0);
     const items = await screen.findAllByTestId('friend-list-item');
-    expect(items[0]).toHaveTextContent(/online/i);
-    expect(items[1]).toHaveTextContent(/offline/i);
+    expect(
+      within(within(items[0] as HTMLElement).getByTestId('presence-badge')).getByText(/^online$/i),
+    ).toBeInTheDocument();
+    expect(
+      within(within(items[1] as HTMLElement).getByTestId('presence-badge')).getByText(/^offline$/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/marvel rivals/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -54,9 +54,9 @@ describe('GamerCard', () => {
 
     render(<GamerCard profile={profileFixture} />);
 
-    expect(screen.getByText(/in game/i)).toBeInTheDocument();
+    expect(screen.getByText(/^jogando$/i)).toBeInTheDocument();
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
-    expect(screen.getByText(/plataforma atual: pc/i)).toBeInTheDocument();
+    expect(screen.getByText(/^via pc$/i)).toBeInTheDocument();
     expect(screen.getByText(/nivel 18/i)).toBeInTheDocument();
     expect(screen.getByText(/founder/i)).toBeInTheDocument();
     const platformsSection = screen.getByTestId('profile-platform-badges');
@@ -92,9 +92,9 @@ describe('GamerCard', () => {
       />,
     );
 
-    expect(screen.getByText(/offline/i)).toBeInTheDocument();
-    expect(screen.getByText(/sem atividade ativa/i)).toBeInTheDocument();
-    expect(screen.getByText(/nenhuma sessao publica no momento/i)).toBeInTheDocument();
+    expect(screen.getByText(/^offline$/i)).toBeInTheDocument();
+    expect(screen.getByText(/sem sessao publica ativa/i)).toBeInTheDocument();
+    expect(screen.getByText(/nenhuma plataforma publica ativa/i)).toBeInTheDocument();
     expect(screen.getByText(/esse jogador ainda nao adicionou uma bio/i)).toBeInTheDocument();
   });
 

--- a/frontend/tests/unit/components/presence-badge.test.tsx
+++ b/frontend/tests/unit/components/presence-badge.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PresenceBadge } from '@/components/profile/presence-badge';
+
+describe('PresenceBadge', () => {
+  it('renders richer in-game context when game and platform are available', () => {
+    render(
+      <PresenceBadge
+        status="IN_GAME"
+        currentGame="Valorant"
+        platform="PC"
+      />,
+    );
+
+    expect(screen.getByTestId('presence-badge')).toBeInTheDocument();
+    expect(screen.getByText(/^jogando$/i)).toBeInTheDocument();
+    expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
+    expect(screen.getByText(/^via pc$/i)).toBeInTheDocument();
+  });
+
+  it('keeps the copy honest when no platform or activity context is available', () => {
+    render(
+      <PresenceBadge
+        status="OFFLINE"
+        currentGame={null}
+        platform={null}
+      />,
+    );
+
+    expect(screen.getByText(/^offline$/i)).toBeInTheDocument();
+    expect(screen.getByText(/sem sessao publica ativa/i)).toBeInTheDocument();
+    expect(screen.getByText(/nenhuma plataforma publica ativa/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Resumo
Esta PR melhora a leitura social da presence entre perfil e lista de amigos usando apenas o contrato realtime atual. O foco esta em tornar a copy menos tecnica, aproveitar melhor `currentGame` e `platform` quando existirem e corrigir uma divergencia local entre snapshot e override realtime na renderizacao da friends list.

## O que foi alterado
- `PresenceBadge`
- Ajuste da semantica de `ONLINE`, `IN_GAME`, `AFK` e `OFFLINE` para uma leitura mais humana.
- Melhor uso de `currentGame` e `platform` sem inferir dados ausentes.
- Adicao de `data-testid` para cobrir a apresentacao de presence com menos fragilidade.
- `FriendsList`
- Ajuste da copy do estado do realtime para ficar menos tecnica e mais coerente com a leitura social da lista.
- Correcao do gate de renderizacao para usar override da store apenas quando a conexao estiver `connected`, alinhando a lista ao mesmo comportamento ja adotado no perfil.
- Testes
- Atualizacao de `gamer-card.test.tsx` e `friends-list.test.tsx` para a nova copy.
- Criacao de `presence-badge.test.tsx` para cobrir a semantica central de presence.

## Motivação
O contrato de presence ja traz `status`, `currentGame` e `platform`, mas a UI ainda comunicava esses estados de forma seca e um pouco tecnica demais. Alem disso, a lista de amigos podia renderizar override realtime mesmo quando a conexao nao estava ativa, o que criava uma leitura menos coerente entre perfil e amizades.

## Como validar
- `cd frontend`
- `npm ci`
- `npm run test -- tests/unit/components/presence-badge.test.tsx tests/unit/components/gamer-card.test.tsx tests/unit/components/friends-list.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Opcional para popular os dados demo no ambiente local: `docker exec clutch_backend npm run db:seed`
- Para smoke operacional desta branch:
  - subir o frontend local com `NEXT_PUBLIC_APP_URL=http://localhost:3017` e `NEXT_PUBLIC_API_URL=http://localhost/api`
  - verificar `GET http://127.0.0.1:3017/api/profiles/clutchplayer` retornando `200`

## Riscos e impactos
- Baixo risco de contrato: a PR nao altera schema, handshake WebSocket nem backend.
- Ha mudanca semantica de copy em perfil e amigos; testes foram ajustados para reduzir fragilidade de frase exata fora do bloco de presence.
- A correcao no gate da friends list muda a renderizacao quando houver entradas stale na store com conexao nao ativa. Esse efeito e intencional para alinhar a UI ao snapshot atual do backend.
- O smoke visual completo do perfil e da lista de amigos permaneceu parcial nesta sessao: sem sessao autenticada, `GET /clutchplayer` na instancia local caiu no fluxo de login, entao a verificacao browser-side do corpo hidratado nao foi concluida.

## Evidências
- Testes executados com sucesso:
  - `npm run test -- tests/unit/components/presence-badge.test.tsx tests/unit/components/gamer-card.test.tsx tests/unit/components/friends-list.test.tsx`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Smoke operacional executado:
  - `docker exec clutch_backend npm run db:seed`
  - `GET http://127.0.0.1:3017/api/profiles/clutchplayer` retornando `200` pela instancia local do frontend apontada para `http://localhost/api`
- Nao ha evidencias visuais anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #217