### PR TITLE
feat(social): expor slice mínimo de continuidade com amigos no perfil

### DIFF
--- a/backend/src/api/routes/profile.routes.ts
+++ b/backend/src/api/routes/profile.routes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { profileRepository } from '../../core/repositories/profile.repository';
+import { socialContinuityService } from '../../core/services/social-continuity.service';
 import { userRepository } from '../../core/repositories/user.repository';
 
 // ─────────────────────────────────────────────────────────────
@@ -28,7 +29,13 @@ export async function profileRoutes(app: FastifyInstance): Promise<void> {
     async (request, reply) => {
       const profile = await profileRepository.findFullProfileByUsername(request.params.username);
       if (!profile) return reply.status(404).send({ message: 'Perfil não encontrado.' });
-      return reply.status(200).send(profile);
+
+      const socialContinuity = await socialContinuityService.summarizeUser(profile.id);
+
+      return reply.status(200).send({
+        ...profile,
+        socialContinuity,
+      });
     },
   );
 

--- a/backend/src/core/repositories/profile.repository.ts
+++ b/backend/src/core/repositories/profile.repository.ts
@@ -13,6 +13,45 @@ export interface UpdateProfileInput {
   accentColor?: string;
 }
 
+export interface FullProfileRecord {
+  id: string;
+  username: string;
+  createdAt: Date;
+  profile: {
+    displayName: string | null;
+    bio: string | null;
+    avatarUrl: string | null;
+    bannerUrl: string | null;
+    accentColor: string | null;
+    badges: string[];
+  };
+  stats: {
+    level: number;
+    xp: number;
+    reputation: number;
+    friendCount: number;
+    postCount: number;
+  };
+  presence: {
+    status: string;
+    currentGame: string | null;
+    gameDetails: Record<string, unknown> | null;
+    platform: string | null;
+    updatedAt: Date;
+  };
+  platformIntegrations: Array<{
+    platform: string;
+    metadata: Record<string, unknown> | null;
+  }>;
+  gameLibrary: Array<{
+    gameName: string;
+    coverUrl: string | null;
+    platform: string;
+    hoursPlayed: number | null;
+    lastPlayedAt: Date | null;
+  }>;
+}
+
 export const profileRepository = {
   async findByUsername(username: string): Promise<Profile | null> {
     const user = await prisma.user.findUnique({
@@ -34,7 +73,7 @@ export const profileRepository = {
     return user?.profile ?? null;
   },
 
-  async findFullProfileByUsername(username: string): Promise<object | null> {
+  async findFullProfileByUsername(username: string): Promise<FullProfileRecord | null> {
     return prisma.user.findUnique({
       where: { username },
       select: {
@@ -84,7 +123,7 @@ export const profileRepository = {
           },
         },
       },
-    });
+    }) as Promise<FullProfileRecord | null>;
   },
 
   async updateByUserId(userId: string, input: UpdateProfileInput): Promise<Profile> {

--- a/backend/src/core/services/social-continuity.service.ts
+++ b/backend/src/core/services/social-continuity.service.ts
@@ -1,0 +1,187 @@
+import { prisma } from '../../infra/database/client';
+import { friendRepository } from '../repositories/friend.repository';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type QualifyingActivityRecord = {
+  userId: string;
+  createdAt: Date;
+};
+
+export interface StrongestFriendOffensive {
+  friendId: string;
+  friendUsername: string;
+  days: number;
+  lastQualifiedAt: string;
+}
+
+export interface SocialContinuitySummary {
+  currentStreakDays: number;
+  activeFriendOffensiveCount: number;
+  strongestFriendOffensive: StrongestFriendOffensive | null;
+}
+
+function toUtcDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function currentUtcDayKey(): string {
+  return toUtcDayKey(new Date());
+}
+
+function utcDayKeyToEpochDay(dayKey: string): number {
+  const parts = dayKey.split('-');
+  if (parts.length !== 3) {
+    return 0;
+  }
+
+  const [yearText, monthText, dayText] = parts as [string, string, string];
+  const year = Number.parseInt(yearText, 10);
+  const month = Number.parseInt(monthText, 10);
+  const day = Number.parseInt(dayText, 10);
+
+  return Math.floor(Date.UTC(year, month - 1, day) / MS_PER_DAY);
+}
+
+function daysBetweenUtcDayKeys(laterDayKey: string, earlierDayKey: string): number {
+  return utcDayKeyToEpochDay(laterDayKey) - utcDayKeyToEpochDay(earlierDayKey);
+}
+
+function buildQualifyingDayMap(
+  userIds: string[],
+  activities: QualifyingActivityRecord[],
+): Map<string, string[]> {
+  const daySets = new Map<string, Set<string>>();
+
+  for (const userId of userIds) {
+    daySets.set(userId, new Set<string>());
+  }
+
+  for (const activity of activities) {
+    const userDays = daySets.get(activity.userId);
+    if (!userDays) {
+      continue;
+    }
+
+    userDays.add(toUtcDayKey(activity.createdAt));
+  }
+
+  return new Map(
+    userIds.map((userId) => {
+      const days = Array.from(daySets.get(userId) ?? []);
+      days.sort((left, right) => daysBetweenUtcDayKeys(right, left));
+      return [userId, days];
+    }),
+  );
+}
+
+function calculateActiveStreakDays(
+  dayKeys: string[],
+  referenceDayKey = currentUtcDayKey(),
+): number {
+  if (dayKeys.length === 0) {
+    return 0;
+  }
+
+  const latestDayKey = dayKeys[0]!;
+  if (daysBetweenUtcDayKeys(referenceDayKey, latestDayKey) > 1) {
+    return 0;
+  }
+
+  let streakDays = 1;
+
+  for (let index = 1; index < dayKeys.length; index += 1) {
+    const previousDayKey = dayKeys[index - 1]!;
+    const currentDayKey = dayKeys[index]!;
+
+    if (daysBetweenUtcDayKeys(previousDayKey, currentDayKey) !== 1) {
+      break;
+    }
+
+    streakDays += 1;
+  }
+
+  return streakDays;
+}
+
+function calculateSharedOffensive(
+  userDayKeys: string[],
+  friendDayKeys: string[],
+  referenceDayKey = currentUtcDayKey(),
+): { days: number; lastQualifiedAt: string | null } {
+  if (userDayKeys.length === 0 || friendDayKeys.length === 0) {
+    return { days: 0, lastQualifiedAt: null };
+  }
+
+  const friendDays = new Set(friendDayKeys);
+  const sharedDayKeys = userDayKeys.filter((dayKey) => friendDays.has(dayKey));
+
+  if (sharedDayKeys.length === 0) {
+    return { days: 0, lastQualifiedAt: null };
+  }
+
+  const days = calculateActiveStreakDays(sharedDayKeys, referenceDayKey);
+  const lastQualifiedAt =
+    days > 0 ? new Date(`${sharedDayKeys[0]!}T00:00:00.000Z`).toISOString() : null;
+
+  return { days, lastQualifiedAt };
+}
+
+export const socialContinuityService = {
+  async summarizeUser(userId: string): Promise<SocialContinuitySummary> {
+    const friends = await friendRepository.findFriendsByUserId(userId);
+    const friendIds = friends.map((friend) => friend.id);
+    const trackedUserIds = [userId, ...friendIds];
+
+    const [posts, comments] = await Promise.all([
+      prisma.post.findMany({
+        where: { userId: { in: trackedUserIds } },
+        select: { userId: true, createdAt: true },
+      }),
+      prisma.comment.findMany({
+        where: { userId: { in: trackedUserIds } },
+        select: { userId: true, createdAt: true },
+      }),
+    ]);
+
+    const qualifyingDayMap = buildQualifyingDayMap(trackedUserIds, [...posts, ...comments]);
+    const userDayKeys = qualifyingDayMap.get(userId) ?? [];
+    const currentStreakDays = calculateActiveStreakDays(userDayKeys);
+
+    let activeFriendOffensiveCount = 0;
+    let strongestFriendOffensive: StrongestFriendOffensive | null = null;
+
+    for (const friend of friends) {
+      const friendDayKeys = qualifyingDayMap.get(friend.id) ?? [];
+      const offensive = calculateSharedOffensive(userDayKeys, friendDayKeys);
+
+      if (offensive.days === 0 || !offensive.lastQualifiedAt) {
+        continue;
+      }
+
+      activeFriendOffensiveCount += 1;
+
+      if (
+        !strongestFriendOffensive ||
+        offensive.days > strongestFriendOffensive.days ||
+        (
+          offensive.days === strongestFriendOffensive.days &&
+          offensive.lastQualifiedAt > strongestFriendOffensive.lastQualifiedAt
+        )
+      ) {
+        strongestFriendOffensive = {
+          friendId: friend.id,
+          friendUsername: friend.username,
+          days: offensive.days,
+          lastQualifiedAt: offensive.lastQualifiedAt,
+        };
+      }
+    }
+
+    return {
+      currentStreakDays,
+      activeFriendOffensiveCount,
+      strongestFriendOffensive,
+    };
+  },
+};

--- a/backend/tests/integration/routes/profile.routes.test.ts
+++ b/backend/tests/integration/routes/profile.routes.test.ts
@@ -8,6 +8,12 @@ vi.mock('@/core/repositories/profile.repository', () => ({
   },
 }));
 
+vi.mock('@/core/services/social-continuity.service', () => ({
+  socialContinuityService: {
+    summarizeUser: vi.fn(),
+  },
+}));
+
 vi.mock('@/core/repositories/user.repository', () => ({
   userRepository: {
     findById: vi.fn(), findByEmail: vi.fn(), findByUsername: vi.fn(),
@@ -16,6 +22,7 @@ vi.mock('@/core/repositories/user.repository', () => ({
 }));
 
 import { profileRepository } from '@/core/repositories/profile.repository';
+import { socialContinuityService } from '@/core/services/social-continuity.service';
 import { userRepository }    from '@/core/repositories/user.repository';
 
 const mockUser = {
@@ -31,6 +38,17 @@ const mockFullProfile = {
   platformIntegrations: [], gameLibrary: [],
 };
 
+const mockSocialContinuity = {
+  currentStreakDays: 3,
+  activeFriendOffensiveCount: 1,
+  strongestFriendOffensive: {
+    friendId: 'friend-1',
+    friendUsername: 'duoqueue',
+    days: 2,
+    lastQualifiedAt: '2026-04-22T00:00:00.000Z',
+  },
+};
+
 const mockUpdatedProfile = {
   id: 'profile-id-1', userId: 'user-id-1', displayName: 'Novo Nome',
   bio: 'Nova bio', avatarUrl: null, bannerUrl: null, accentColor: null,
@@ -39,7 +57,10 @@ const mockUpdatedProfile = {
 
 describe('Profile Routes', () => {
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(socialContinuityService.summarizeUser).mockResolvedValue(mockSocialContinuity);
+  });
 
   describe('GET /profiles/:username', () => {
     it('retorna 200 com perfil completo', async () => {
@@ -49,7 +70,18 @@ describe('Profile Routes', () => {
       const response = await app.inject({ method: 'GET', url: '/profiles/clutchplayer' });
 
       expect(response.statusCode).toBe(200);
-      expect(response.json()).toMatchObject({ username: 'clutchplayer' });
+      expect(response.json()).toMatchObject({
+        username: 'clutchplayer',
+        socialContinuity: {
+          currentStreakDays: 3,
+          activeFriendOffensiveCount: 1,
+          strongestFriendOffensive: {
+            friendId: 'friend-1',
+            friendUsername: 'duoqueue',
+            days: 2,
+          },
+        },
+      });
       await app.close();
     });
 

--- a/backend/tests/unit/services/social-continuity.service.test.ts
+++ b/backend/tests/unit/services/social-continuity.service.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { socialContinuityService } from '@/core/services/social-continuity.service';
+
+vi.mock('@/core/repositories/friend.repository', () => ({
+  friendRepository: {
+    findFriendsByUserId: vi.fn(),
+  },
+}));
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    post: {
+      findMany: vi.fn(),
+    },
+    comment: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { friendRepository } from '@/core/repositories/friend.repository';
+import { prisma } from '@/infra/database/client';
+
+describe('socialContinuityService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-22T12:00:00.000Z'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('deriva streak atual e ofensiva ativa a partir de posts e comentarios reais', async () => {
+    vi.mocked(friendRepository.findFriendsByUserId).mockResolvedValue([
+      {
+        id: 'friend-1',
+        username: 'duoqueue',
+        profile: null,
+        presence: null,
+      },
+      {
+        id: 'friend-2',
+        username: 'latejoin',
+        profile: null,
+        presence: null,
+      },
+    ]);
+
+    vi.mocked(prisma.post.findMany).mockResolvedValue([
+      { userId: 'user-1', createdAt: new Date('2026-04-22T10:00:00.000Z') },
+      { userId: 'user-1', createdAt: new Date('2026-04-21T10:00:00.000Z') },
+      { userId: 'friend-1', createdAt: new Date('2026-04-22T09:00:00.000Z') },
+      { userId: 'friend-1', createdAt: new Date('2026-04-21T09:00:00.000Z') },
+      { userId: 'friend-2', createdAt: new Date('2026-04-20T09:00:00.000Z') },
+    ] as never);
+    vi.mocked(prisma.comment.findMany).mockResolvedValue([
+      { userId: 'user-1', createdAt: new Date('2026-04-20T11:00:00.000Z') },
+      { userId: 'friend-2', createdAt: new Date('2026-04-21T11:00:00.000Z') },
+    ] as never);
+
+    const summary = await socialContinuityService.summarizeUser('user-1');
+
+    expect(summary).toEqual({
+      currentStreakDays: 3,
+      activeFriendOffensiveCount: 2,
+      strongestFriendOffensive: {
+        friendId: 'friend-1',
+        friendUsername: 'duoqueue',
+        days: 2,
+        lastQualifiedAt: '2026-04-22T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('zera o resumo quando a atividade mais recente ficou mais antiga que ontem em UTC', async () => {
+    vi.mocked(friendRepository.findFriendsByUserId).mockResolvedValue([
+      {
+        id: 'friend-1',
+        username: 'duoqueue',
+        profile: null,
+        presence: null,
+      },
+    ]);
+
+    vi.mocked(prisma.post.findMany).mockResolvedValue([
+      { userId: 'user-1', createdAt: new Date('2026-04-19T10:00:00.000Z') },
+      { userId: 'friend-1', createdAt: new Date('2026-04-19T09:00:00.000Z') },
+    ] as never);
+    vi.mocked(prisma.comment.findMany).mockResolvedValue([] as never);
+
+    const summary = await socialContinuityService.summarizeUser('user-1');
+
+    expect(summary).toEqual({
+      currentStreakDays: 0,
+      activeFriendOffensiveCount: 0,
+      strongestFriendOffensive: null,
+    });
+  });
+});

--- a/frontend/src/components/profile/gamer-card.tsx
+++ b/frontend/src/components/profile/gamer-card.tsx
@@ -36,6 +36,14 @@ function formatMemberSince(createdAt: string): string {
   return `No CLUTCH desde ${formattedMonthYear}`;
 }
 
+function formatDayCount(days: number): string {
+  if (days <= 0) {
+    return 'Sem atividade';
+  }
+
+  return days === 1 ? '1 dia' : `${days.toLocaleString('pt-BR')} dias`;
+}
+
 export function GamerCard({ profile, actions }: GamerCardProps) {
   const displayName = profile.profile.displayName || profile.username;
   const badgeList = normalizeBadges(profile.profile.badges);
@@ -53,6 +61,7 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
     currentGame: realtimePresence?.currentGame ?? profile.presence.currentGame,
     platform: realtimePresence?.platform ?? profile.presence.platform,
   };
+  const strongestFriendOffensive = profile.socialContinuity.strongestFriendOffensive;
 
   return (
     <Card className="overflow-hidden p-0">
@@ -174,8 +183,9 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
                 Progresso social visivel
               </p>
               <p className="text-sm leading-6 text-secondary">
-                Este primeiro slice usa apenas stats reais do perfil. Continuidade
-                com amigos, streaks e ofensivas ficam para a etapa funcional posterior.
+                Este slice combina stats reais do perfil com atividade publica ja
+                observavel para resumir continuidade social sem prometer um sistema
+                completo de recompensas.
               </p>
             </div>
 
@@ -204,6 +214,51 @@ export function GamerCard({ profile, actions }: GamerCardProps) {
                 </p>
                 <p className="mt-2 font-display text-xl font-semibold text-primary">
                   {profile.stats.postCount.toLocaleString('pt-BR')}
+                </p>
+              </div>
+            </div>
+
+            <div
+              data-testid="profile-social-continuity"
+              className="grid gap-3 rounded-control border border-border bg-background-secondary/40 p-3 sm:grid-cols-3"
+            >
+              <div className="rounded-control border border-border bg-background-secondary/70 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                  Streak atual
+                </p>
+                <p className="mt-2 font-display text-xl font-semibold text-primary">
+                  {formatDayCount(profile.socialContinuity.currentStreakDays)}
+                </p>
+                <p className="mt-1 text-xs text-secondary">
+                  Dias seguidos com post ou comentario publico.
+                </p>
+              </div>
+
+              <div className="rounded-control border border-border bg-background-secondary/70 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                  Ofensivas ativas
+                </p>
+                <p className="mt-2 font-display text-xl font-semibold text-primary">
+                  {profile.socialContinuity.activeFriendOffensiveCount.toLocaleString('pt-BR')}
+                </p>
+                <p className="mt-1 text-xs text-secondary">
+                  Amigos com continuidade compartilhada na janela diaria atual.
+                </p>
+              </div>
+
+              <div className="rounded-control border border-border bg-background-secondary/70 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.3em] text-secondary">
+                  Maior ofensiva
+                </p>
+                <p className="mt-2 font-display text-xl font-semibold text-primary">
+                  {strongestFriendOffensive
+                    ? formatDayCount(strongestFriendOffensive.days)
+                    : 'Sem ofensiva'}
+                </p>
+                <p className="mt-1 text-xs text-secondary">
+                  {strongestFriendOffensive
+                    ? `Com @${strongestFriendOffensive.friendUsername}`
+                    : 'Ainda sem sobreposicao ativa com amigos.'}
                 </p>
               </div>
             </div>

--- a/frontend/src/schemas/profile.ts
+++ b/frontend/src/schemas/profile.ts
@@ -18,6 +18,19 @@ export const profileIntegrationPlatformSchema = z.enum([
   'MYANIMELIST',
 ]);
 
+export const strongestFriendOffensiveSchema = z.object({
+  friendId: z.string().min(1),
+  friendUsername: z.string().min(1),
+  days: z.number().int().min(0),
+  lastQualifiedAt: z.string().min(1),
+});
+
+export const socialContinuitySchema = z.object({
+  currentStreakDays: z.number().int().min(0),
+  activeFriendOffensiveCount: z.number().int().min(0),
+  strongestFriendOffensive: strongestFriendOffensiveSchema.nullable(),
+});
+
 export const profileResponseSchema = z.object({
   id: z.string().min(1),
   username: z.string().min(1),
@@ -59,6 +72,7 @@ export const profileResponseSchema = z.object({
       lastPlayedAt: z.string().nullable(),
     }),
   ),
+  socialContinuity: socialContinuitySchema,
 });
 
 export const profileUpdateRequestSchema = z.object({

--- a/frontend/tests/unit/components/app-shell-route-warmup.test.tsx
+++ b/frontend/tests/unit/components/app-shell-route-warmup.test.tsx
@@ -103,6 +103,11 @@ describe('AppShellRouteWarmup', () => {
       },
       platformIntegrations: [],
       gameLibrary: [],
+      socialContinuity: {
+        currentStreakDays: 0,
+        activeFriendOffensiveCount: 0,
+        strongestFriendOffensive: null,
+      },
     });
   });
 

--- a/frontend/tests/unit/components/friend-button.test.tsx
+++ b/frontend/tests/unit/components/friend-button.test.tsx
@@ -79,6 +79,11 @@ function createProfileFixture({
     },
     platformIntegrations: [],
     gameLibrary: [],
+    socialContinuity: {
+      currentStreakDays: 0,
+      activeFriendOffensiveCount: 0,
+      strongestFriendOffensive: null,
+    },
   };
 }
 

--- a/frontend/tests/unit/components/friend-request-card.test.tsx
+++ b/frontend/tests/unit/components/friend-request-card.test.tsx
@@ -71,6 +71,11 @@ function createProfileFixture({
     },
     platformIntegrations: [],
     gameLibrary: [],
+    socialContinuity: {
+      currentStreakDays: 0,
+      activeFriendOffensiveCount: 0,
+      strongestFriendOffensive: null,
+    },
   };
 }
 

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -33,6 +33,16 @@ const profileFixture: ProfileResponse = {
   },
   platformIntegrations: [],
   gameLibrary: [],
+  socialContinuity: {
+    currentStreakDays: 4,
+    activeFriendOffensiveCount: 1,
+    strongestFriendOffensive: {
+      friendId: 'friend-1',
+      friendUsername: 'duoqueue',
+      days: 3,
+      lastQualifiedAt: '2026-03-29T00:00:00.000Z',
+    },
+  },
 };
 
 describe('GamerCard', () => {
@@ -51,6 +61,10 @@ describe('GamerCard', () => {
     );
     expect(screen.getByTestId('profile-social-progress')).toHaveTextContent('215');
     expect(screen.getByTestId('profile-social-progress')).toHaveTextContent('2');
+    expect(screen.getByTestId('profile-social-continuity')).toHaveTextContent(/4 dias/i);
+    expect(screen.getByTestId('profile-social-continuity')).toHaveTextContent(
+      /com @duoqueue/i,
+    );
   });
 
   it('overrides static profile presence with realtime store data', () => {
@@ -151,5 +165,30 @@ describe('GamerCard', () => {
 
     expect(screen.queryByTestId('profile-featured-title')).not.toBeInTheDocument();
     expect(screen.queryByTestId('profile-special-badges')).not.toBeInTheDocument();
+  });
+
+  it('renders honest fallbacks when no active friend offensive exists', () => {
+    render(
+      <GamerCard
+        profile={{
+          ...profileFixture,
+          socialContinuity: {
+            currentStreakDays: 0,
+            activeFriendOffensiveCount: 0,
+            strongestFriendOffensive: null,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('profile-social-continuity')).toHaveTextContent(
+      /sem atividade/i,
+    );
+    expect(screen.getByTestId('profile-social-continuity')).toHaveTextContent(
+      /sem ofensiva/i,
+    );
+    expect(screen.getByTestId('profile-social-continuity')).toHaveTextContent(
+      /ainda sem sobreposicao ativa com amigos/i,
+    );
   });
 });

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -105,6 +105,11 @@ describe('IntegrationsPageContent', () => {
           lastPlayedAt: '2026-03-29T22:15:00.000Z',
         },
       ],
+      socialContinuity: {
+        currentStreakDays: 0,
+        activeFriendOffensiveCount: 0,
+        strongestFriendOffensive: null,
+      },
     });
 
     renderWithQuery(<IntegrationsPageContent />);

--- a/frontend/tests/unit/components/library-page-content.test.tsx
+++ b/frontend/tests/unit/components/library-page-content.test.tsx
@@ -84,6 +84,11 @@ const profileFixture: ProfileResponse = {
       lastPlayedAt: '2026-03-27T10:00:00.000Z',
     },
   ],
+  socialContinuity: {
+    currentStreakDays: 0,
+    activeFriendOffensiveCount: 0,
+    strongestFriendOffensive: null,
+  },
 };
 
 function renderWithQuery(ui: ReactElement) {

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -77,6 +77,16 @@ const profileFixture: ProfileResponse = {
       lastPlayedAt: '2026-03-29T22:15:00.000Z',
     },
   ],
+  socialContinuity: {
+    currentStreakDays: 4,
+    activeFriendOffensiveCount: 1,
+    strongestFriendOffensive: {
+      friendId: 'friend-2',
+      friendUsername: 'duoqueue',
+      days: 3,
+      lastQualifiedAt: '2026-03-29T00:00:00.000Z',
+    },
+  },
 };
 
 function renderWithQuery(ui: ReactElement) {
@@ -126,6 +136,10 @@ describe('ProfilePageContent', () => {
     expect(screen.getByTestId('profile-featured-title')).toHaveTextContent('Founder');
     expect(screen.getByTestId('profile-social-progress')).toHaveTextContent(
       /progresso social visivel/i,
+    );
+    expect(screen.getByTestId('profile-social-continuity')).toHaveTextContent(/4 dias/i);
+    expect(screen.getByTestId('profile-social-continuity')).toHaveTextContent(
+      /com @duoqueue/i,
     );
     expect(screen.getByText(/jogando valorant/i)).toBeInTheDocument();
     const statsSection = screen.getByTestId('profile-stats');

--- a/frontend/tests/unit/components/profile-settings-form.test.tsx
+++ b/frontend/tests/unit/components/profile-settings-form.test.tsx
@@ -104,6 +104,11 @@ describe('ProfileSettingsForm', () => {
       },
       platformIntegrations: [],
       gameLibrary: [],
+      socialContinuity: {
+        currentStreakDays: 0,
+        activeFriendOffensiveCount: 0,
+        strongestFriendOffensive: null,
+      },
     });
     vi.stubGlobal('navigator', {
       clipboard: {

--- a/frontend/tests/unit/services/profile.test.ts
+++ b/frontend/tests/unit/services/profile.test.ts
@@ -48,6 +48,11 @@ describe('profile service', () => {
           },
           platformIntegrations: [],
           gameLibrary: [],
+          socialContinuity: {
+            currentStreakDays: 0,
+            activeFriendOffensiveCount: 0,
+            strongestFriendOffensive: null,
+          },
         }),
         {
           status: 200,


### PR DESCRIPTION
## Resumo
Esta PR entrega o primeiro vertical slice funcional da continuidade social com amigos definido na #222. O backend passa a derivar um resumo pequeno e honesto de streak e ofensivas ativas a partir de posts e comentários reais, e o frontend materializa esse resumo no perfil público sem abrir reward engine, ranking ou Arena.

## O que foi alterado
- Backend
- Adicionado `socialContinuityService` para derivar `currentStreakDays`, `activeFriendOffensiveCount` e `strongestFriendOffensive` a partir de posts e comentários em janelas diárias UTC.
- Estendido `GET /profiles/:username` para retornar `socialContinuity` junto do payload existente do profile.
- Tipado o retorno completo do repositório de profile para acomodar a extensão de contrato com segurança.
- Adicionados testes unitários da derivação e cobertura de rota para o novo resumo.
- Frontend
- Estendido o schema de `ProfileResponse` com `socialContinuity`.
- Atualizado o `GamerCard` do perfil para exibir streak atual, ofensivas ativas e maior ofensiva com fallback honesto.
- Ajustados fixtures e testes de componentes afetados pelo novo contrato de profile.

## Motivação
A modelagem da #222 já definia o menor slice funcional recomendável para continuidade social com amigos. Faltava transformar essa definição em uma fonte de verdade backend-side e em uma superfície visível pequena no perfil, sem prometer um sistema social completo antes da hora.

## Como validar
- Backend
- `cd backend`
- `npm ci`
- `npm run test -- tests/unit/services/social-continuity.service.test.ts tests/integration/routes/profile.routes.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Frontend
- `cd frontend`
- `npm ci`
- `npm run test -- tests/unit/components/gamer-card.test.tsx tests/unit/components/profile-page-content.test.tsx tests/unit/components/library-page-content.test.tsx tests/unit/components/app-shell-route-warmup.test.tsx tests/unit/components/friend-button.test.tsx tests/unit/components/friend-request-card.test.tsx tests/unit/components/integrations-page-content.test.tsx tests/unit/components/profile-settings-form.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Smoke manual
- Tentar `GET /api/profiles/:username` e `/[username]` com um usuário que tenha posts, comentários e amizades suficientes.
- Nesta rodada o smoke manual visual ficou bloqueado porque `localhost` não estava respondendo e o daemon Docker não estava disponível no ambiente.

## Riscos e impactos
- O resumo é derivado em tempo de leitura do profile. Para o estágio atual do produto isso mantém o slice pequeno, mas pode exigir materialização futura se o volume crescer.
- A regra usa janelas diárias em UTC e considera streak/ofensiva ainda ativa quando o último dia qualificado é hoje ou ontem em UTC. Essa escolha está documentada, mas merece revisão se o produto passar a exigir semântica local por fuso.
- O lint do backend continua emitindo warnings preexistentes em `src/config/rate-limit.ts`, sem relação com esta PR.
- Não há reward engine, títulos dinâmicos, ranking, shell ou friends list nesta entrega.

## Evidências
- Testes backend executados com sucesso para derivação e rota de profile.
- Testes frontend executados com sucesso para perfil e fixtures afetados pelo novo contrato.
- Não há evidências visuais anexadas nesta PR porque o smoke manual do ambiente local ficou indisponível.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Refs #222
Closes #233