### PR TITLE
docs(context): alinhar documentação ao estado real do frontend

### DIFF
--- a/.codex/PROJECT.md
+++ b/.codex/PROJECT.md
@@ -1,71 +1,94 @@
-# CLUTCH — PROJECT.md
+# CLUTCH - PROJECT.md
 
-## Escopo deste documento
+## Escopo do documento
 
-Este arquivo registra o estado real atual do repositorio para orientar implementacao, revisao e manutencao. Ele nao descreve roadmap como se ja estivesse entregue.
+Este arquivo resume o estado real atual do projeto para orientar implementacao, revisao, onboarding tecnico e manutencao da documentacao.
+Ele e derivado do blueprint atual, do codigo real e da validacao operacional mais recente.
 
-## Estado atual do produto
+Nao descreve roadmap como se ja estivesse entregue.
+Nao substitui o blueprint nem o backlog.
 
-### Implementado
-- Frontend Next.js com shell autenticado, landing publica simples, login, registro, feed, notificacoes, settings e perfil publico
-- Backend Fastify com auth, profiles, friends, posts, notifications, presence e integrations
-- Presence service em Go com autenticacao JWT e endpoint WebSocket em `/ws/presence`
-- Stack local container-first via `docker-compose.yml` e proxy reverso Traefik
-- Fluxo completo de sessao:
-  - access token curto
-  - refresh token rotativo em cookie httpOnly
-  - revogacao de sessao atual
-  - key rotation com `kid`
-  - validacao de `iss`, `aud` e `nbf`
-  - rate limit no auth path
-- Observabilidade estruturada no auth path e gate de seguranca para logs
-- Comandos locais de DX:
-  - `npm run env:bootstrap`
-  - `npm run env:reset`
-  - `npm run env:validate`
+## Estado atual real do produto
 
-### Parcial
-- Frontend do produto ainda nao cobre todas as telas e estados previstos nas issues abertas
-- Integracoes do frontend cobrem Steam, Epic e busca IGDB, mas Discord continua fora do contrato real atual
-- Documentacao secundaria do repositorio pode exigir alinhamento adicional fora do escopo deste arquivo
+O CLUTCH hoje opera sobre um runtime principal composto por:
 
-### Ausente
-- Pagina `/<username>/library`
-- App Router global com `error.tsx`, `loading.tsx` e `not-found.tsx`
-- Discord OAuth end-to-end
-- Uso do `python-service` no stack local atual
+- frontend Next.js 15 + TypeScript
+- backend Fastify + Prisma + TypeScript
+- presence/realtime em Go + Redis Pub/Sub
+- PostgreSQL + Redis
+- Docker Compose + Traefik como topologia local principal
 
-## Arquitetura runtime atual
+No estado atual, o produto ja entrega:
 
-### Stack local
-- `traefik` exposto na porta `80`
-- `frontend` Next.js 15 servido internamente na `3000`
-- `backend` Fastify servido internamente na `3344`
-- `presence` Go servido internamente na `8080`
-- `postgres` e `redis` internos ao compose
+- landing publica
+- login e registro
+- shell autenticado
+- feed com posts, comentarios e reacoes
+- notificacoes
+- perfil de usuario
+- settings de perfil
+- integracoes Steam, Epic, IGDB e Discord OAuth
+- biblioteca do usuario em `/:username/library`
+- presence real no frontend
+- superficies globais de `error`, `loading` e `not-found`
 
-### Topologia
-- Browser fala com o host publico unico
-- Frontend server-side fala com o backend por `INTERNAL_API_URL`
-- Realtime usa `/api/auth/presence-token` para obter JWT e conecta em `/ws/presence`
-
-## Auth e sessao no estado atual
-
-### Backend
-- Assinatura JWT com `HS256`
-- Access token com TTL curto
-- Refresh token com TTL mais longo
-- Key rotation com conjunto de chaves versionadas e `kid`
-- Compatibilidade temporaria para tokens legados sem `kid` ou sem claims adicionais, enquanto a janela operacional permitir
+## Arquitetura atual
 
 ### Frontend
-- `clutch_session` guarda o access token como cookie httpOnly
-- `clutch_refresh` e gerenciado pelo backend e propagado pelo frontend server-side
-- Rotas server-side de auth fazem refresh transparente em `401` onde isso faz sentido
 
-## Contratos atuais relevantes
+- Next.js 15 App Router
+- React 19
+- React Query para leitura e invalidacao
+- Zustand para estado global leve
+- rotas server-side `/api/*` como boundary de auth e proxy para o backend
 
-### Rotas server-side do frontend
+### Backend
+
+- Fastify como servidor HTTP principal
+- Prisma como camada de persistencia
+- organizacao em rotas finas + services + repositories
+- integracoes externas encapsuladas por provider/client especifico
+
+### Realtime
+
+- servico Go separado do backend principal
+- autenticacao JWT para WebSocket
+- Redis Pub/Sub para fan-out e sincronizacao de estado
+
+### Infra
+
+- Docker Compose como ambiente principal de execucao
+- Traefik como proxy reverso e unica entrada publica
+- service discovery por nome de container
+
+## Runtime e topologia
+
+Topologia atual simplificada:
+
+```text
+Browser
+  -> Traefik (:80)
+    -> Frontend Next.js (:3000 interno)
+      -> rotas server-side /api/*
+        -> Backend Fastify (:3344 interno)
+    -> Presence service Go (:8080 interno)
+    -> Postgres (:5432 interno)
+    -> Redis (:6379 interno)
+```
+
+Premissas operacionais atuais:
+
+- apenas Traefik expoe porta publica
+- frontend, backend e presence se comunicam por rede interna
+- postgres e redis nao devem ser assumidos como servicos expostos publicamente
+- `python-service` existe no repositorio, mas nao participa do runtime principal
+
+## Contratos principais
+
+### Auth e sessao
+
+Frontend server-side:
+
 - `/api/auth/login`
 - `/api/auth/register`
 - `/api/auth/refresh`
@@ -74,51 +97,103 @@ Este arquivo registra o estado real atual do repositorio para orientar implement
 - `/api/auth/presence-token`
 - `/api/[...path]`
 
-### Rotas principais do backend
+Backend:
+
 - `/auth`
 - `/profiles`
 - `/friends`
-- `/presence`
-- `/integrations`
 - `/posts`
 - `/notifications`
+- `/presence`
+- `/integrations`
+
+### Profile e library
+
+- a fonte principal da biblioteca continua sendo `GET /profiles/:username`
+- `gameLibrary` e consumido pelo perfil e por `/:username/library`
+- busca, filtro e ordenacao da library continuam locais no frontend
 
 ### Presence
-- Health: `/presence/health` via proxy
-- WebSocket: `/ws/presence?token=<jwt>`
 
-## Estado do frontend
+- token emitido via `/api/auth/presence-token`
+- WebSocket consumido em `/ws/presence?token=<jwt>`
+- o frontend distingue snapshot do backend e overlay realtime
 
-### Entregue
-- Shell com grupos `(auth)` e `(app)`
-- Navbar, sidebar, providers e stores de auth/presence
-- Consumidores reais de feed, notificacoes, perfil e integracoes
-- Fluxo de auth server-side e proxy ao backend
+## O que esta implementado
 
-### Nao entregue
-- Biblioteca publica do usuario
-- Discord connect no frontend
-- Superficie global completa de erro/loading/not-found
+### Frontend
 
-## Operacao local
+- library entregue e refinada
+- Discord OAuth entregue ponta a ponta entre frontend e backend
+- shell autenticado com navegacao real
+- superficies globais de erro/loading/404
+- feedback visual basico em notificacoes e amizade
+- hydration resilience nos pontos principais de data/hora
 
-Fluxo recomendado hoje:
+### Backend
 
-```bash
-npm run env:bootstrap
-npm run env:validate
-```
+- auth com access token curto, refresh token rotativo e key rotation com `kid`
+- integracoes Steam, Epic, IGDB e Discord
+- query de profile sem truncamento silencioso da library
+- enrichment de capas preservando `coverUrl` confiavel nas sincronizacoes
+- logging estruturado e redaction basica
+- fronteira backend-side de ingestao de presence Discord
 
-Reset destrutivo:
+### Presence
 
-```bash
-npm run env:reset
-```
+- presence token real
+- lifecycle de conexao, heartbeat e fan-out
+- publish de estado pelo frontend
 
-`env:reset` apaga volumes nomeados e destrói o estado local de banco e Redis. Ele existe para recomeço limpo e eliminacao de drift.
+## O que esta parcial
 
-## Limites e premissas
+- a suite completa do backend ainda nao esta 100% estavel fora do ambiente ideal
+- a integracao Epic continua limitada ao que o adapter atual fornece
+- o enrichment automatico da Steam ainda depende do primeiro candidato retornado pelo IGDB
+- parte da documentacao historica fora da `.codex` ainda pode divergir do estado atual
 
-- O repositório contem artefatos e referencias historicas que nao fazem parte do runtime local principal.
-- O backend expõe mais superficie do que o frontend consome hoje.
-- Este arquivo deve ser atualizado sempre que contratos de auth, session, realtime, stack local ou superficie de frontend mudarem.
+## O que esta sensivel
+
+- alteracoes em auth/session exigem cuidado com ordem entre middleware, bootstrap e navegacao
+- alteracoes em presence exigem cuidado com fallback entre snapshot e realtime
+- alteracoes em integracoes exigem contrato honesto para timeout, indisponibilidade e dados ausentes
+- o backend nao deve ser descrito como "100% saudavel" sem ressalva enquanto a suite completa continuar parcial
+
+## O que nao deve ser assumido
+
+- nao assumir Kafka, MongoDB ou Kubernetes no estado atual
+- nao assumir um servico Python/FastAPI real no runtime principal
+- nao assumir endpoints de library dedicados alem de `GET /profiles/:username`
+- nao assumir que backlog estrategico ja virou feature entregue
+- nao assumir que qualquer doc antiga tenha precedencia sobre o blueprint e o codigo real
+
+## Limites atuais
+
+- validacao completa do backend ainda depende de ambiente adequado para integracao com banco e Redis
+- ha warnings remanescentes de lint em `backend/src/config/rate-limit.ts`
+- o produto ainda nao deve ser planejado como se tivesse pipeline pesado de midia, mensageria sofisticada ou stack de ML operacional
+
+## Regras de manutencao da documentacao
+
+Hierarquia de verdade da `.codex`:
+
+1. blueprint atual
+2. codigo real
+3. validacao operacional comprovada
+4. documentos resumidos desta pasta
+
+Regras:
+
+- quando houver divergencia, corrigir a doc resumida e manter o blueprint como referencia principal
+- nao promover itens parciais para "entregue" sem evidencia no codigo e na validacao
+- atualizar este arquivo sempre que mudarem:
+  - arquitetura de runtime
+  - contratos centrais
+  - topologia operacional
+  - estado de implementacao do produto
+
+## Como usar este arquivo
+
+- use `PROJECT.md` como resumo operacional
+- use o blueprint atual quando precisar de detalhe tecnico mais profundo
+- use `SPRINT-NEXT.md` para o recorte de produto previsto para a proxima fase

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -20,16 +20,18 @@ Este arquivo descreve o estado real atual do frontend do CLUTCH, os contratos qu
 - `/`
 - `/login`
 - `/register`
+- `/offline`
 
 ### Autenticadas
 - `/feed`
 - `/notifications`
 - `/settings`
 - `/settings/integrations`
+- `/settings/integrations/discord/callback`
 - `/:username`
-
-### Ausentes no App Router atual
 - `/:username/library`
+
+### Superficies globais do App Router
 - `error.tsx`
 - `loading.tsx`
 - `not-found.tsx`
@@ -96,11 +98,14 @@ Esse catch-all encaminha chamadas para o backend real e, quando existe `clutch_s
 - `PATCH /notifications/:id/read`
 - `POST /integrations/steam/connect`
 - `POST /integrations/steam/sync`
-- `GET /integrations/igdb/search`
 - `POST /integrations/epic/connect`
+- `GET /integrations/igdb/search`
+- `GET /integrations/discord/auth`
+- `GET /integrations/discord/callback`
 
 ### Observacao importante
-O frontend atual nao depende de um endpoint de Discord connect porque esse contrato nao existe no backend atual. A UI de integracoes ja reconhece isso como limitacao real.
+- o frontend usa Discord OAuth real via backend, mas nao consome diretamente a rota interna de ingestao de presence Discord
+- a presence do browser continua chegando pela API do CLUTCH e pelo WebSocket do proprio produto
 
 ## Resolucao de URLs
 
@@ -124,7 +129,11 @@ NEXT_PUBLIC_API_URL=/api
 2. a rota server-side valida ou renova a sessao
 3. a resposta devolve `{ token }`
 4. o client abre `ws://<host>/ws/presence?token=<jwt>`
-5. o hook `usePresence` atualiza o store e limpa a sessao se houver falha de auth
+5. o hook `usePresence` atualiza a store e limpa a sessao se houver falha de auth
+
+### Comportamento atual
+- o frontend combina snapshot vindo do backend com overlay realtime da store
+- shell, perfil e lista de amigos distinguem realtime ativo, reconexao e fallback para snapshot
 
 ### Dependencia atual
 O presence service aceita token por query string e por header `Authorization`, mas o frontend atual usa query string.
@@ -139,13 +148,13 @@ O presence service aceita token por query string e por header `Authorization`, m
 ## Limitacoes reais
 
 ### Implementado parcialmente
-- a UI de landing publica e simples
+- a UI de landing publica continua simples
 - varias paginas existem e consomem contratos reais, mas a cobertura funcional do produto ainda nao esta completa
 
-### Ausente
-- biblioteca publica do usuario
-- Discord OAuth
-- tela global de erro/loading/404 no App Router
+### Sensivel
+- auth e refresh exigem cuidado com a ordem entre middleware, bootstrap e navegacao
+- presence exige cuidado com fallback entre snapshot e realtime
+- integracoes dependem de indisponibilidade e dados ausentes serem tratados com honestidade
 
 ### Nao assumir
 - nao assumir que `python-service` participe do runtime do frontend


### PR DESCRIPTION
## Resumo
Esta PR corrige drift documental entre `.codex/PROJECT.md`, `frontend/CONTEXT.md` e o estado real atual do repositório. O objetivo é alinhar a documentação local ao código já entregue, sem alterar runtime, contratos ou comportamento do produto.

## O que foi alterado
- Atualizado `.codex/PROJECT.md` para refletir o estado real do produto, incluindo library, Discord OAuth, superfícies globais do App Router e presença atual.
- Atualizado `frontend/CONTEXT.md` para corrigir rotas, contratos de integrações consumidos pelo frontend e o estado real de library, Discord OAuth e realtime.
- Removidas afirmações desatualizadas que marcavam features já entregues como ausentes.

## Motivação
A documentação local estava atrás do código real e já contradizia superfícies importantes do frontend. Esse drift tornava o contexto operacional menos confiável para implementação, revisão e onboarding técnico.

## Como validar
- Revisar os arquivos alterados e comparar com o código real em:
- `frontend/src/app/(app)/[username]/library/page.tsx`
- `frontend/src/app/error.tsx`
- `frontend/src/app/loading.tsx`
- `frontend/src/app/not-found.tsx`
- `frontend/src/components/settings/discord-integration-card.tsx`
- `frontend/src/components/settings/discord-oauth-callback-content.tsx`
- `frontend/src/services/integrations.ts`
- Confirmar que as rotas, contratos e limitações descritos na documentação batem com os arquivos acima.

## Riscos e impactos
- A mudança e exclusivamente documental.
- Nao ha impacto em runtime, build, dados, contratos HTTP ou comportamento de UI.
- O risco principal e apenas de texto impreciso; por isso a validacao foi feita contra o codigo real antes do commit.

## Evidências
- Auditoria manual dos arquivos de App Router, integracoes e services do frontend.
- Nao ha evidencias executaveis anexadas porque a PR nao altera runtime.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #244