### PR TITLE
feat(sharing): adicionar metadata pública e CTA de share no perfil

### DIFF
--- a/frontend/src/app/(app)/[username]/page.tsx
+++ b/frontend/src/app/(app)/[username]/page.tsx
@@ -1,10 +1,24 @@
+import type { Metadata } from 'next';
 import { ProfilePageContent } from '@/components/profile/profile-page-content';
+import {
+  buildPublicProfileMetadata,
+  fetchPublicProfileForShare,
+} from '@/lib/profile/public-profile-share';
 
 type ProfilePageProps = {
   params: Promise<{
     username: string;
   }>;
 };
+
+export async function generateMetadata({
+  params,
+}: ProfilePageProps): Promise<Metadata> {
+  const { username } = await params;
+  const profile = await fetchPublicProfileForShare(username);
+
+  return buildPublicProfileMetadata(username, profile);
+}
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
   const { username } = await params;

--- a/frontend/src/components/profile/profile-page-content.tsx
+++ b/frontend/src/components/profile/profile-page-content.tsx
@@ -6,6 +6,7 @@ import { FriendsList } from '@/components/friends/friends-list';
 import { Card } from '@/components/ui/card';
 import { GamerCard } from '@/components/profile/gamer-card';
 import { GameLibraryPreview } from '@/components/profile/game-library-preview';
+import { ProfileShareButton } from '@/components/profile/profile-share-button';
 import { ProfileSkeleton } from '@/components/profile/profile-skeleton';
 import { ProfileStats } from '@/components/profile/profile-stats';
 import {
@@ -78,7 +79,12 @@ export function ProfilePageContent({ username }: ProfilePageContentProps) {
     <div className="space-y-section" data-testid="profile-success">
       <GamerCard
         profile={profileQuery.data}
-        actions={<FriendButton targetUserId={profileQuery.data.id} />}
+        actions={
+          <>
+            <ProfileShareButton username={profileQuery.data.username} />
+            <FriendButton targetUserId={profileQuery.data.id} />
+          </>
+        }
       />
       <div className="grid gap-6 xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]">
         <ProfileStats stats={profileQuery.data.stats} />

--- a/frontend/src/components/profile/profile-share-button.tsx
+++ b/frontend/src/components/profile/profile-share-button.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toaster';
+import { buildPublicProfileCanonicalUrl } from '@/lib/profile/public-profile-share';
+
+type ProfileShareButtonProps = {
+  username: string;
+};
+
+export function ProfileShareButton({ username }: ProfileShareButtonProps) {
+  const { showToast } = useToast();
+  const [isCopying, setIsCopying] = useState(false);
+
+  const handleCopyProfileLink = async () => {
+    if (!navigator.clipboard?.writeText) {
+      showToast({
+        title: 'Nao foi possivel copiar o link',
+        description: 'Seu navegador nao liberou acesso ao clipboard nesta superficie.',
+        tone: 'error',
+      });
+      return;
+    }
+
+    setIsCopying(true);
+
+    try {
+      const profileUrl = buildPublicProfileCanonicalUrl(username);
+      await navigator.clipboard.writeText(profileUrl);
+
+      showToast({
+        title: 'Link do perfil copiado',
+        description: 'O link publico do perfil foi enviado para o clipboard.',
+        tone: 'success',
+      });
+    } catch {
+      showToast({
+        title: 'Nao foi possivel copiar o link',
+        description: 'Tente novamente em alguns instantes.',
+        tone: 'error',
+      });
+    } finally {
+      setIsCopying(false);
+    }
+  };
+
+  return (
+    <Button
+      data-testid="profile-share-button"
+      variant="secondary"
+      size="sm"
+      onClick={() => {
+        void handleCopyProfileLink();
+      }}
+      aria-label={`Copiar link publico do perfil de @${username}`}
+      disabled={isCopying}
+    >
+      {isCopying ? 'Copiando link...' : 'Copiar link'}
+    </Button>
+  );
+}

--- a/frontend/src/lib/profile/public-profile-share.ts
+++ b/frontend/src/lib/profile/public-profile-share.ts
@@ -1,0 +1,178 @@
+import type { Metadata } from 'next';
+import { profileResponseSchema, type ProfileResponse } from '@/schemas/profile';
+import { buildApiUrl, buildPublicAppUrl } from '@/services/http/client';
+
+const PROFILE_SHARE_DESCRIPTION_MAX_LENGTH = 160;
+
+function normalizeText(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function formatCount(
+  count: number,
+  singularLabel: string,
+  pluralLabel: string,
+): string {
+  return `${count.toLocaleString('pt-BR')} ${count === 1 ? singularLabel : pluralLabel}`;
+}
+
+function normalizeImageUrl(imageUrl: string | null | undefined): string | null {
+  const normalized = normalizeText(imageUrl);
+
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    return new URL(normalized, buildPublicAppUrl('/')).toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchPublicProfileForShare(
+  username: string,
+): Promise<ProfileResponse | null> {
+  try {
+    const response = await fetch(
+      buildApiUrl(`/profiles/${encodeURIComponent(username)}`),
+      {
+        cache: 'no-store',
+      },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = await response.json();
+    const parsedProfile = profileResponseSchema.safeParse(payload);
+
+    return parsedProfile.success ? parsedProfile.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildPublicProfileCanonicalUrl(username: string): string {
+  return buildPublicAppUrl(`/${encodeURIComponent(username)}`);
+}
+
+export function buildPublicProfileTitle(
+  username: string,
+  profile: ProfileResponse | null,
+): string {
+  const displayName = normalizeText(profile?.profile.displayName);
+
+  if (displayName && displayName.toLocaleLowerCase('pt-BR') !== username.toLocaleLowerCase('pt-BR')) {
+    return `${displayName} (@${username}) | CLUTCH`;
+  }
+
+  return `@${username} | CLUTCH`;
+}
+
+export function buildPublicProfileDescription(
+  username: string,
+  profile: ProfileResponse | null,
+): string {
+  const bio = normalizeText(profile?.profile.bio);
+
+  if (bio) {
+    return truncateText(bio, PROFILE_SHARE_DESCRIPTION_MAX_LENGTH);
+  }
+
+  const descriptionParts: string[] = [];
+
+  if (profile?.profile.badges.length) {
+    descriptionParts.push(formatCount(profile.profile.badges.length, 'badge', 'badges'));
+  }
+
+  if (profile?.platformIntegrations.length) {
+    descriptionParts.push(
+      formatCount(
+        profile.platformIntegrations.length,
+        'plataforma conectada',
+        'plataformas conectadas',
+      ),
+    );
+  }
+
+  if (profile?.gameLibrary.length) {
+    descriptionParts.push(
+      formatCount(profile.gameLibrary.length, 'jogo na biblioteca', 'jogos na biblioteca'),
+    );
+  }
+
+  const currentStreakDays = profile?.socialContinuity.currentStreakDays ?? 0;
+
+  if (currentStreakDays > 0) {
+    descriptionParts.push(
+      `streak atual de ${formatCount(
+        currentStreakDays,
+        'dia',
+        'dias',
+      )}`,
+    );
+  }
+
+  const prefix = `Perfil gamer de @${username} no CLUTCH`;
+
+  if (descriptionParts.length === 0) {
+    return prefix;
+  }
+
+  return truncateText(
+    `${prefix} com ${descriptionParts.join(', ')}.`,
+    PROFILE_SHARE_DESCRIPTION_MAX_LENGTH,
+  );
+}
+
+export function buildPublicProfileMetadata(
+  username: string,
+  profile: ProfileResponse | null,
+): Metadata {
+  const title = buildPublicProfileTitle(username, profile);
+  const description = buildPublicProfileDescription(username, profile);
+  const canonicalUrl = buildPublicProfileCanonicalUrl(username);
+  const imageCandidates = [
+    normalizeImageUrl(profile?.profile.bannerUrl),
+    normalizeImageUrl(profile?.profile.avatarUrl),
+  ].filter((value): value is string => value !== null);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonicalUrl,
+      siteName: 'CLUTCH',
+      images:
+        imageCandidates.length > 0
+          ? imageCandidates.map((url) => ({
+              url,
+              alt: title,
+            }))
+          : undefined,
+    },
+    twitter: {
+      card: imageCandidates.length > 0 ? 'summary_large_image' : 'summary',
+      title,
+      description,
+      images: imageCandidates.length > 0 ? imageCandidates : undefined,
+    },
+  };
+}

--- a/frontend/src/services/http/client.ts
+++ b/frontend/src/services/http/client.ts
@@ -17,7 +17,7 @@ function isAbsoluteUrl(value: string): boolean {
   }
 }
 
-function resolvePublicAppOrigin(): string {
+export function resolvePublicAppOrigin(): string {
   const explicitPublicOrigin =
     process.env.PUBLIC_APP_URL?.trim() ||
     process.env.NEXT_PUBLIC_APP_URL?.trim();
@@ -45,6 +45,13 @@ function resolvePublicAppOrigin(): string {
   }
 
   throw new Error('Public app origin is not configured.');
+}
+
+export function buildPublicAppUrl(pathname: string): string {
+  return new URL(
+    normalizePathname(pathname),
+    normalizeBaseUrl(resolvePublicAppOrigin()),
+  ).toString();
 }
 
 export function resolvePublicApiBaseUrl(): string {

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProfilePageContent } from '@/components/profile/profile-page-content';
+import { ToastProvider } from '@/components/ui/toaster';
 import {
   fetchProfileByUsername,
   ProfileRequestError,
@@ -99,7 +100,9 @@ function renderWithQuery(ui: ReactElement) {
   });
 
   return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </ToastProvider>,
   );
 }
 
@@ -148,6 +151,7 @@ describe('ProfilePageContent', () => {
     expect(libraryPreview).toBeInTheDocument();
     expect(within(statsSection).getByText(/^reputacao$/i)).toBeInTheDocument();
     expect(screen.getByTestId('friend-button')).toHaveTextContent('friend-button:user-1');
+    expect(screen.getByTestId('profile-share-button')).toHaveTextContent(/copiar link/i);
     expect(screen.getByTestId('friends-list')).toHaveTextContent('friends-list:user-1');
     expect(screen.getByRole('link', { name: /ver biblioteca completa/i })).toHaveAttribute(
       'href',

--- a/frontend/tests/unit/components/profile-share-button.test.tsx
+++ b/frontend/tests/unit/components/profile-share-button.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProfileShareButton } from '@/components/profile/profile-share-button';
+import { ToastProvider } from '@/components/ui/toaster';
+
+const originalClipboard = globalThis.navigator.clipboard;
+const originalNextPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+const originalPublicAppUrl = process.env.PUBLIC_APP_URL;
+
+function renderWithToastProvider() {
+  return render(
+    <ToastProvider>
+      <ProfileShareButton username="clutchplayer" />
+    </ToastProvider>,
+  );
+}
+
+describe('ProfileShareButton', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://clutch.gg';
+    process.env.PUBLIC_APP_URL = '';
+  });
+
+  it('copies the public profile URL and shows success feedback', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(globalThis.navigator, {
+      clipboard: {
+        writeText,
+      },
+    });
+
+    renderWithToastProvider();
+
+    fireEvent.click(screen.getByTestId('profile-share-button'));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('https://clutch.gg/clutchplayer');
+    });
+
+    expect(screen.getByTestId('toast-item')).toHaveTextContent(/link do perfil copiado/i);
+  });
+
+  it('shows an error when clipboard access is unavailable', async () => {
+    Object.assign(globalThis.navigator, {
+      clipboard: undefined,
+    });
+
+    renderWithToastProvider();
+
+    fireEvent.click(screen.getByTestId('profile-share-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('toast-item')).toHaveTextContent(
+        /nao foi possivel copiar o link/i,
+      );
+    });
+  });
+});
+
+afterAll(() => {
+  process.env.NEXT_PUBLIC_APP_URL = originalNextPublicAppUrl;
+  process.env.PUBLIC_APP_URL = originalPublicAppUrl;
+
+  Object.assign(globalThis.navigator, {
+    clipboard: originalClipboard,
+  });
+});

--- a/frontend/tests/unit/lib/public-profile-share.test.ts
+++ b/frontend/tests/unit/lib/public-profile-share.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProfileResponse } from '@/schemas/profile';
+import {
+  buildPublicProfileCanonicalUrl,
+  buildPublicProfileDescription,
+  buildPublicProfileMetadata,
+  buildPublicProfileTitle,
+} from '@/lib/profile/public-profile-share';
+
+const profileFixture: ProfileResponse = {
+  id: 'user-1',
+  username: 'clutchplayer',
+  createdAt: '2026-03-29T22:15:00.000Z',
+  profile: {
+    displayName: 'CLUTCH Player',
+    bio: 'Bio de teste do perfil publico',
+    avatarUrl: 'https://cdn.clutch.gg/avatar.jpg',
+    bannerUrl: 'https://cdn.clutch.gg/banner.jpg',
+    accentColor: '#7C3AED',
+    badges: ['Founder'],
+  },
+  stats: {
+    level: 18,
+    xp: 4820,
+    reputation: 215,
+    friendCount: 2,
+    postCount: 2,
+  },
+  presence: {
+    status: 'ONLINE',
+    currentGame: null,
+    gameDetails: null,
+    platform: null,
+    updatedAt: '2026-03-29T22:15:00.000Z',
+  },
+  platformIntegrations: [
+    {
+      platform: 'STEAM',
+      metadata: null,
+    },
+  ],
+  gameLibrary: [
+    {
+      gameName: 'Valorant',
+      coverUrl: null,
+      platform: 'PC',
+      hoursPlayed: 120,
+      lastPlayedAt: '2026-03-29T22:15:00.000Z',
+    },
+  ],
+  socialContinuity: {
+    currentStreakDays: 4,
+    activeFriendOffensiveCount: 1,
+    strongestFriendOffensive: {
+      friendId: 'friend-1',
+      friendUsername: 'duoqueue',
+      days: 3,
+      lastQualifiedAt: '2026-03-29T00:00:00.000Z',
+    },
+  },
+};
+
+const originalNextPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+const originalPublicAppUrl = process.env.PUBLIC_APP_URL;
+
+describe('public profile share metadata helpers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'https://clutch.gg';
+    process.env.PUBLIC_APP_URL = '';
+  });
+
+  it('builds title, description and canonical from the real public profile contract', () => {
+    const metadata = buildPublicProfileMetadata('clutchplayer', profileFixture);
+
+    expect(buildPublicProfileTitle('clutchplayer', profileFixture)).toBe(
+      'CLUTCH Player (@clutchplayer) | CLUTCH',
+    );
+    expect(buildPublicProfileDescription('clutchplayer', profileFixture)).toBe(
+      'Bio de teste do perfil publico',
+    );
+    expect(buildPublicProfileCanonicalUrl('clutchplayer')).toBe(
+      'https://clutch.gg/clutchplayer',
+    );
+    expect(metadata.alternates?.canonical).toBe('https://clutch.gg/clutchplayer');
+    expect(metadata.openGraph?.url).toBe('https://clutch.gg/clutchplayer');
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: 'https://cdn.clutch.gg/banner.jpg',
+        alt: 'CLUTCH Player (@clutchplayer) | CLUTCH',
+      },
+      {
+        url: 'https://cdn.clutch.gg/avatar.jpg',
+        alt: 'CLUTCH Player (@clutchplayer) | CLUTCH',
+      },
+    ]);
+  });
+
+  it('falls back to an honest public-profile summary when richer fields are absent', () => {
+    const metadata = buildPublicProfileMetadata('ghostplayer', null);
+
+    expect(buildPublicProfileTitle('ghostplayer', null)).toBe('@ghostplayer | CLUTCH');
+    expect(buildPublicProfileDescription('ghostplayer', null)).toBe(
+      'Perfil gamer de @ghostplayer no CLUTCH',
+    );
+    expect(metadata.alternates?.canonical).toBe('https://clutch.gg/ghostplayer');
+    expect(metadata.openGraph?.images).toBeUndefined();
+    expect(metadata.twitter).toMatchObject({
+      card: 'summary',
+    });
+  });
+});
+
+afterAll(() => {
+  process.env.NEXT_PUBLIC_APP_URL = originalNextPublicAppUrl;
+  process.env.PUBLIC_APP_URL = originalPublicAppUrl;
+});


### PR DESCRIPTION
## Resumo
Implementa o primeiro slice real de sharing outbound no perfil público `/:username`, adicionando metadata específica por rota, URL canônica consistente e um CTA local para copiar o link público do perfil. A mudança reaproveita apenas dados públicos já existentes no contrato de profile e mantém o escopo restrito ao outbound sharing do perfil.

## O que foi alterado
- Frontend
- Adicionada `generateMetadata` na rota pública de perfil para montar `title`, `description`, `alternates.canonical`, `openGraph` e `twitter` com base em dados reais do profile.
- Criado um helper dedicado para resolver origem pública, URL canônica e fallbacks honestos de metadata para `/:username`.
- Adicionado um CTA local de copiar link do perfil no bloco de ações do perfil público, com feedback de sucesso e erro via toast.
- Exportado um helper de URL pública reutilizável para manter a regra de canonical consistente com a configuração atual do app.
- Testes
- Adicionada cobertura unitária para metadata rica e fallback textual sem avatar/banner.
- Adicionada cobertura unitária para o CTA de copiar link e para a presença do CTA no fluxo do perfil público.

## Motivação
As definições das issues `#234`, `#235` e `#236` consolidaram que o primeiro slice de sharing do CLUTCH deveria ser outbound only, centrado no perfil público `/:username`, sem provider externo, tracking ou novas fronteiras de backend. Esta PR materializa esse recorte mínimo com uma unidade compartilhável real e pequena.

## Como validar
- No diretório `frontend`, executar:
- `npm run test -- tests/unit/lib/public-profile-share.test.ts tests/unit/components/profile-share-button.test.tsx tests/unit/components/profile-page-content.test.tsx tests/unit/components/gamer-card.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Smoke controlado de metadata:
- subir o frontend com `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_API_URL` e `INTERNAL_API_URL` apontando para um payload válido de `GET /profiles/:username`
- acessar `/:username`
- verificar `title`, `description`, `canonical` e `og:url` no HTML retornado
- repetir com um perfil sem `bio`, `avatarUrl` e `bannerUrl` para validar o fallback textual sem `og:image`

## Riscos e impactos
- A URL canônica e os links públicos passam a depender da configuração correta de `PUBLIC_APP_URL` ou `NEXT_PUBLIC_APP_URL`; na ausência desses valores, a lógica continua usando os fallbacks já existentes da camada HTTP.
- Esta PR não adiciona imagem Open Graph dinâmica; quando houver `bannerUrl` ou `avatarUrl`, eles são reaproveitados como preview, e quando não houver, a metadata cai para texto puro.
- O CTA de share usa a Clipboard API do navegador. Em superfícies sem permissão de clipboard, o comportamento é fallback para toast de erro.
- Não há alteração de backend, contrato público novo nem tracking de origem.

## Evidências
- Smoke controlado com perfil rico:
- `title`: `CLUTCH Player (@clutchplayer) | CLUTCH`
- `canonical`: `http://127.0.0.1:3035/clutchplayer`
- `description`: bio pública do perfil
- `og:url`: `http://127.0.0.1:3035/clutchplayer`
- `og:image`: `bannerUrl` público do perfil
- Smoke controlado com fallback textual:
- `title`: `@ghostplayer | CLUTCH`
- `canonical`: `http://127.0.0.1:3035/ghostplayer`
- `description`: `Perfil gamer de @ghostplayer no CLUTCH`
- `og:image`: ausente
- A cópia do link foi validada por teste unitário do componente, porque não houve automação de browser disponível nesta sessão para clicar no CTA em ambiente real.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #255