### PR TITLE
feat(feed): tornar a criação de post mais orientada a diário gamer

### DIFF
--- a/frontend/src/components/feed/create-post-form.tsx
+++ b/frontend/src/components/feed/create-post-form.tsx
@@ -5,9 +5,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { RemoteImageField } from '@/components/media/remote-image-field';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { useToast } from '@/components/ui/toaster';
+import { cn } from '@/lib/utils/cn';
 import {
   createPostRequestSchema,
   type CreatePostRequest,
@@ -22,11 +24,56 @@ type CreatePostFormProps = {
 const postTypeOptions: Array<{
   value: CreatePostRequest['type'];
   label: string;
+  description: string;
+  hint: string;
+  placeholder: string;
+  mediaDescription: string;
+  mediaEmptyDescription: string;
 }> = [
-  { value: 'TEXT', label: 'Texto' },
-  { value: 'IMAGE', label: 'Imagem' },
-  { value: 'ACHIEVEMENT', label: 'Conquista' },
-  { value: 'GAME_SESSION', label: 'Sessao' },
+  {
+    value: 'TEXT',
+    label: 'Texto',
+    description: 'Atualizacao rapida sobre o que voce jogou, descobriu ou quer registrar.',
+    hint: 'Use para um registro direto do dia sem depender de imagem.',
+    placeholder: 'Conte o que rolou na sua jogatina, no seu progresso ou no momento de hoje.',
+    mediaDescription:
+      'Imagem opcional para complementar esse registro. O upload real continua disponivel e a URL publica segue como fallback.',
+    mediaEmptyDescription:
+      'Adicione uma imagem se quiser dar contexto visual ao seu registro.',
+  },
+  {
+    value: 'IMAGE',
+    label: 'Imagem',
+    description: 'Publique uma captura, setup ou momento visual da sua jogatina.',
+    hint: 'Ideal quando a imagem conta a historia e o texto entra como legenda.',
+    placeholder: 'Adicione contexto para a imagem: o que esta acontecendo aqui?',
+    mediaDescription:
+      'Envie uma imagem do seu computador. A URL publica continua disponivel como fallback explicito.',
+    mediaEmptyDescription:
+      'Envie uma captura ou use uma URL publica para registrar esse momento visual.',
+  },
+  {
+    value: 'ACHIEVEMENT',
+    label: 'Conquista',
+    description: 'Registre rank, trofeu, zerada ou objetivo concluido.',
+    hint: 'Bom para marcar um marco do progresso, mesmo sem print.',
+    placeholder: 'Qual conquista, rank ou objetivo voce desbloqueou hoje?',
+    mediaDescription:
+      'Imagem opcional para comprovar ou ilustrar a conquista. O upload real continua disponivel.',
+    mediaEmptyDescription:
+      'Adicione uma imagem se quiser mostrar a conquista, mas ela nao e obrigatoria.',
+  },
+  {
+    value: 'GAME_SESSION',
+    label: 'Sessao',
+    description: 'Resuma a sessao atual ou mais recente e o contexto da partida.',
+    hint: 'Use para registrar o que jogou, com quem e como a sessao terminou.',
+    placeholder: 'Como foi a sessao, o que voce jogou e qual era o objetivo?',
+    mediaDescription:
+      'Imagem opcional para complementar a sessao. O upload real continua disponivel e a URL publica segue como fallback.',
+    mediaEmptyDescription:
+      'Adicione uma imagem se ela ajudar a contar como foi a sessao.',
+  },
 ];
 
 export function CreatePostForm({ userId }: CreatePostFormProps) {
@@ -56,10 +103,10 @@ export function CreatePostForm({ userId }: CreatePostFormProps) {
     mutationFn: createPost,
     onSuccess: async () => {
       setServerError(null);
-      setFeedbackMessage('Post publicado com sucesso.');
+      setFeedbackMessage('Registro publicado com sucesso.');
       showToast({
-        title: 'Post publicado com sucesso',
-        description: 'Seu post ja apareceu no fluxo atual do feed.',
+        title: 'Registro publicado com sucesso',
+        description: 'Seu diario gamer ja foi atualizado no feed.',
         tone: 'success',
       });
       reset({
@@ -93,6 +140,10 @@ export function CreatePostForm({ userId }: CreatePostFormProps) {
     },
   });
   const mediaUrl = watch('mediaUrl');
+  const selectedPostType = watch('type');
+  const selectedPostTypeOption =
+    postTypeOptions.find((option) => option.value === selectedPostType) ??
+    postTypeOptions[0]!;
 
   const onSubmit = handleSubmit(async (values) => {
     setFeedbackMessage(null);
@@ -113,11 +164,12 @@ export function CreatePostForm({ userId }: CreatePostFormProps) {
             Novo post
           </p>
           <h2 className="font-display text-2xl font-semibold text-primary">
-            Compartilhe algo com sua timeline
+            Registre algo no seu diario gamer
           </h2>
           <p className="text-sm leading-6 text-secondary">
-            O backend decide sozinho se o post recebe game context com base na sua
-            presenca atual.
+            Marque uma sessao, conte um momento da jogatina ou registre uma conquista.
+            Se sua presenca estiver ativa, o CLUTCH tenta contextualizar o post com
+            base no jogo atual.
           </p>
         </div>
 
@@ -139,11 +191,72 @@ export function CreatePostForm({ userId }: CreatePostFormProps) {
           </div>
         ) : null}
 
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-medium text-primary">
+            Como este registro entra no feed
+          </legend>
+          <p className="text-sm leading-6 text-secondary">
+            Escolha o formato que mais combina com o momento que voce quer guardar.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {postTypeOptions.map((option) => {
+              const isSelected = option.value === selectedPostType;
+
+              return (
+                <label
+                  key={option.value}
+                  className={cn(
+                    'cursor-pointer rounded-control border px-4 py-4 transition',
+                    isSelected
+                      ? 'border-accent-cyan bg-[rgba(6,182,212,0.12)]'
+                      : 'border-border bg-background-tertiary/40 hover:border-accent-cyan/40',
+                  )}
+                >
+                  <input
+                    type="radio"
+                    value={option.value}
+                    className="sr-only"
+                    aria-label={`Tipo ${option.label}`}
+                    {...register('type')}
+                  />
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="text-sm font-semibold text-primary">{option.label}</span>
+                      {isSelected ? <Badge tone="accent">Selecionado</Badge> : null}
+                    </div>
+                    <p className="text-sm leading-6 text-primary/90">{option.description}</p>
+                    <p className="text-xs uppercase tracking-[0.24em] text-secondary">
+                      {option.hint}
+                    </p>
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <div
+          data-testid="selected-post-type-summary"
+          className="rounded-control border border-border bg-background-tertiary/50 px-control-x py-control-y"
+        >
+          <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+            Tipo selecionado
+          </p>
+          <div className="mt-2 space-y-1">
+            <p className="text-sm font-semibold text-primary">
+              {selectedPostTypeOption.label}
+            </p>
+            <p className="text-sm leading-6 text-secondary">
+              {selectedPostTypeOption.hint}
+            </p>
+          </div>
+        </div>
+
         <label className="block space-y-2">
-          <span className="text-sm font-medium text-primary">Conteudo</span>
+          <span className="text-sm font-medium text-primary">Registro</span>
           <textarea
             className="min-h-32 w-full rounded-control border border-border bg-background-tertiary px-control-x py-control-y text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/30"
-            placeholder="O que voce quer compartilhar hoje?"
+            placeholder={selectedPostTypeOption.placeholder}
             aria-invalid={Boolean(errors.contentText)}
             aria-describedby={errors.contentText ? 'post-content-error' : undefined}
             {...register('contentText')}
@@ -182,33 +295,28 @@ export function CreatePostForm({ userId }: CreatePostFormProps) {
               error={errors.mediaUrl?.message}
               previewAlt="Preview da imagem do post"
               emptyTitle="Nenhuma imagem selecionada"
-              emptyDescription="Envie uma imagem do seu computador ou use uma URL publica como fallback."
-              description="O post agora aceita upload real de imagem. A URL publica continua disponivel como fallback explicito."
+              emptyDescription={selectedPostTypeOption.mediaEmptyDescription}
+              description={selectedPostTypeOption.mediaDescription}
               previewClassName="aspect-[16/9]"
             />
           </div>
 
-          <label className="block space-y-2 self-start">
-            <span className="text-sm font-medium text-primary">Tipo</span>
-            <select
-              className="h-11 rounded-control border border-border bg-background-tertiary px-control-x text-sm text-primary outline-none transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/30"
-              {...register('type')}
-            >
-              {postTypeOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+          <div className="space-y-2 self-start rounded-control border border-border bg-background-tertiary/40 px-4 py-4">
+            <span className="text-sm font-medium text-primary">Resumo do formato</span>
             <p className="text-sm leading-6 text-secondary">
-              O upload real preenche `mediaUrl` com a URL publica gerada pelo backend. O seletor continua disponivel para ajustar o tipo quando necessario.
+              <span className="font-semibold text-primary">{selectedPostTypeOption.label}:</span>{' '}
+              {selectedPostTypeOption.description}
             </p>
-          </label>
+            <p className="text-sm leading-6 text-secondary">
+              O tipo continua usando o mesmo contrato do backend. O upload real so
+              preenche `mediaUrl` quando voce adicionar uma imagem.
+            </p>
+          </div>
         </div>
 
         <div className="flex items-center justify-end">
           <Button type="submit" disabled={createPostMutation.isPending}>
-            {createPostMutation.isPending ? 'Publicando...' : 'Publicar post'}
+            {createPostMutation.isPending ? 'Registrando...' : 'Registrar no feed'}
           </Button>
         </div>
       </form>

--- a/frontend/tests/unit/components/create-post-form.test.tsx
+++ b/frontend/tests/unit/components/create-post-form.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreatePostForm } from '@/components/feed/create-post-form';
 import { ToastProvider } from '@/components/ui/toaster';
@@ -67,15 +67,19 @@ describe('CreatePostForm', () => {
     renderCreatePostForm();
 
     expect(
-      screen.getByRole('heading', { name: /compartilhe algo com sua timeline/i }),
+      screen.getByRole('heading', { name: /registre algo no seu diario gamer/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /publicar post/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /registrar no feed/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /^tipo texto$/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /^tipo imagem$/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /^tipo conquista$/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /^tipo sessao$/i })).toBeInTheDocument();
   });
 
   it('validates when both content and media are empty', async () => {
     renderCreatePostForm();
 
-    fireEvent.click(screen.getByRole('button', { name: /publicar post/i }));
+    fireEvent.click(screen.getByRole('button', { name: /registrar no feed/i }));
 
     expect(
       await screen.findByText(/adicione texto ou uma url de midia para publicar/i),
@@ -124,7 +128,24 @@ describe('CreatePostForm', () => {
     expect(screen.getByLabelText(/^imagem do post$/i)).toHaveValue(
       'http://localhost/api/uploads/images/post-image.png',
     );
-    expect(screen.getByLabelText(/tipo/i)).toHaveValue('IMAGE');
+    expect(screen.getByRole('radio', { name: /^tipo imagem$/i })).toBeChecked();
+  });
+
+  it('updates the diary guidance when the selected post type changes', () => {
+    renderCreatePostForm();
+
+    fireEvent.click(screen.getByRole('radio', { name: /^tipo conquista$/i }));
+
+    const selectedSummary = screen.getByTestId('selected-post-type-summary');
+
+    expect(within(selectedSummary).getByText(/^tipo selecionado$/i)).toBeInTheDocument();
+    expect(
+      within(selectedSummary).getByText(/bom para marcar um marco do progresso, mesmo sem print/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^registro$/i)).toHaveAttribute(
+      'placeholder',
+      'Qual conquista, rank ou objetivo voce desbloqueou hoje?',
+    );
   });
 
   it('submits successfully and invalidates the feed query', async () => {
@@ -140,10 +161,10 @@ describe('CreatePostForm', () => {
 
     const { invalidateQueriesSpy } = renderCreatePostForm();
 
-    fireEvent.change(screen.getByLabelText(/conteudo/i), {
+    fireEvent.change(screen.getByLabelText(/^registro$/i), {
       target: { value: 'Novo post' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /publicar post/i }));
+    fireEvent.click(screen.getByRole('button', { name: /registrar no feed/i }));
 
     await waitFor(() => {
       expect(mockedCreatePost).toHaveBeenCalled();
@@ -160,9 +181,9 @@ describe('CreatePostForm', () => {
       });
     });
 
-    expect(await screen.findByText(/post publicado com sucesso\./i)).toBeInTheDocument();
+    expect(await screen.findByText(/registro publicado com sucesso\./i)).toBeInTheDocument();
     expect(await screen.findByTestId('toast-item')).toHaveTextContent(
-      /post publicado com sucesso/i,
+      /registro publicado com sucesso/i,
     );
   });
 
@@ -173,10 +194,10 @@ describe('CreatePostForm', () => {
 
     renderCreatePostForm();
 
-    fireEvent.change(screen.getByLabelText(/conteudo/i), {
+    fireEvent.change(screen.getByLabelText(/^registro$/i), {
       target: { value: 'Falha de teste' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /publicar post/i }));
+    fireEvent.click(screen.getByRole('button', { name: /registrar no feed/i }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       /post precisa ter texto ou midia/i,


### PR DESCRIPTION
## Resumo
Esta PR refina o fluxo de criação de post para comunicar melhor o feed como diário gamer usando apenas os tipos e contratos já existentes. A mudança fica restrita ao formulário de criação e à sua cobertura de testes, sem alterar backend, `PostType` ou upload.

## O que foi alterado
- O formulário passou a apresentar `TEXT`, `IMAGE`, `ACHIEVEMENT` e `GAME_SESSION` como opções mais legíveis, com orientação de uso por tipo.
- A microcopy principal foi ajustada para enquadrar o post como registro de jornada gamer, e não apenas como publicação genérica de timeline.
- O campo de texto e os hints de mídia agora mudam de acordo com o tipo selecionado, sem introduzir campos ou contratos novos.
- O resumo do tipo selecionado foi destacado para reforçar o contexto do post antes do envio.
- Os testes unitários do `CreatePostForm` foram atualizados para cobrir a nova orientação do fluxo.

## Motivação
O formulário já suportava os tipos corretos, mas a UX ainda apresentava esses formatos de forma seca, com pouco contexto sobre quando usar cada um. O objetivo foi tornar o fluxo mais útil como diário gamer sem abrir uma feature paralela nem depender de mudança no backend.

## Como validar
- `cd frontend`
- `npm ci`
- `npm run test -- tests/unit/components/create-post-form.test.tsx tests/unit/components/feed-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Com o ambiente local disponível, validar manualmente em `/feed` que:
- o formulário mostra os quatro tipos já suportados
- trocar o tipo muda o contexto do placeholder e dos hints
- o upload continua selecionando `IMAGE`
- o envio continua funcionando com o contrato atual

## Riscos e impactos
- A mudança é restrita ao frontend e não altera contrato do backend.
- O principal risco é a microcopy ficar excessivamente específica; os testes foram ajustados para proteger os sinais principais sem depender de uma única frase longa.
- A renderização dos cards do feed não foi alterada nesta PR e permanece fora do escopo da `#220`.
- O smoke manual completo não foi concluído nesta rodada porque `http://localhost` não estava respondendo e o daemon Docker não estava disponível no ambiente local.

## Evidências
- `npm run test -- tests/unit/components/create-post-form.test.tsx tests/unit/components/feed-page-content.test.tsx` passou.
- `npm run typecheck` passou.
- `npm run lint` passou.
- `npm run build` passou.
- Não há capturas de tela anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #219