### PR TITLE
feat(feed): destacar posts de sessão e conquista no card do feed

### DIFF
--- a/frontend/src/components/feed/game-context-badge.tsx
+++ b/frontend/src/components/feed/game-context-badge.tsx
@@ -6,18 +6,16 @@ type GameContextBadgeProps = {
 };
 
 export function GameContextBadge({ gameContext }: GameContextBadgeProps) {
-  const gameName = gameContext.gameName ?? 'jogo nao identificado';
-  const platformLabel = gameContext.platform
-    ? ` • ${gameContext.platform}`
-    : '';
+  const gameName = gameContext.gameName?.trim() || null;
+  const platform = gameContext.platform?.trim() || null;
+  const contextLabel = [gameName, platform].filter(Boolean).join(' • ') || 'Contexto de jogo';
 
   return (
     <Badge
       tone="accent"
       className="normal-case tracking-[0.02em] text-accent-cyan"
     >
-      Jogando {gameName}
-      {platformLabel}
+      {contextLabel}
     </Badge>
   );
 }

--- a/frontend/src/components/feed/post-card.tsx
+++ b/frontend/src/components/feed/post-card.tsx
@@ -17,9 +17,68 @@ type PostCardProps = {
   post: FeedPost;
 };
 
+type PostTypeTone = 'neutral' | 'accent' | 'success' | 'warning';
+
+type PostCardPresentation = {
+  badgeLabel: string;
+  badgeTone: PostTypeTone;
+  highlightEyebrow: string | null;
+  highlightTitle: string | null;
+  highlightDetail: string | null;
+};
+
+function normalizeContextValue(value: string | null | undefined) {
+  const normalized = value?.trim();
+
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function getPostCardPresentation(post: FeedPost): PostCardPresentation {
+  const gameName = normalizeContextValue(post.gameContext?.gameName);
+  const platform = normalizeContextValue(post.gameContext?.platform);
+  const platformDetail = platform ? `Via ${platform}` : null;
+
+  switch (post.type) {
+    case 'GAME_SESSION':
+      return {
+        badgeLabel: 'Sessao',
+        badgeTone: 'success',
+        highlightEyebrow: 'Registro de sessao',
+        highlightTitle: gameName ? `Sessao em ${gameName}` : 'Sessao de jogo registrada',
+        highlightDetail: platformDetail,
+      };
+    case 'ACHIEVEMENT':
+      return {
+        badgeLabel: 'Conquista',
+        badgeTone: 'warning',
+        highlightEyebrow: 'Registro de conquista',
+        highlightTitle: gameName ? `Conquista em ${gameName}` : 'Conquista registrada',
+        highlightDetail: platformDetail,
+      };
+    case 'IMAGE':
+      return {
+        badgeLabel: 'Imagem',
+        badgeTone: 'accent',
+        highlightEyebrow: null,
+        highlightTitle: null,
+        highlightDetail: null,
+      };
+    case 'TEXT':
+    default:
+      return {
+        badgeLabel: 'Texto',
+        badgeTone: 'neutral',
+        highlightEyebrow: null,
+        highlightTitle: null,
+        highlightDetail: null,
+      };
+  }
+}
+
 export function PostCard({ post }: PostCardProps) {
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const postPresentation = getPostCardPresentation(post);
   const displayName =
     post.author.profile?.displayName && post.author.profile.displayName.length > 0
       ? post.author.profile.displayName
@@ -59,8 +118,26 @@ export function PostCard({ post }: PostCardProps) {
               <p className="truncate text-xs text-secondary">@{post.author.username}</p>
             </div>
           </div>
-          <Badge tone="neutral">{post.type}</Badge>
+          <Badge tone={postPresentation.badgeTone}>{postPresentation.badgeLabel}</Badge>
         </header>
+
+        {postPresentation.highlightEyebrow && postPresentation.highlightTitle ? (
+          <div className="space-y-2 rounded-control border border-border/80 bg-background-secondary/60 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-secondary">
+              {postPresentation.highlightEyebrow}
+            </p>
+            <div className="space-y-1">
+              <p className="text-base font-semibold text-primary">
+                {postPresentation.highlightTitle}
+              </p>
+              {postPresentation.highlightDetail ? (
+                <p className="text-sm leading-6 text-secondary">
+                  {postPresentation.highlightDetail}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
 
         {post.contentText ? (
           <p className="text-sm leading-6 text-primary">{post.contentText}</p>

--- a/frontend/tests/unit/components/post-card.test.tsx
+++ b/frontend/tests/unit/components/post-card.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PostCard } from '@/components/feed/post-card';
+import { useAuth } from '@/hooks/use-auth';
+import { type FeedPost } from '@/schemas/feed';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/feed', () => ({
+  deletePost: vi.fn(),
+  FeedRequestError: class FeedRequestError extends Error {},
+}));
+
+vi.mock('@/components/feed/reaction-bar', () => ({
+  ReactionBar: ({ postId }: { postId: string }) => (
+    <div data-testid={`reaction-bar-${postId}`}>reactions</div>
+  ),
+}));
+
+vi.mock('@/components/feed/comment-section', () => ({
+  CommentSection: ({ postId }: { postId: string }) => (
+    <div data-testid={`comment-section-${postId}`}>comments</div>
+  ),
+}));
+
+vi.mock('@/components/ui/hydration-safe-time', () => ({
+  HydrationSafeTime: ({ fallback }: { fallback: string }) => (
+    <time>{fallback}</time>
+  ),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+
+function buildPost(overrides: Partial<FeedPost> = {}): FeedPost {
+  return {
+    id: 'post-1',
+    contentText: 'Resumo do registro',
+    mediaUrl: null,
+    type: 'TEXT',
+    gameContext: null,
+    createdAt: '2026-04-21T12:00:00.000Z',
+    author: {
+      id: 'author-1',
+      username: 'clutchplayer',
+      profile: {
+        displayName: 'Clutch Player',
+        avatarUrl: null,
+        accentColor: '#06B6D4',
+      },
+    },
+    _count: {
+      interactions: 2,
+      comments: 1,
+    },
+    ...overrides,
+  };
+}
+
+function renderPostCard(post: FeedPost) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PostCard post={post} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('PostCard', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedUseAuth.mockReturnValue({
+      status: 'authenticated',
+      user: {
+        id: 'viewer-1',
+        username: 'viewer',
+        email: 'viewer@clutch.gg',
+      },
+      logout: vi.fn(),
+    });
+  });
+
+  it('destaca posts de sessao com contexto de jogo quando disponivel', () => {
+    renderPostCard(
+      buildPost({
+        type: 'GAME_SESSION',
+        gameContext: {
+          gameName: 'Hades II',
+          platform: 'Steam',
+          capturedAt: '2026-04-21T12:00:00.000Z',
+        },
+      }),
+    );
+
+    expect(screen.getByText(/^sessao$/i)).toBeInTheDocument();
+    expect(screen.getByText(/registro de sessao/i)).toBeInTheDocument();
+    expect(screen.getByText(/sessao em hades ii/i)).toBeInTheDocument();
+    expect(screen.getByText(/via steam/i)).toBeInTheDocument();
+    expect(screen.getByText(/hades ii • steam/i)).toBeInTheDocument();
+  });
+
+  it('destaca posts de conquista sem depender de copy tecnica do tipo', () => {
+    renderPostCard(
+      buildPost({
+        type: 'ACHIEVEMENT',
+        gameContext: {
+          gameName: 'Celeste',
+          platform: null,
+          capturedAt: '2026-04-21T12:00:00.000Z',
+        },
+      }),
+    );
+
+    expect(screen.getByText(/^conquista$/i)).toBeInTheDocument();
+    expect(screen.getByText(/registro de conquista/i)).toBeInTheDocument();
+    expect(screen.getByText(/conquista em celeste/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^ACHIEVEMENT$/)).not.toBeInTheDocument();
+  });
+
+  it('mantem posts genericos sem bloco extra de sessao ou conquista', () => {
+    renderPostCard(buildPost());
+
+    expect(screen.getByText(/^texto$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/registro de sessao/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/registro de conquista/i)).not.toBeInTheDocument();
+  });
+
+  it('degrada com honestidade quando a sessao nao informa jogo ou plataforma', () => {
+    renderPostCard(
+      buildPost({
+        type: 'GAME_SESSION',
+        gameContext: {
+          gameName: null,
+          platform: null,
+          capturedAt: '2026-04-21T12:00:00.000Z',
+        },
+      }),
+    );
+
+    expect(screen.getByText(/sessao de jogo registrada/i)).toBeInTheDocument();
+    expect(screen.getByText(/^contexto de jogo$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/via /i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Resumo
Esta PR melhora a leitura dos cards do feed para posts de sessão e conquista usando apenas o contrato atual de posts. O objetivo é reforçar o feed como diário gamer sem alterar `PostType`, `gameContext` ou a composição geral do feed.

## O que foi alterado
- Feed card
- Substituída a badge técnica baseada em `post.type` por rótulos mais legíveis para `TEXT`, `IMAGE`, `ACHIEVEMENT` e `GAME_SESSION`.
- Adicionado um bloco contextual no `PostCard` para destacar registros de sessão e conquista quando o tipo do post pedir isso.
- O bloco contextual usa `gameContext` de forma opcional e honesta, sem inventar jogo, plataforma ou metadados ausentes.
- Contexto de jogo
- Ajustado o `GameContextBadge` para deixar de assumir sempre "Jogando ..." e passar a exibir somente o contexto factual disponível.
- Testes
- Adicionada cobertura dedicada do `PostCard` para sessão, conquista, posts genéricos e fallback sem `gameName` ou `platform`.

## Motivação
Os posts de `GAME_SESSION` e `ACHIEVEMENT` já existiam no contrato, mas o card do feed ainda os tratava quase como posts genéricos, com pouca diferença além do enum técnico do tipo. Isso enfraquecia a leitura do feed como diário gamer mesmo quando o payload já trazia contexto suficiente para comunicar melhor a natureza do registro.

## Como validar
- No diretório `frontend`, executar:
- `npm ci`
- `npm run test -- tests/unit/components/post-card.test.tsx`
- `npm run test -- tests/unit/components/feed-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Com o ambiente local ativo, abrir `/feed` e verificar:
- posts `GAME_SESSION` com destaque de sessão e uso opcional de `gameContext`
- posts `ACHIEVEMENT` com destaque de conquista
- posts `TEXT` e `IMAGE` sem bloco extra indevido

## Riscos e impactos
- O contrato de posts foi preservado; a mudança é apenas de renderização local no frontend.
- O `GameContextBadge` deixou de usar o verbo fixo "Jogando", então qualquer uso desse componente fora do feed passa a exibir apenas o contexto factual disponível.
- O risco funcional é baixo, porque a alteração ficou limitada ao card do feed e ganhou cobertura unitária dedicada.
- O smoke manual completo do feed não foi concluído nesta sessão porque não havia app local respondendo em `localhost` e o daemon Docker estava indisponível.

## Evidências
- Validação executada com sucesso:
- `npm run test -- tests/unit/components/post-card.test.tsx`
- `npm run test -- tests/unit/components/feed-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #220