### PR TITLE
feat(presence): explicitar realtime ativo, reconexão e fallback para snapshot

### DIFF
--- a/frontend/src/components/friends/friends-list.tsx
+++ b/frontend/src/components/friends/friends-list.tsx
@@ -5,9 +5,17 @@ import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { PresenceBadge } from '@/components/profile/presence-badge';
+import {
+  getPresenceConnectionView,
+  isPresenceRealtimeActive,
+} from '@/lib/presence/connection-state';
 import { type FriendSummary, type FriendPresenceStatus } from '@/schemas/friends';
 import { fetchFriends } from '@/services/friends';
-import { usePresenceStore, type PresenceEntry } from '@/store/presence-store';
+import {
+  usePresenceStore,
+  type PresenceConnectionStatus,
+  type PresenceEntry,
+} from '@/store/presence-store';
 
 type FriendsListProps = {
   userId: string;
@@ -53,47 +61,6 @@ export function sortFriendsByEffectivePresence(
   });
 }
 
-function describeRealtimeState(connectionStatus: string, errorMessage: string | null) {
-  switch (connectionStatus) {
-    case 'connected':
-      return {
-        tone: 'success' as const,
-        label: 'Presenca ao vivo',
-        detail: 'Status e ordenacao refletem atualizacoes em tempo real.',
-      };
-    case 'connecting':
-      return {
-        tone: 'neutral' as const,
-        label: 'Sincronizando presenca',
-        detail: 'Exibindo o snapshot mais recente ate o realtime estabilizar.',
-      };
-    case 'reconnecting':
-      return {
-        tone: 'warning' as const,
-        label: 'Reconectando presenca',
-        detail: 'Mantendo o snapshot atual enquanto as atualizacoes ao vivo retornam.',
-      };
-    case 'auth_error':
-      return {
-        tone: 'warning' as const,
-        label: 'Sessao de presenca expirada',
-        detail: errorMessage ?? 'A sessao sera renovada antes de retomar as atualizacoes ao vivo.',
-      };
-    case 'error':
-      return {
-        tone: 'warning' as const,
-        label: 'Atualizacoes ao vivo indisponiveis',
-        detail: errorMessage ?? 'Exibindo o snapshot mais recente do backend.',
-      };
-    default:
-      return {
-        tone: 'neutral' as const,
-        label: 'Presenca ao vivo inativa',
-        detail: 'Exibindo o snapshot mais recente do backend.',
-      };
-  }
-}
-
 function FriendsListLoadingState() {
   return (
     <Card data-testid="friends-list-loading">
@@ -111,7 +78,9 @@ export function FriendsList({
   title = 'Amigos',
 }: FriendsListProps) {
   const presenceEntries = usePresenceStore((state) => state.entries);
-  const connectionStatus = usePresenceStore((state) => state.connectionStatus);
+  const connectionStatus = usePresenceStore(
+    (state) => state.connectionStatus,
+  ) as PresenceConnectionStatus;
   const errorMessage = usePresenceStore((state) => state.errorMessage);
   const friendsQuery = useQuery({
     queryKey: ['friends', userId],
@@ -137,9 +106,9 @@ export function FriendsList({
     );
   }
 
-  const realtimeEntries = connectionStatus === 'connected' ? presenceEntries : {};
+  const realtimeEntries = isPresenceRealtimeActive(connectionStatus) ? presenceEntries : {};
   const friends = sortFriendsByEffectivePresence(friendsQuery.data, realtimeEntries);
-  const realtimeState = describeRealtimeState(connectionStatus, errorMessage);
+  const realtimeState = getPresenceConnectionView(connectionStatus, errorMessage);
 
   if (friends.length === 0) {
     return (
@@ -203,6 +172,7 @@ export function FriendsList({
                   status={effectivePresence.status}
                   currentGame={effectivePresence.currentGame}
                   platform={effectivePresence.platform}
+                  connectionStatus={connectionStatus}
                 />
               </div>
             );

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -10,8 +10,10 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { NotificationsBell } from '@/components/notifications/notifications-bell';
 import { useAuth } from '@/hooks/use-auth';
+import { getPresenceConnectionView } from '@/lib/presence/connection-state';
 import { cn } from '@/lib/utils/cn';
 import { fetchPendingFriendRequests } from '@/services/friends';
+import { usePresenceStore } from '@/store/presence-store';
 
 type NavbarVariant = 'auth' | 'app';
 
@@ -55,6 +57,12 @@ export function Navbar({
 }: NavbarProps) {
   const { user, status, logout } = useAuth();
   const [isRequestsOpen, setIsRequestsOpen] = useState(false);
+  const presenceConnectionStatus = usePresenceStore((state) => state.connectionStatus);
+  const presenceConnectionError = usePresenceStore((state) => state.errorMessage);
+  const presenceConnectionView = getPresenceConnectionView(
+    presenceConnectionStatus,
+    presenceConnectionError,
+  );
   const pendingRequestsQuery = useQuery({
     queryKey: ['friend-requests', user?.id],
     queryFn: () => fetchPendingFriendRequests(user?.id as string),
@@ -109,6 +117,17 @@ export function Navbar({
         <div className="flex items-center gap-2">
           {variant === 'app' ? (
             <>
+              <div
+                className="hidden min-w-0 flex-col items-end gap-1 lg:flex"
+                data-testid="navbar-presence-status"
+              >
+                <Badge tone={presenceConnectionView.tone}>
+                  {presenceConnectionView.label}
+                </Badge>
+                <p className="max-w-52 text-right text-[11px] leading-4 text-secondary">
+                  {presenceConnectionView.detail}
+                </p>
+              </div>
               <NotificationsBell />
               <ActionButton
                 type="button"

--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { PresenceBadge } from '@/components/profile/presence-badge';
 import { PlatformBadges } from '@/components/profile/platform-badges';
+import { isPresenceRealtimeActive } from '@/lib/presence/connection-state';
 import { type ProfileResponse } from '@/schemas/profile';
 import { usePresenceStore } from '@/store/presence-store';
 
@@ -35,8 +36,9 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
   const initials = profile.username.slice(0, 2).toUpperCase();
   const accentColor = profile.profile.accentColor ?? '#7C3AED';
   const memberSinceLabel = formatMemberSince(profile.createdAt);
+  const connectionStatus = usePresenceStore((state) => state.connectionStatus);
   const realtimePresence = usePresenceStore((state) =>
-    state.connectionStatus === 'connected' ? state.entries[profile.id] : undefined,
+    isPresenceRealtimeActive(state.connectionStatus) ? state.entries[profile.id] : undefined,
   );
   const effectivePresence = {
     status: realtimePresence?.status ?? profile.presence.status,
@@ -112,6 +114,7 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
           status={effectivePresence.status}
           currentGame={effectivePresence.currentGame}
           platform={effectivePresence.platform}
+          connectionStatus={connectionStatus}
         />
 
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(260px,0.65fr)]">

--- a/frontend/src/components/profile/presence-badge.tsx
+++ b/frontend/src/components/profile/presence-badge.tsx
@@ -2,12 +2,15 @@
 
 import { motion } from 'framer-motion';
 import { Badge } from '@/components/ui/badge';
+import { getPresenceConnectionView } from '@/lib/presence/connection-state';
 import { type ProfilePresenceStatus } from '@/schemas/profile';
+import { type PresenceConnectionStatus } from '@/store/presence-store';
 
 type PresenceBadgeProps = {
   status: ProfilePresenceStatus;
   currentGame: string | null;
   platform: string | null;
+  connectionStatus?: PresenceConnectionStatus;
 };
 
 const toneByStatus: Record<
@@ -69,31 +72,42 @@ export function PresenceBadge({
   status,
   currentGame,
   platform,
+  connectionStatus = 'connected',
 }: PresenceBadgeProps) {
   const primaryDetail = resolvePrimaryDetail(status, currentGame);
   const secondaryDetail = resolveSecondaryDetail(status, platform);
+  const connectionView = getPresenceConnectionView(connectionStatus);
 
   return (
     <div
       data-testid="presence-badge"
       className="flex flex-wrap items-center gap-3 rounded-control border border-border bg-background-tertiary/70 px-3 py-3"
     >
-      <Badge tone={toneByStatus[status]}>
-        <motion.span
-          initial={{ opacity: 0.55 }}
-          animate={{ opacity: [0.55, 1, 0.55] }}
-          transition={{ duration: 1.4, repeat: Number.POSITIVE_INFINITY }}
-          className="mr-1 inline-block h-2 w-2 rounded-full bg-current"
-          aria-hidden="true"
-        />
-        {labelByStatus[status]}
-      </Badge>
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge tone={toneByStatus[status]}>
+          <motion.span
+            initial={{ opacity: 0.55 }}
+            animate={{ opacity: [0.55, 1, 0.55] }}
+            transition={{ duration: 1.4, repeat: Number.POSITIVE_INFINITY }}
+            className="mr-1 inline-block h-2 w-2 rounded-full bg-current"
+            aria-hidden="true"
+          />
+          {labelByStatus[status]}
+        </Badge>
+        <Badge
+          tone={connectionView.tone}
+          data-testid="presence-source-badge"
+          title={connectionView.detail}
+        >
+          {connectionView.badgeLabel}
+        </Badge>
+      </div>
       <div className="min-w-0 space-y-1">
         <p className="truncate text-sm font-medium text-primary">
           {primaryDetail}
         </p>
         <p className="truncate text-xs uppercase tracking-[0.28em] text-secondary">
-          {secondaryDetail}
+          {[secondaryDetail, connectionView.sourceLabel].join(' • ')}
         </p>
       </div>
     </div>

--- a/frontend/src/lib/presence/connection-state.ts
+++ b/frontend/src/lib/presence/connection-state.ts
@@ -1,0 +1,76 @@
+import { type PresenceConnectionStatus } from '@/store/presence-store';
+
+type PresenceConnectionTone = 'neutral' | 'success' | 'warning';
+
+export type PresenceConnectionView = {
+  tone: PresenceConnectionTone;
+  label: string;
+  detail: string;
+  badgeLabel: string;
+  sourceLabel: string;
+};
+
+export function isPresenceRealtimeActive(
+  connectionStatus: PresenceConnectionStatus,
+): boolean {
+  return connectionStatus === 'connected';
+}
+
+export function getPresenceConnectionView(
+  connectionStatus: PresenceConnectionStatus,
+  errorMessage: string | null = null,
+): PresenceConnectionView {
+  switch (connectionStatus) {
+    case 'connected':
+      return {
+        tone: 'success',
+        label: 'Realtime ativo',
+        detail: 'Atualizacoes ao vivo estao ativas agora.',
+        badgeLabel: 'Ao vivo',
+        sourceLabel: 'Presenca ao vivo',
+      };
+    case 'connecting':
+      return {
+        tone: 'neutral',
+        label: 'Sincronizando presenca',
+        detail: 'Usando o snapshot mais recente ate o realtime estabilizar.',
+        badgeLabel: 'Sincronizando',
+        sourceLabel: 'Snapshot recente',
+      };
+    case 'reconnecting':
+      return {
+        tone: 'warning',
+        label: 'Reconectando presenca',
+        detail: 'Mantendo o snapshot atual enquanto as atualizacoes ao vivo retornam.',
+        badgeLabel: 'Reconectando',
+        sourceLabel: 'Snapshot durante reconexao',
+      };
+    case 'auth_error':
+      return {
+        tone: 'warning',
+        label: 'Sessao de presenca expirada',
+        detail:
+          errorMessage ??
+          'Mantendo o snapshot mais recente ate renovar a sessao do realtime.',
+        badgeLabel: 'Snapshot',
+        sourceLabel: 'Snapshot ate renovar sessao',
+      };
+    case 'error':
+      return {
+        tone: 'warning',
+        label: 'Atualizacoes ao vivo indisponiveis',
+        detail: errorMessage ?? 'Exibindo o snapshot mais recente do backend.',
+        badgeLabel: 'Snapshot',
+        sourceLabel: 'Snapshot do backend',
+      };
+    case 'idle':
+    default:
+      return {
+        tone: 'neutral',
+        label: 'Presenca ao vivo inativa',
+        detail: 'Exibindo o snapshot mais recente do backend.',
+        badgeLabel: 'Snapshot',
+        sourceLabel: 'Snapshot do backend',
+      };
+  }
+}

--- a/frontend/tests/unit/components/friends-list.test.tsx
+++ b/frontend/tests/unit/components/friends-list.test.tsx
@@ -101,9 +101,16 @@ describe('FriendsList', () => {
     const firstPresenceBadge = within(items[0] as HTMLElement).getByTestId('presence-badge');
     const secondPresenceBadge = within(items[1] as HTMLElement).getByTestId('presence-badge');
 
+    expect(screen.getByText(/realtime ativo/i)).toBeInTheDocument();
+    expect(screen.getByText(/atualizacoes ao vivo estao ativas agora/i)).toBeInTheDocument();
+    expect(within(firstPresenceBadge).getByTestId('presence-source-badge')).toHaveTextContent(
+      /ao vivo/i,
+    );
     expect(within(firstPresenceBadge).getByText(/^jogando$/i)).toBeInTheDocument();
     expect(within(firstPresenceBadge).getByText(/jogando marvel rivals/i)).toBeInTheDocument();
-    expect(within(firstPresenceBadge).getByText(/^via pc$/i)).toBeInTheDocument();
+    expect(
+      within(firstPresenceBadge).getByText(/via pc • presenca ao vivo/i),
+    ).toBeInTheDocument();
     expect(within(secondPresenceBadge).getByText(/^online$/i)).toBeInTheDocument();
   });
 
@@ -137,10 +144,16 @@ describe('FriendsList', () => {
     renderFriendsList();
 
     expect((await screen.findAllByText(/atualizacoes ao vivo indisponiveis/i)).length).toBeGreaterThan(0);
+    expect(screen.getByText(/realtime indisponivel/i)).toBeInTheDocument();
     const items = await screen.findAllByTestId('friend-list-item');
     expect(
       within(within(items[0] as HTMLElement).getByTestId('presence-badge')).getByText(/^online$/i),
     ).toBeInTheDocument();
+    expect(
+      within(
+        within(items[0] as HTMLElement).getByTestId('presence-badge'),
+      ).getByTestId('presence-source-badge'),
+    ).toHaveTextContent(/snapshot/i);
     expect(
       within(within(items[1] as HTMLElement).getByTestId('presence-badge')).getByText(/^offline$/i),
     ).toBeInTheDocument();

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -55,8 +55,9 @@ describe('GamerCard', () => {
     render(<GamerCard profile={profileFixture} />);
 
     expect(screen.getByText(/^jogando$/i)).toBeInTheDocument();
+    expect(screen.getByTestId('presence-source-badge')).toHaveTextContent(/ao vivo/i);
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
-    expect(screen.getByText(/^via pc$/i)).toBeInTheDocument();
+    expect(screen.getByText(/via pc • presenca ao vivo/i)).toBeInTheDocument();
     expect(screen.getByText(/nivel 18/i)).toBeInTheDocument();
     expect(screen.getByText(/founder/i)).toBeInTheDocument();
     const platformsSection = screen.getByTestId('profile-platform-badges');
@@ -94,7 +95,10 @@ describe('GamerCard', () => {
 
     expect(screen.getByText(/^offline$/i)).toBeInTheDocument();
     expect(screen.getByText(/sem sessao publica ativa/i)).toBeInTheDocument();
-    expect(screen.getByText(/nenhuma plataforma publica ativa/i)).toBeInTheDocument();
+    expect(screen.getByTestId('presence-source-badge')).toHaveTextContent(/snapshot/i);
+    expect(
+      screen.getByText(/nenhuma plataforma publica ativa • snapshot do backend/i),
+    ).toBeInTheDocument();
     expect(screen.getByText(/esse jogador ainda nao adicionou uma bio/i)).toBeInTheDocument();
   });
 

--- a/frontend/tests/unit/components/navbar.test.tsx
+++ b/frontend/tests/unit/components/navbar.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Navbar } from '@/components/layout/navbar';
 import { useAuth } from '@/hooks/use-auth';
 import { fetchPendingFriendRequests } from '@/services/friends';
+import { resetPresenceStore, usePresenceStore } from '@/store/presence-store';
 
 vi.mock('@/hooks/use-auth', () => ({
   useAuth: vi.fn(),
@@ -47,6 +48,7 @@ describe('Navbar', () => {
     mockedUseAuth.mockReset();
     mockedFetchPendingFriendRequests.mockReset();
     logoutMock.mockReset();
+    resetPresenceStore();
 
     mockedUseAuth.mockReturnValue({
       status: 'authenticated',
@@ -106,5 +108,21 @@ describe('Navbar', () => {
     fireEvent.click(screen.getByRole('button', { name: /encerrar sessao/i }));
 
     expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('signals when the shell fell back to the backend snapshot during reconnect', () => {
+    mockedFetchPendingFriendRequests.mockResolvedValue([]);
+    usePresenceStore
+      .getState()
+      .setConnectionStatus('reconnecting', 'Retomando o websocket de presenca');
+
+    renderNavbar();
+
+    expect(screen.getByTestId('navbar-presence-status')).toHaveTextContent(
+      /reconectando presenca/i,
+    );
+    expect(
+      screen.getByText(/mantendo o snapshot atual enquanto as atualizacoes ao vivo retornam/i),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/presence-badge.test.tsx
+++ b/frontend/tests/unit/components/presence-badge.test.tsx
@@ -10,26 +10,32 @@ describe('PresenceBadge', () => {
         status="IN_GAME"
         currentGame="Valorant"
         platform="PC"
+        connectionStatus="connected"
       />,
     );
 
     expect(screen.getByTestId('presence-badge')).toBeInTheDocument();
     expect(screen.getByText(/^jogando$/i)).toBeInTheDocument();
+    expect(screen.getByTestId('presence-source-badge')).toHaveTextContent(/ao vivo/i);
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
-    expect(screen.getByText(/^via pc$/i)).toBeInTheDocument();
+    expect(screen.getByText(/via pc • presenca ao vivo/i)).toBeInTheDocument();
   });
 
-  it('keeps the copy honest when no platform or activity context is available', () => {
+  it('signals snapshot fallback when realtime is reconnecting', () => {
     render(
       <PresenceBadge
         status="OFFLINE"
         currentGame={null}
         platform={null}
+        connectionStatus="reconnecting"
       />,
     );
 
     expect(screen.getByText(/^offline$/i)).toBeInTheDocument();
+    expect(screen.getByTestId('presence-source-badge')).toHaveTextContent(/reconectando/i);
     expect(screen.getByText(/sem sessao publica ativa/i)).toBeInTheDocument();
-    expect(screen.getByText(/nenhuma plataforma publica ativa/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/nenhuma plataforma publica ativa • snapshot durante reconexao/i),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Resumo
Esta PR melhora a clareza operacional da presence no frontend sem alterar contrato, backend ou handshake WebSocket. Shell, perfil e lista de amigos passam a distinguir de forma consistente quando a UI está em realtime ativo, sincronizando/reconectando ou usando fallback para snapshot.

## O que foi alterado
- Centralizada a leitura do estado operacional de presence em um helper compartilhado no frontend.
- Atualizados os badges de presence do perfil e da lista de amigos para expor a origem efetiva da informação (`Ao vivo`, `Reconectando`, `Snapshot`).
- Alinhada a friends list ao mesmo estado operacional usado no perfil para ordenação e renderização do fallback.
- Adicionado um indicador compacto no shell autenticado para explicitar o estado atual do realtime.
- Atualizados testes unitários de navbar, friends list, gamer card e presence badge para cobrir realtime ativo, reconexão e fallback.

## Motivação
A trilha anterior já havia melhorado a microcopy social da presence, mas ainda faltava clareza sobre a origem dos dados exibidos. Quando o websocket oscilava, a UI podia parecer inconsistente ou quebrada porque shell, perfil e amigos não explicitavam da mesma forma quando estavam mostrando snapshot do backend.

## Como validar
- `cd frontend`
- `npm ci`
- `npm run test -- tests/unit/components/presence-badge.test.tsx tests/unit/components/gamer-card.test.tsx tests/unit/components/friends-list.test.tsx tests/unit/components/navbar.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Validar visualmente, com o ambiente local disponível, que:
- o shell mostra `Realtime ativo`, `Reconectando presença` ou fallback equivalente
- o perfil mostra o badge de origem da presence (`Ao vivo`, `Reconectando` ou `Snapshot`)
- a lista de amigos usa snapshot quando o realtime não está conectado

## Riscos e impactos
- A mudança é restrita ao frontend e preserva o contrato atual de presence.
- A UI ganha um indicador adicional no shell autenticado; o principal risco é ruído visual se esse estado for exposto em excesso, mas a implementação ficou contida ao navbar e aos badges já existentes.
- Não houve alteração no backend, no provider realtime nem no protocolo WebSocket.
- O smoke manual completo de shell/perfil/amigos não foi concluído nesta rodada porque o ambiente local não estava respondendo em `http://localhost` e o daemon Docker não estava disponível para subir o stack.

## Evidências
- Testes unitários afetados passaram localmente.
- `npm run typecheck` passou.
- `npm run lint` passou.
- `npm run build` passou.
- Não há capturas de tela anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #218