### PR TITLE
feat(profile): exibir badges especiais e progresso social visível no gamer card

### DIFF
--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -15,6 +15,12 @@ type GamerCardProps = {
   actions?: ReactNode;
 };
 
+function normalizeBadges(badges: string[]): string[] {
+  return badges
+    .map((badge) => badge.trim())
+    .filter((badge, index, list) => badge.length > 0 && list.indexOf(badge) === index);
+}
+
 function formatMemberSince(createdAt: string): string {
   const joinedAt = new Date(createdAt);
 
@@ -32,7 +38,9 @@ function formatMemberSince(createdAt: string): string {
 
 export function GamerCard({ profile, actions }: GamerCardProps) {
   const displayName = profile.profile.displayName || profile.username;
-  const badgeList = profile.profile.badges.slice(0, 4);
+  const badgeList = normalizeBadges(profile.profile.badges);
+  const featuredTitle = badgeList[0] ?? null;
+  const specialBadges = badgeList.slice(1, 4);
   const initials = profile.username.slice(0, 2).toUpperCase();
   const accentColor = profile.profile.accentColor ?? '#7C3AED';
   const memberSinceLabel = formatMemberSince(profile.createdAt);
@@ -84,9 +92,19 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
               </div>
 
               <div className="space-y-1">
-                <h1 className="truncate font-display text-3xl font-semibold text-primary sm:text-4xl">
-                  {displayName}
-                </h1>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h1 className="truncate font-display text-3xl font-semibold text-primary sm:text-4xl">
+                    {displayName}
+                  </h1>
+                  {featuredTitle ? (
+                    <span
+                      data-testid="profile-featured-title"
+                      className="inline-flex items-center rounded-pill border border-[rgba(124,58,237,0.24)] bg-[rgba(124,58,237,0.14)] px-3 py-1 text-xs font-semibold text-accent-purple"
+                    >
+                      {featuredTitle}
+                    </span>
+                  ) : null}
+                </div>
                 <p className="truncate text-sm font-medium text-secondary">
                   @{profile.username}
                 </p>
@@ -94,11 +112,9 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
 
               <div className="flex flex-wrap items-center gap-2">
                 <Badge tone="accent">Nivel {profile.stats.level}</Badge>
-                {badgeList.map((badge) => (
-                  <Badge key={badge} tone="neutral">
-                    {badge}
-                  </Badge>
-                ))}
+                <Badge tone="success">
+                  Reputacao {profile.stats.reputation.toLocaleString('pt-BR')}
+                </Badge>
               </div>
             </div>
           </div>
@@ -117,18 +133,80 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
           connectionStatus={connectionStatus}
         />
 
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(260px,0.65fr)]">
-          <div className="space-y-2 rounded-control border border-border bg-background-tertiary/40 px-4 py-4">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(240px,0.65fr)_minmax(260px,0.8fr)]">
+          <div className="space-y-4 rounded-control border border-border bg-background-tertiary/40 px-4 py-4">
             <p className="text-xs uppercase tracking-[0.3em] text-secondary">
               Identidade
             </p>
             <p className="text-sm leading-6 text-secondary">
               {profile.profile.bio || 'Esse jogador ainda nao adicionou uma bio.'}
             </p>
+
+            {specialBadges.length > 0 ? (
+              <div className="space-y-2" data-testid="profile-special-badges">
+                <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                  Badges especiais
+                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  {specialBadges.map((badge) => (
+                    <span
+                      key={badge}
+                      className="inline-flex items-center rounded-pill border border-border bg-background-secondary/70 px-3 py-1 text-xs font-semibold text-primary"
+                    >
+                      {badge}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <div className="rounded-control border border-border bg-background-tertiary/40 px-4 py-4">
             <PlatformBadges integrations={profile.platformIntegrations} />
+          </div>
+
+          <div
+            data-testid="profile-social-progress"
+            className="space-y-4 rounded-control border border-border bg-background-tertiary/40 px-4 py-4"
+          >
+            <div className="space-y-1">
+              <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                Progresso social visivel
+              </p>
+              <p className="text-sm leading-6 text-secondary">
+                Este primeiro slice usa apenas stats reais do perfil. Continuidade
+                com amigos, streaks e ofensivas ficam para a etapa funcional posterior.
+              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+              <div className="rounded-control border border-border bg-background-secondary/70 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                  Reputacao
+                </p>
+                <p className="mt-2 font-display text-xl font-semibold text-primary">
+                  {profile.stats.reputation.toLocaleString('pt-BR')}
+                </p>
+              </div>
+
+              <div className="rounded-control border border-border bg-background-secondary/70 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                  Amigos
+                </p>
+                <p className="mt-2 font-display text-xl font-semibold text-primary">
+                  {profile.stats.friendCount.toLocaleString('pt-BR')}
+                </p>
+              </div>
+
+              <div className="rounded-control border border-border bg-background-secondary/70 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                  Posts
+                </p>
+                <p className="mt-2 font-display text-xl font-semibold text-primary">
+                  {profile.stats.postCount.toLocaleString('pt-BR')}
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -15,7 +15,7 @@ const profileFixture: ProfileResponse = {
     avatarUrl: null,
     bannerUrl: null,
     accentColor: '#7C3AED',
-    badges: ['Founder'],
+    badges: ['Founder', 'Ranked Grinder', 'Community Host'],
   },
   stats: {
     level: 18,
@@ -38,6 +38,19 @@ const profileFixture: ProfileResponse = {
 describe('GamerCard', () => {
   beforeEach(() => {
     resetPresenceStore();
+  });
+
+  it('renders featured title, special badges and visible social progress from current profile data', () => {
+    render(<GamerCard profile={profileFixture} />);
+
+    expect(screen.getByTestId('profile-featured-title')).toHaveTextContent('Founder');
+    expect(screen.getByTestId('profile-special-badges')).toHaveTextContent('Ranked Grinder');
+    expect(screen.getByTestId('profile-special-badges')).toHaveTextContent('Community Host');
+    expect(screen.getByTestId('profile-social-progress')).toHaveTextContent(
+      /progresso social visivel/i,
+    );
+    expect(screen.getByTestId('profile-social-progress')).toHaveTextContent('215');
+    expect(screen.getByTestId('profile-social-progress')).toHaveTextContent('2');
   });
 
   it('overrides static profile presence with realtime store data', () => {
@@ -121,5 +134,22 @@ describe('GamerCard', () => {
     ).toBeInTheDocument();
     expect(within(platformsSection).getByText(/^steam$/i)).toBeInTheDocument();
     expect(within(platformsSection).getByText(/^discord$/i)).toBeInTheDocument();
+  });
+
+  it('omits featured title and special badges when no badge source exists', () => {
+    render(
+      <GamerCard
+        profile={{
+          ...profileFixture,
+          profile: {
+            ...profileFixture.profile,
+            badges: [],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('profile-featured-title')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('profile-special-badges')).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -46,7 +46,7 @@ const profileFixture: ProfileResponse = {
     avatarUrl: null,
     bannerUrl: null,
     accentColor: '#7C3AED',
-    badges: ['Founder'],
+    badges: ['Founder', 'Ranked Grinder'],
   },
   stats: {
     level: 18,
@@ -123,6 +123,10 @@ describe('ProfilePageContent', () => {
     expect(
       screen.getByRole('heading', { name: /clutch player/i }),
     ).toBeInTheDocument();
+    expect(screen.getByTestId('profile-featured-title')).toHaveTextContent('Founder');
+    expect(screen.getByTestId('profile-social-progress')).toHaveTextContent(
+      /progresso social visivel/i,
+    );
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
     const statsSection = screen.getByTestId('profile-stats');
     const libraryPreview = screen.getByTestId('game-library-preview');


### PR DESCRIPTION
## Resumo
Esta PR implementa o primeiro slice visível da #232 no `gamer-card` do perfil público. A entrega usa apenas fontes de verdade já existentes no contrato de perfil: o primeiro badge persistido aparece como rótulo em destaque ao lado do nome, os badges restantes ganham tratamento de insígnias especiais e o card passa a expor progressão social visível com base em nível, reputação, amigos e posts.

## O que foi alterado
- Frontend
- Atualizado `frontend/src/components/profile/gamer-card.tsx` para destacar o primeiro badge persistido como rótulo/título visível ao lado do nome.
- Separados os badges restantes em uma área de badges especiais, com fallback honesto quando não houver fonte de verdade.
- Adicionado um bloco de progresso social visível usando apenas `level`, `reputation`, `friendCount` e `postCount` já presentes no payload de `GET /profiles/:username`.
- Atualizados os testes de `GamerCard` e `ProfilePageContent` para cobrir título em destaque, badges especiais, progresso visível e ausência de badges.

## Motivação
A trilha social já consolidou na #222 que a camada visível de identidade e progresso precisa nascer pequena e honesta. O contrato atual já sustenta badges persistidos e stats reais no perfil, mas ainda não sustenta títulos dinâmicos, streaks ou ofensivas vindas da futura #233. Esta PR materializa um primeiro recorte útil sem prometer um sistema social completo.

## Como validar
- `cd frontend`
- `npm ci`
- `npm run test -- tests/unit/components/gamer-card.test.tsx tests/unit/components/profile-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Smoke manual da superfície alterada não pôde ser concluído nesta rodada porque `http://localhost` e o daemon Docker não estavam disponíveis no ambiente.

## Riscos e impactos
- Impacto restrito ao frontend do perfil público.
- Não há alteração de contrato no backend.
- O rótulo em destaque reutiliza o primeiro item de `profile.badges`; se a ordem persistida não refletir prioridade semântica, o badge destacado pode não ser o ideal até existir um contrato dedicado para título social.
- Friends list e shell permanecem sem badges/títulos porque seus contratos atuais não carregam esses dados.
- Streaks, ofensivas e progressão ligada à continuidade com amigos continuam fora desta PR e permanecem dependentes da #233.

## Evidências
- Testes afetados executados com sucesso:
  - `tests/unit/components/gamer-card.test.tsx`
  - `tests/unit/components/profile-page-content.test.tsx`
- `npm run typecheck`, `npm run lint` e `npm run build` executados com sucesso.
- Não há smoke visual autenticado anexado nesta PR por indisponibilidade do ambiente local durante a validação.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #232