### PR TITLE
feat(sharing): adicionar metadata pública e CTA de share na library

### DIFF
--- a/frontend/src/app/(app)/[username]/library/page.tsx
+++ b/frontend/src/app/(app)/[username]/library/page.tsx
@@ -1,10 +1,24 @@
+import type { Metadata } from 'next';
 import { LibraryPageContent } from '@/components/library/library-page-content';
+import {
+  buildPublicLibraryMetadata,
+  fetchPublicLibraryForShare,
+} from '@/lib/profile/public-library-share';
 
 type LibraryPageProps = {
   params: Promise<{
     username: string;
   }>;
 };
+
+export async function generateMetadata({
+  params,
+}: LibraryPageProps): Promise<Metadata> {
+  const { username } = await params;
+  const profile = await fetchPublicLibraryForShare(username);
+
+  return buildPublicLibraryMetadata(username, profile);
+}
 
 export default async function LibraryPage({ params }: LibraryPageProps) {
   const { username } = await params;

--- a/frontend/src/components/library/library-page-content.tsx
+++ b/frontend/src/components/library/library-page-content.tsx
@@ -4,6 +4,9 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { GameCard, type LibraryGameRecord } from '@/components/library/game-card';
 import {
+  LibraryShareButton,
+} from '@/components/library/library-share-button';
+import {
   LibraryFilters,
   type LibrarySortOption,
 } from '@/components/library/library-filters';
@@ -231,11 +234,14 @@ export function LibraryPageContent({ username }: LibraryPageContentProps) {
         description="Explore a biblioteca carregada pelo profile atual com busca, filtros e ordenação locais, sem alterar os dados importados."
         level="h1"
         actions={
-          hasActiveRefinements ? (
-            <Button variant="secondary" size="sm" onClick={resetRefinements}>
-              Limpar refinamentos
-            </Button>
-          ) : undefined
+          <>
+            <LibraryShareButton username={profileQuery.data.username} />
+            {hasActiveRefinements ? (
+              <Button variant="secondary" size="sm" onClick={resetRefinements}>
+                Limpar refinamentos
+              </Button>
+            ) : null}
+          </>
         }
       />
 

--- a/frontend/src/components/library/library-share-button.tsx
+++ b/frontend/src/components/library/library-share-button.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toaster';
+import { buildPublicLibraryCanonicalUrl } from '@/lib/profile/public-library-share';
+
+type LibraryShareButtonProps = {
+  username: string;
+};
+
+export function LibraryShareButton({ username }: LibraryShareButtonProps) {
+  const { showToast } = useToast();
+  const [isCopying, setIsCopying] = useState(false);
+
+  const handleCopyLibraryLink = async () => {
+    if (!navigator.clipboard?.writeText) {
+      showToast({
+        title: 'Nao foi possivel copiar o link',
+        description: 'Seu navegador nao liberou acesso ao clipboard nesta superficie.',
+        tone: 'error',
+      });
+      return;
+    }
+
+    setIsCopying(true);
+
+    try {
+      const libraryUrl = buildPublicLibraryCanonicalUrl(username);
+      await navigator.clipboard.writeText(libraryUrl);
+
+      showToast({
+        title: 'Link da biblioteca copiado',
+        description: 'O link publico da biblioteca foi enviado para o clipboard.',
+        tone: 'success',
+      });
+    } catch {
+      showToast({
+        title: 'Nao foi possivel copiar o link',
+        description: 'Tente novamente em alguns instantes.',
+        tone: 'error',
+      });
+    } finally {
+      setIsCopying(false);
+    }
+  };
+
+  return (
+    <Button
+      data-testid="library-share-button"
+      variant="secondary"
+      size="sm"
+      onClick={() => {
+        void handleCopyLibraryLink();
+      }}
+      aria-label={`Copiar link publico da biblioteca de @${username}`}
+      disabled={isCopying}
+    >
+      {isCopying ? 'Copiando link...' : 'Copiar link'}
+    </Button>
+  );
+}

--- a/frontend/src/lib/profile/public-library-share.ts
+++ b/frontend/src/lib/profile/public-library-share.ts
@@ -1,0 +1,224 @@
+import type { Metadata } from 'next';
+import type { ProfileResponse } from '@/schemas/profile';
+import { buildPublicAppUrl } from '@/services/http/client';
+import { fetchPublicProfileForShare } from '@/lib/profile/public-profile-share';
+
+const LIBRARY_SHARE_DESCRIPTION_MAX_LENGTH = 160;
+
+function normalizeText(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function formatCount(
+  count: number,
+  singularLabel: string,
+  pluralLabel: string,
+): string {
+  return `${count.toLocaleString('pt-BR')} ${count === 1 ? singularLabel : pluralLabel}`;
+}
+
+function normalizeImageUrl(imageUrl: string | null | undefined): string | null {
+  const normalized = normalizeText(imageUrl);
+
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    return new URL(normalized, buildPublicAppUrl('/')).toString();
+  } catch {
+    return null;
+  }
+}
+
+function resolveTimestamp(value: string | null): number {
+  if (!value) {
+    return 0;
+  }
+
+  const parsedValue = new Date(value).getTime();
+
+  return Number.isNaN(parsedValue) ? 0 : parsedValue;
+}
+
+function resolvePrimaryLibraryGame(
+  profile: ProfileResponse | null,
+): ProfileResponse['gameLibrary'][number] | null {
+  if (!profile || profile.gameLibrary.length === 0) {
+    return null;
+  }
+
+  const sortedGames = [...profile.gameLibrary].sort((left, right) => {
+    const hoursDifference = (right.hoursPlayed ?? -1) - (left.hoursPlayed ?? -1);
+
+    if (hoursDifference !== 0) {
+      return hoursDifference;
+    }
+
+    const recentDifference = resolveTimestamp(right.lastPlayedAt) - resolveTimestamp(left.lastPlayedAt);
+
+    if (recentDifference !== 0) {
+      return recentDifference;
+    }
+
+    return left.gameName.localeCompare(right.gameName, 'pt-BR');
+  });
+
+  return sortedGames[0] ?? null;
+}
+
+function resolveTrackedHours(profile: ProfileResponse | null): number | null {
+  if (!profile) {
+    return null;
+  }
+
+  const trackedHours = profile.gameLibrary.reduce((sum, game) => {
+    if (typeof game.hoursPlayed !== 'number' || !Number.isFinite(game.hoursPlayed)) {
+      return sum;
+    }
+
+    return sum + game.hoursPlayed;
+  }, 0);
+
+  const hasTrackedHours = profile.gameLibrary.some((game) => {
+    return typeof game.hoursPlayed === 'number' && Number.isFinite(game.hoursPlayed);
+  });
+
+  if (!hasTrackedHours) {
+    return null;
+  }
+
+  return Math.max(0, Math.round(trackedHours));
+}
+
+function resolveLibraryPlatformCount(profile: ProfileResponse | null): number {
+  if (!profile) {
+    return 0;
+  }
+
+  return new Set(profile.gameLibrary.map((game) => game.platform)).size;
+}
+
+function resolveLibraryImageCandidates(profile: ProfileResponse | null): string[] {
+  const primaryGame = resolvePrimaryLibraryGame(profile);
+
+  return [
+    normalizeImageUrl(primaryGame?.coverUrl),
+    normalizeImageUrl(profile?.profile.bannerUrl),
+    normalizeImageUrl(profile?.profile.avatarUrl),
+  ].filter((value, index, collection): value is string => {
+    return value !== null && collection.indexOf(value) === index;
+  });
+}
+
+export async function fetchPublicLibraryForShare(
+  username: string,
+): Promise<ProfileResponse | null> {
+  return fetchPublicProfileForShare(username);
+}
+
+export function buildPublicLibraryCanonicalUrl(username: string): string {
+  return buildPublicAppUrl(`/${encodeURIComponent(username)}/library`);
+}
+
+export function buildPublicLibraryTitle(
+  username: string,
+  profile: ProfileResponse | null,
+): string {
+  const displayName = normalizeText(profile?.profile.displayName);
+
+  if (
+    displayName &&
+    displayName.toLocaleLowerCase('pt-BR') !== username.toLocaleLowerCase('pt-BR')
+  ) {
+    return `Biblioteca de ${displayName} (@${username}) | CLUTCH`;
+  }
+
+  return `Biblioteca de @${username} | CLUTCH`;
+}
+
+export function buildPublicLibraryDescription(
+  username: string,
+  profile: ProfileResponse | null,
+): string {
+  const prefix = `Explore a biblioteca publica de @${username} no CLUTCH`;
+
+  if (!profile || profile.gameLibrary.length === 0) {
+    return `${prefix}.`;
+  }
+
+  const descriptionParts: string[] = [];
+  const trackedHours = resolveTrackedHours(profile);
+  const platformCount = resolveLibraryPlatformCount(profile);
+  const primaryGame = resolvePrimaryLibraryGame(profile);
+
+  descriptionParts.push(
+    formatCount(profile.gameLibrary.length, 'jogo', 'jogos'),
+  );
+
+  if (trackedHours !== null && trackedHours > 0) {
+    descriptionParts.push(`${trackedHours.toLocaleString('pt-BR')}h registradas`);
+  }
+
+  if (platformCount > 0) {
+    descriptionParts.push(
+      formatCount(platformCount, 'plataforma', 'plataformas'),
+    );
+  }
+
+  if (primaryGame) {
+    descriptionParts.push(`destaque para ${primaryGame.gameName}`);
+  }
+
+  return truncateText(
+    `${prefix} com ${descriptionParts.join(', ')}.`,
+    LIBRARY_SHARE_DESCRIPTION_MAX_LENGTH,
+  );
+}
+
+export function buildPublicLibraryMetadata(
+  username: string,
+  profile: ProfileResponse | null,
+): Metadata {
+  const title = buildPublicLibraryTitle(username, profile);
+  const description = buildPublicLibraryDescription(username, profile);
+  const canonicalUrl = buildPublicLibraryCanonicalUrl(username);
+  const imageCandidates = resolveLibraryImageCandidates(profile);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonicalUrl,
+      siteName: 'CLUTCH',
+      images:
+        imageCandidates.length > 0
+          ? imageCandidates.map((url) => ({
+              url,
+              alt: title,
+            }))
+          : undefined,
+    },
+    twitter: {
+      card: imageCandidates.length > 0 ? 'summary_large_image' : 'summary',
+      title,
+      description,
+      images: imageCandidates.length > 0 ? imageCandidates : undefined,
+    },
+  };
+}

--- a/frontend/tests/unit/components/library-page-content.test.tsx
+++ b/frontend/tests/unit/components/library-page-content.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LibraryPageContent } from '@/components/library/library-page-content';
+import { ToastProvider } from '@/components/ui/toaster';
 import {
   fetchProfileByUsername,
   ProfileRequestError,
@@ -101,7 +102,9 @@ function renderWithQuery(ui: ReactElement) {
   });
 
   return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    <ToastProvider>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </ToastProvider>,
   );
 }
 
@@ -133,6 +136,7 @@ describe('LibraryPageContent', () => {
     });
 
     expect(screen.getByText(/biblioteca de @clutchplayer/i)).toBeInTheDocument();
+    expect(screen.getByTestId('library-share-button')).toHaveTextContent(/copiar link/i);
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getByText('1157h')).toBeInTheDocument();
     expect(screen.getByText(/exibindo 4 de 4 jogos/i)).toBeInTheDocument();

--- a/frontend/tests/unit/components/library-share-button.test.tsx
+++ b/frontend/tests/unit/components/library-share-button.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LibraryShareButton } from '@/components/library/library-share-button';
+import { ToastProvider } from '@/components/ui/toaster';
+
+const originalClipboard = globalThis.navigator.clipboard;
+const originalNextPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+const originalPublicAppUrl = process.env.PUBLIC_APP_URL;
+
+function renderWithToastProvider() {
+  return render(
+    <ToastProvider>
+      <LibraryShareButton username="clutchplayer" />
+    </ToastProvider>,
+  );
+}
+
+describe('LibraryShareButton', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://clutch.gg';
+    process.env.PUBLIC_APP_URL = '';
+  });
+
+  it('copies the public library URL and shows success feedback', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(globalThis.navigator, {
+      clipboard: {
+        writeText,
+      },
+    });
+
+    renderWithToastProvider();
+
+    fireEvent.click(screen.getByTestId('library-share-button'));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        'https://clutch.gg/clutchplayer/library',
+      );
+    });
+
+    expect(screen.getByTestId('toast-item')).toHaveTextContent(
+      /link da biblioteca copiado/i,
+    );
+  });
+
+  it('shows an error when clipboard access is unavailable', async () => {
+    Object.assign(globalThis.navigator, {
+      clipboard: undefined,
+    });
+
+    renderWithToastProvider();
+
+    fireEvent.click(screen.getByTestId('library-share-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('toast-item')).toHaveTextContent(
+        /nao foi possivel copiar o link/i,
+      );
+    });
+  });
+});
+
+afterAll(() => {
+  process.env.NEXT_PUBLIC_APP_URL = originalNextPublicAppUrl;
+  process.env.PUBLIC_APP_URL = originalPublicAppUrl;
+
+  Object.assign(globalThis.navigator, {
+    clipboard: originalClipboard,
+  });
+});

--- a/frontend/tests/unit/lib/public-library-share.test.ts
+++ b/frontend/tests/unit/lib/public-library-share.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProfileResponse } from '@/schemas/profile';
+import {
+  buildPublicLibraryCanonicalUrl,
+  buildPublicLibraryDescription,
+  buildPublicLibraryMetadata,
+  buildPublicLibraryTitle,
+} from '@/lib/profile/public-library-share';
+
+const profileFixture: ProfileResponse = {
+  id: 'user-1',
+  username: 'clutchplayer',
+  createdAt: '2026-03-29T22:15:00.000Z',
+  profile: {
+    displayName: 'CLUTCH Player',
+    bio: 'Bio de teste do perfil publico',
+    avatarUrl: 'https://cdn.clutch.gg/avatar.jpg',
+    bannerUrl: 'https://cdn.clutch.gg/banner.jpg',
+    accentColor: '#7C3AED',
+    badges: ['Founder'],
+  },
+  stats: {
+    level: 18,
+    xp: 4820,
+    reputation: 215,
+    friendCount: 2,
+    postCount: 2,
+  },
+  presence: {
+    status: 'ONLINE',
+    currentGame: null,
+    gameDetails: null,
+    platform: null,
+    updatedAt: '2026-03-29T22:15:00.000Z',
+  },
+  platformIntegrations: [
+    {
+      platform: 'STEAM',
+      metadata: null,
+    },
+  ],
+  gameLibrary: [
+    {
+      gameName: 'Valorant',
+      coverUrl: 'https://cdn.clutch.gg/valorant.jpg',
+      platform: 'PC',
+      hoursPlayed: 120,
+      lastPlayedAt: '2026-03-29T22:15:00.000Z',
+    },
+    {
+      gameName: 'Fortnite',
+      coverUrl: 'https://cdn.clutch.gg/fortnite.jpg',
+      platform: 'EPIC',
+      hoursPlayed: 30,
+      lastPlayedAt: '2026-03-28T22:15:00.000Z',
+    },
+  ],
+  socialContinuity: {
+    currentStreakDays: 4,
+    activeFriendOffensiveCount: 1,
+    strongestFriendOffensive: {
+      friendId: 'friend-1',
+      friendUsername: 'duoqueue',
+      days: 3,
+      lastQualifiedAt: '2026-03-29T00:00:00.000Z',
+    },
+  },
+};
+
+const originalNextPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+const originalPublicAppUrl = process.env.PUBLIC_APP_URL;
+
+describe('public library share metadata helpers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'https://clutch.gg';
+    process.env.PUBLIC_APP_URL = '';
+  });
+
+  it('builds title, description and canonical from the real public library contract', () => {
+    const metadata = buildPublicLibraryMetadata('clutchplayer', profileFixture);
+
+    expect(buildPublicLibraryTitle('clutchplayer', profileFixture)).toBe(
+      'Biblioteca de CLUTCH Player (@clutchplayer) | CLUTCH',
+    );
+    expect(buildPublicLibraryDescription('clutchplayer', profileFixture)).toBe(
+      'Explore a biblioteca publica de @clutchplayer no CLUTCH com 2 jogos, 150h registradas, 2 plataformas, destaque para Valorant.',
+    );
+    expect(buildPublicLibraryCanonicalUrl('clutchplayer')).toBe(
+      'https://clutch.gg/clutchplayer/library',
+    );
+    expect(metadata.alternates?.canonical).toBe(
+      'https://clutch.gg/clutchplayer/library',
+    );
+    expect(metadata.openGraph?.url).toBe(
+      'https://clutch.gg/clutchplayer/library',
+    );
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: 'https://cdn.clutch.gg/valorant.jpg',
+        alt: 'Biblioteca de CLUTCH Player (@clutchplayer) | CLUTCH',
+      },
+      {
+        url: 'https://cdn.clutch.gg/banner.jpg',
+        alt: 'Biblioteca de CLUTCH Player (@clutchplayer) | CLUTCH',
+      },
+      {
+        url: 'https://cdn.clutch.gg/avatar.jpg',
+        alt: 'Biblioteca de CLUTCH Player (@clutchplayer) | CLUTCH',
+      },
+    ]);
+  });
+
+  it('falls back to an honest library summary when richer fields are absent', () => {
+    const metadata = buildPublicLibraryMetadata('ghostplayer', {
+      ...profileFixture,
+      username: 'ghostplayer',
+      profile: {
+        ...profileFixture.profile,
+        displayName: null,
+        avatarUrl: null,
+        bannerUrl: null,
+      },
+      gameLibrary: [],
+    });
+
+    expect(buildPublicLibraryTitle('ghostplayer', null)).toBe(
+      'Biblioteca de @ghostplayer | CLUTCH',
+    );
+    expect(buildPublicLibraryDescription('ghostplayer', null)).toBe(
+      'Explore a biblioteca publica de @ghostplayer no CLUTCH.',
+    );
+    expect(metadata.alternates?.canonical).toBe(
+      'https://clutch.gg/ghostplayer/library',
+    );
+    expect(metadata.openGraph?.images).toBeUndefined();
+    expect(metadata.twitter).toMatchObject({
+      card: 'summary',
+    });
+  });
+});
+
+afterAll(() => {
+  process.env.NEXT_PUBLIC_APP_URL = originalNextPublicAppUrl;
+  process.env.PUBLIC_APP_URL = originalPublicAppUrl;
+});


### PR DESCRIPTION
## Resumo
Implementa o segundo slice real de sharing outbound do CLUTCH na library pública `/:username/library`, adicionando metadata específica por rota, URL canônica consistente e um CTA local para copiar o link público da biblioteca. A mudança reaproveita apenas dados públicos já existentes no contrato de profile e mantém o escopo restrito ao outbound sharing da library.

## O que foi alterado
- Frontend
- Adicionada `generateMetadata` na rota pública da library para montar `title`, `description`, `alternates.canonical`, `openGraph` e `twitter` com base em dados reais do profile e da `gameLibrary`.
- Criado um helper dedicado para resolver canonical, descrição, preview e fallbacks honestos de metadata para `/:username/library`.
- Adicionado um CTA local de copiar link da library no `SectionHeading` da página pública, com feedback de sucesso e erro via toast.
- A página da library passou a reaproveitar a mesma regra de origem pública já consolidada no slice de `/:username`.
- Testes
- Adicionada cobertura unitária para metadata rica e fallback textual sem covers ou imagens de perfil.
- Adicionada cobertura unitária para o CTA de copiar link da library e para a presença do CTA no fluxo da página pública.

## Motivação
As definições das issues `#234`, `#235` e `#236` consolidaram que a próxima share unit real do CLUTCH depois do perfil público deveria ser `/:username/library`, ainda em modo outbound only e sem provider externo. Esta PR materializa esse segundo recorte mínimo sem abrir post individual, tracking ou backend novo.

## Como validar
- No diretório `frontend`, executar:
- `npm run test -- tests/unit/lib/public-library-share.test.ts tests/unit/components/library-share-button.test.tsx tests/unit/components/library-page-content.test.tsx tests/unit/components/profile-share-button.test.tsx tests/unit/lib/public-profile-share.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Smoke controlado de metadata:
- subir o frontend com `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_API_URL` e `INTERNAL_API_URL` apontando para um payload válido de `GET /profiles/:username`
- acessar `/:username/library`
- verificar `title`, `description`, `canonical`, `og:url` e `og:image` no HTML retornado
- repetir com uma library sem `coverUrl`, `bannerUrl` e `avatarUrl` para validar o fallback textual sem `og:image`

## Riscos e impactos
- A canonical da library depende da mesma configuração de `PUBLIC_APP_URL` ou `NEXT_PUBLIC_APP_URL` usada no slice do perfil público; se a origem pública estiver mal configurada, o link absoluto também ficará incorreto.
- Esta PR não adiciona imagem Open Graph dinâmica; o preview reaproveita primeiro `coverUrl` de jogo, depois `bannerUrl` e `avatarUrl`, e cai para texto puro quando não houver imagem pública válida.
- O CTA de share usa a Clipboard API do navegador. Em superfícies sem permissão de clipboard, o comportamento é fallback para toast de erro.
- Não há alteração de backend, contrato público novo nem tracking de origem.

## Evidências
- Smoke controlado com library rica:
- `title`: `Biblioteca de CLUTCH Player (@clutchplayer) | CLUTCH`
- `canonical`: `http://127.0.0.1:3036/clutchplayer/library`
- `description`: `Explore a biblioteca publica de @clutchplayer no CLUTCH com 2 jogos, 150h registradas, 2 plataformas, destaque para Valorant.`
- `og:url`: `http://127.0.0.1:3036/clutchplayer/library`
- `og:image`: `https://cdn.clutch.gg/valorant.jpg`
- Smoke controlado com fallback textual:
- `title`: `Biblioteca de @ghostplayer | CLUTCH`
- `canonical`: `http://127.0.0.1:3036/ghostplayer/library`
- `description`: `Explore a biblioteca publica de @ghostplayer no CLUTCH.`
- `og:image`: ausente
- A cópia do link foi validada por teste unitário do componente, porque não houve automação de browser disponível nesta sessão para clicar no CTA em ambiente real.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #257