### PR TITLE
feat(profile): implementar slice mínimo de otakuShowcase no perfil

### DIFF
--- a/backend/prisma/migrations/20260424161000_add_otaku_showcase/migration.sql
+++ b/backend/prisma/migrations/20260424161000_add_otaku_showcase/migration.sql
@@ -1,0 +1,42 @@
+-- CreateEnum
+CREATE TYPE "MediaKind" AS ENUM ('ANIME', 'MANGA');
+
+-- CreateEnum
+CREATE TYPE "MediaConsumptionStatus" AS ENUM ('PLANNING', 'CONSUMING', 'COMPLETED', 'PAUSED', 'DROPPED');
+
+-- CreateTable
+CREATE TABLE "media_titles" (
+    "id" TEXT NOT NULL,
+    "kind" "MediaKind" NOT NULL,
+    "canonicalTitle" TEXT NOT NULL,
+    "coverUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "media_titles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_media_entries" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "mediaTitleId" TEXT NOT NULL,
+    "status" "MediaConsumptionStatus" NOT NULL,
+    "showcaseRank" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_media_entries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_media_entries_userId_mediaTitleId_key" ON "user_media_entries"("userId", "mediaTitleId");
+
+-- CreateIndex
+CREATE INDEX "user_media_entries_userId_showcaseRank_idx" ON "user_media_entries"("userId", "showcaseRank");
+
+-- AddForeignKey
+ALTER TABLE "user_media_entries" ADD CONSTRAINT "user_media_entries_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_media_entries" ADD CONSTRAINT "user_media_entries_mediaTitleId_fkey" FOREIGN KEY ("mediaTitleId") REFERENCES "media_titles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -63,6 +63,19 @@ enum FriendRequestStatus {
   REJECTED
 }
 
+enum MediaKind {
+  ANIME
+  MANGA
+}
+
+enum MediaConsumptionStatus {
+  PLANNING
+  CONSUMING
+  COMPLETED
+  PAUSED
+  DROPPED
+}
+
 // ── User ─────────────────────────────────────────────────────
 
 model User {
@@ -90,6 +103,7 @@ model User {
   friendOf             Friendship[]          @relation("FriendshipFriend")
   sentGameInvites      GameInvite[]          @relation("GameInviteSender")
   receivedGameInvites  GameInvite[]          @relation("GameInviteReceiver")
+  mediaEntries         UserMediaEntry[]
 
   @@map("users")
 }
@@ -183,6 +197,36 @@ model UserGameLibrary {
 
   @@unique([userId, gameId, platform])
   @@map("user_game_library")
+}
+
+model MediaTitle {
+  id             String           @id @default(uuid())
+  kind           MediaKind
+  canonicalTitle String
+  coverUrl       String?
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
+
+  userEntries UserMediaEntry[]
+
+  @@map("media_titles")
+}
+
+model UserMediaEntry {
+  id           String                 @id @default(uuid())
+  userId       String
+  mediaTitleId String
+  status       MediaConsumptionStatus
+  showcaseRank Int?
+  createdAt    DateTime               @default(now())
+  updatedAt    DateTime               @updatedAt
+
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  mediaTitle MediaTitle @relation(fields: [mediaTitleId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, mediaTitleId])
+  @@index([userId, showcaseRank])
+  @@map("user_media_entries")
 }
 
 // ── Post ─────────────────────────────────────────────────────

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'node:url';
 
 const {
   InteractionType,
+  MediaConsumptionStatus,
+  MediaKind,
   NotificationType,
   Platform,
   PostType,
@@ -17,6 +19,8 @@ const {
 } = prismaClientPackage;
 
 type InteractionType = (typeof InteractionType)[keyof typeof InteractionType];
+type MediaConsumptionStatus = (typeof MediaConsumptionStatus)[keyof typeof MediaConsumptionStatus];
+type MediaKind = (typeof MediaKind)[keyof typeof MediaKind];
 type NotificationType = (typeof NotificationType)[keyof typeof NotificationType];
 type Platform = (typeof Platform)[keyof typeof Platform];
 type PostType = (typeof PostType)[keyof typeof PostType];
@@ -65,6 +69,18 @@ export const SEEDED_ENTITY_IDS = {
     'f4444444-4444-4444-8444-444444444444',
     'f5555555-5555-4555-8555-555555555555',
     'f6666666-6666-4666-8666-666666666666',
+  ],
+  mediaTitles: [
+    'g1111111-1111-4111-8111-111111111111',
+    'g2222222-2222-4222-8222-222222222222',
+    'g3333333-3333-4333-8333-333333333333',
+    'g4444444-4444-4444-8444-444444444444',
+  ],
+  mediaEntries: [
+    'h1111111-1111-4111-8111-111111111111',
+    'h2222222-2222-4222-8222-222222222222',
+    'h3333333-3333-4333-8333-333333333333',
+    'h4444444-4444-4444-8444-444444444444',
   ],
 } as const;
 
@@ -165,6 +181,21 @@ type SeedIntegrationConfig = {
   platform: Platform;
   externalId: string;
   metadata: Prisma.JsonObject;
+};
+
+type SeedMediaTitleConfig = {
+  id: string;
+  kind: MediaKind;
+  canonicalTitle: string;
+  coverUrl: string | null;
+};
+
+type SeedUserMediaEntryConfig = {
+  id: string;
+  userEmail: string;
+  mediaTitleId: string;
+  status: MediaConsumptionStatus;
+  showcaseRank: number | null;
 };
 
 function toNullableJsonInput(value: Prisma.JsonObject | null): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
@@ -536,6 +567,64 @@ const seedIntegrations: SeedIntegrationConfig[] = [
   },
 ];
 
+const seedMediaTitles: SeedMediaTitleConfig[] = [
+  {
+    id: 'g1111111-1111-4111-8111-111111111111',
+    kind: MediaKind.ANIME,
+    canonicalTitle: 'Sousou no Frieren',
+    coverUrl: 'https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=600&q=80',
+  },
+  {
+    id: 'g2222222-2222-4222-8222-222222222222',
+    kind: MediaKind.ANIME,
+    canonicalTitle: 'Dungeon Meshi',
+    coverUrl: 'https://images.unsplash.com/photo-1511884642898-4c92249e20b6?auto=format&fit=crop&w=600&q=80',
+  },
+  {
+    id: 'g3333333-3333-4333-8333-333333333333',
+    kind: MediaKind.MANGA,
+    canonicalTitle: 'Blue Lock',
+    coverUrl: 'https://images.unsplash.com/photo-1542751110-97427bbecf20?auto=format&fit=crop&w=600&q=80',
+  },
+  {
+    id: 'g4444444-4444-4444-8444-444444444444',
+    kind: MediaKind.MANGA,
+    canonicalTitle: 'Vagabond',
+    coverUrl: null,
+  },
+];
+
+const seedUserMediaEntries: SeedUserMediaEntryConfig[] = [
+  {
+    id: 'h1111111-1111-4111-8111-111111111111',
+    userEmail: DEMO_ACCOUNT.email,
+    mediaTitleId: 'g1111111-1111-4111-8111-111111111111',
+    status: MediaConsumptionStatus.COMPLETED,
+    showcaseRank: 1,
+  },
+  {
+    id: 'h2222222-2222-4222-8222-222222222222',
+    userEmail: DEMO_ACCOUNT.email,
+    mediaTitleId: 'g2222222-2222-4222-8222-222222222222',
+    status: MediaConsumptionStatus.CONSUMING,
+    showcaseRank: 2,
+  },
+  {
+    id: 'h3333333-3333-4333-8333-333333333333',
+    userEmail: DEMO_ACCOUNT.email,
+    mediaTitleId: 'g3333333-3333-4333-8333-333333333333',
+    status: MediaConsumptionStatus.CONSUMING,
+    showcaseRank: 3,
+  },
+  {
+    id: 'h4444444-4444-4444-8444-444444444444',
+    userEmail: 'luna@clutch.gg',
+    mediaTitleId: 'g4444444-4444-4444-8444-444444444444',
+    status: MediaConsumptionStatus.PLANNING,
+    showcaseRank: null,
+  },
+];
+
 function seedUsersPlaceholder(): readonly string[] {
   return [
     DEMO_ACCOUNT.email,
@@ -638,6 +727,42 @@ function getUserId(userIdsByEmail: Map<string, string>, email: string): string {
 }
 
 async function upsertSeedRelations(client: PrismaClient, userIdsByEmail: Map<string, string>): Promise<void> {
+  for (const mediaTitle of seedMediaTitles) {
+    await client.mediaTitle.upsert({
+      where: { id: mediaTitle.id },
+      update: {
+        kind: mediaTitle.kind,
+        canonicalTitle: mediaTitle.canonicalTitle,
+        coverUrl: mediaTitle.coverUrl,
+      },
+      create: {
+        id: mediaTitle.id,
+        kind: mediaTitle.kind,
+        canonicalTitle: mediaTitle.canonicalTitle,
+        coverUrl: mediaTitle.coverUrl,
+      },
+    });
+  }
+
+  for (const mediaEntry of seedUserMediaEntries) {
+    await client.userMediaEntry.upsert({
+      where: { id: mediaEntry.id },
+      update: {
+        userId: getUserId(userIdsByEmail, mediaEntry.userEmail),
+        mediaTitleId: mediaEntry.mediaTitleId,
+        status: mediaEntry.status,
+        showcaseRank: mediaEntry.showcaseRank,
+      },
+      create: {
+        id: mediaEntry.id,
+        userId: getUserId(userIdsByEmail, mediaEntry.userEmail),
+        mediaTitleId: mediaEntry.mediaTitleId,
+        status: mediaEntry.status,
+        showcaseRank: mediaEntry.showcaseRank,
+      },
+    });
+  }
+
   for (const integration of seedIntegrations) {
     const userId = getUserId(userIdsByEmail, integration.userEmail);
     await client.platformIntegration.upsert({

--- a/backend/src/api/routes/profile.routes.ts
+++ b/backend/src/api/routes/profile.routes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { profileRepository } from '../../core/repositories/profile.repository';
+import { otakuShowcaseService } from '../../core/services/otaku-showcase.service';
 import { socialContinuityService } from '../../core/services/social-continuity.service';
 import { userRepository } from '../../core/repositories/user.repository';
 
@@ -30,11 +31,15 @@ export async function profileRoutes(app: FastifyInstance): Promise<void> {
       const profile = await profileRepository.findFullProfileByUsername(request.params.username);
       if (!profile) return reply.status(404).send({ message: 'Perfil não encontrado.' });
 
-      const socialContinuity = await socialContinuityService.summarizeUser(profile.id);
+      const [socialContinuity, otakuShowcase] = await Promise.all([
+        socialContinuityService.summarizeUser(profile.id),
+        otakuShowcaseService.summarizeUser(profile.id),
+      ]);
 
       return reply.status(200).send({
         ...profile,
         socialContinuity,
+        otakuShowcase,
       });
     },
   );

--- a/backend/src/core/services/otaku-showcase.service.ts
+++ b/backend/src/core/services/otaku-showcase.service.ts
@@ -1,0 +1,87 @@
+import { prisma } from '../../infra/database/client';
+
+export interface OtakuShowcaseItem {
+  id: string;
+  kind: 'ANIME' | 'MANGA';
+  title: string;
+  coverUrl: string | null;
+}
+
+export interface OtakuShowcaseSummary {
+  featured: OtakuShowcaseItem[];
+  consumingNow: OtakuShowcaseItem[];
+  consumingCount: number;
+  completedCount: number;
+}
+
+type PublicShowcaseEntry = {
+  showcaseRank: number | null;
+  status: 'PLANNING' | 'CONSUMING' | 'COMPLETED' | 'PAUSED' | 'DROPPED';
+  mediaTitle: {
+    id: string;
+    kind: 'ANIME' | 'MANGA';
+    canonicalTitle: string;
+    coverUrl: string | null;
+  };
+};
+
+function compareShowcaseEntries(left: PublicShowcaseEntry, right: PublicShowcaseEntry): number {
+  const leftRank = left.showcaseRank ?? Number.MAX_SAFE_INTEGER;
+  const rightRank = right.showcaseRank ?? Number.MAX_SAFE_INTEGER;
+
+  if (leftRank !== rightRank) {
+    return leftRank - rightRank;
+  }
+
+  return left.mediaTitle.canonicalTitle.localeCompare(right.mediaTitle.canonicalTitle, 'pt-BR');
+}
+
+function toShowcaseItem(entry: PublicShowcaseEntry): OtakuShowcaseItem {
+  return {
+    id: entry.mediaTitle.id,
+    kind: entry.mediaTitle.kind,
+    title: entry.mediaTitle.canonicalTitle,
+    coverUrl: entry.mediaTitle.coverUrl,
+  };
+}
+
+export const otakuShowcaseService = {
+  async summarizeUser(userId: string): Promise<OtakuShowcaseSummary | null> {
+    const publicEntries = (await prisma.userMediaEntry.findMany({
+      where: {
+        userId,
+        showcaseRank: {
+          not: null,
+        },
+      },
+      select: {
+        showcaseRank: true,
+        status: true,
+        mediaTitle: {
+          select: {
+            id: true,
+            kind: true,
+            canonicalTitle: true,
+            coverUrl: true,
+          },
+        },
+      },
+    })) as PublicShowcaseEntry[];
+
+    if (publicEntries.length === 0) {
+      return null;
+    }
+
+    publicEntries.sort(compareShowcaseEntries);
+
+    return {
+      featured: publicEntries.slice(0, 3).map(toShowcaseItem),
+      consumingNow: publicEntries
+        .filter((entry) => entry.status === 'CONSUMING')
+        .slice(0, 2)
+        .map(toShowcaseItem),
+      consumingCount: publicEntries.filter((entry) => entry.status === 'CONSUMING').length,
+      completedCount: publicEntries.filter((entry) => entry.status === 'COMPLETED').length,
+    };
+  },
+};

--- a/backend/tests/integration/prisma.seed.test.ts
+++ b/backend/tests/integration/prisma.seed.test.ts
@@ -25,6 +25,16 @@ describe('Prisma seed', () => {
         presence: true,
         platformIntegrations: true,
         gameLibrary: true,
+        mediaEntries: {
+          where: {
+            showcaseRank: {
+              not: null,
+            },
+          },
+          include: {
+            mediaTitle: true,
+          },
+        },
       },
     });
 
@@ -38,6 +48,8 @@ describe('Prisma seed', () => {
     expect(demoUserRecord.presence?.status).toBe('IN_GAME');
     expect(demoUserRecord.platformIntegrations.length).toBeGreaterThanOrEqual(2);
     expect(demoUserRecord.gameLibrary.length).toBeGreaterThanOrEqual(2);
+    expect(demoUserRecord.mediaEntries.length).toBeGreaterThanOrEqual(3);
+    expect(demoUserRecord.mediaEntries[0]?.mediaTitle.canonicalTitle).toBeTruthy();
 
     const countsBeforeRerun = {
       posts: await prisma.post.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.posts] } } }),
@@ -46,6 +58,8 @@ describe('Prisma seed', () => {
       notifications: await prisma.notification.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.notifications] } } }),
       friendships: await prisma.friendship.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.friendships] } } }),
       friendRequests: await prisma.friendRequest.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.friendRequests] } } }),
+      mediaTitles: await prisma.mediaTitle.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.mediaTitles] } } }),
+      mediaEntries: await prisma.userMediaEntry.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.mediaEntries] } } }),
     };
 
     await runSeed(prisma);
@@ -57,6 +71,8 @@ describe('Prisma seed', () => {
       notifications: await prisma.notification.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.notifications] } } }),
       friendships: await prisma.friendship.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.friendships] } } }),
       friendRequests: await prisma.friendRequest.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.friendRequests] } } }),
+      mediaTitles: await prisma.mediaTitle.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.mediaTitles] } } }),
+      mediaEntries: await prisma.userMediaEntry.count({ where: { id: { in: [...SEEDED_ENTITY_IDS.mediaEntries] } } }),
     };
 
     expect(countsAfterRerun).toEqual(countsBeforeRerun);
@@ -96,6 +112,15 @@ describe('Prisma seed', () => {
       profile: expect.objectContaining({
         displayName: 'CLUTCH Player',
       }),
+      otakuShowcase: {
+        featured: expect.arrayContaining([
+          expect.objectContaining({
+            title: 'Sousou no Frieren',
+          }),
+        ]),
+        consumingCount: 2,
+        completedCount: 1,
+      },
     });
 
     const friendsResponse = await app.inject({

--- a/backend/tests/integration/routes/profile.routes.test.ts
+++ b/backend/tests/integration/routes/profile.routes.test.ts
@@ -14,6 +14,12 @@ vi.mock('@/core/services/social-continuity.service', () => ({
   },
 }));
 
+vi.mock('@/core/services/otaku-showcase.service', () => ({
+  otakuShowcaseService: {
+    summarizeUser: vi.fn(),
+  },
+}));
+
 vi.mock('@/core/repositories/user.repository', () => ({
   userRepository: {
     findById: vi.fn(), findByEmail: vi.fn(), findByUsername: vi.fn(),
@@ -22,6 +28,7 @@ vi.mock('@/core/repositories/user.repository', () => ({
 }));
 
 import { profileRepository } from '@/core/repositories/profile.repository';
+import { otakuShowcaseService } from '@/core/services/otaku-showcase.service';
 import { socialContinuityService } from '@/core/services/social-continuity.service';
 import { userRepository }    from '@/core/repositories/user.repository';
 
@@ -49,6 +56,27 @@ const mockSocialContinuity = {
   },
 };
 
+const mockOtakuShowcase = {
+  featured: [
+    {
+      id: 'media-1',
+      kind: 'ANIME' as const,
+      title: 'Sousou no Frieren',
+      coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+    },
+  ],
+  consumingNow: [
+    {
+      id: 'media-2',
+      kind: 'MANGA' as const,
+      title: 'Blue Lock',
+      coverUrl: null,
+    },
+  ],
+  consumingCount: 1,
+  completedCount: 1,
+};
+
 const mockUpdatedProfile = {
   id: 'profile-id-1', userId: 'user-id-1', displayName: 'Novo Nome',
   bio: 'Nova bio', avatarUrl: null, bannerUrl: null, accentColor: null,
@@ -60,6 +88,7 @@ describe('Profile Routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(socialContinuityService.summarizeUser).mockResolvedValue(mockSocialContinuity);
+    vi.mocked(otakuShowcaseService.summarizeUser).mockResolvedValue(mockOtakuShowcase);
   });
 
   describe('GET /profiles/:username', () => {
@@ -81,6 +110,37 @@ describe('Profile Routes', () => {
             days: 2,
           },
         },
+        otakuShowcase: {
+          featured: [
+            {
+              id: 'media-1',
+              title: 'Sousou no Frieren',
+            },
+          ],
+          consumingNow: [
+            {
+              id: 'media-2',
+              title: 'Blue Lock',
+            },
+          ],
+          consumingCount: 1,
+          completedCount: 1,
+        },
+      });
+      await app.close();
+    });
+
+    it('retorna otakuShowcase nulo quando o usuario nao configurou destaque publico', async () => {
+      vi.mocked(profileRepository.findFullProfileByUsername).mockResolvedValue(mockFullProfile);
+      vi.mocked(otakuShowcaseService.summarizeUser).mockResolvedValue(null);
+
+      const app = await buildApp();
+      const response = await app.inject({ method: 'GET', url: '/profiles/clutchplayer' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        username: 'clutchplayer',
+        otakuShowcase: null,
       });
       await app.close();
     });

--- a/backend/tests/unit/services/otaku-showcase.service.test.ts
+++ b/backend/tests/unit/services/otaku-showcase.service.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { otakuShowcaseService } from '@/core/services/otaku-showcase.service';
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    userMediaEntry: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/infra/database/client';
+
+describe('otakuShowcaseService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resume entradas publicas destacadas em um showcase compacto', async () => {
+    vi.mocked(prisma.userMediaEntry.findMany).mockResolvedValue([
+      {
+        showcaseRank: 2,
+        status: 'CONSUMING',
+        mediaTitle: {
+          id: 'media-2',
+          kind: 'MANGA',
+          canonicalTitle: 'Blue Lock',
+          coverUrl: null,
+        },
+      },
+      {
+        showcaseRank: 1,
+        status: 'COMPLETED',
+        mediaTitle: {
+          id: 'media-1',
+          kind: 'ANIME',
+          canonicalTitle: 'Sousou no Frieren',
+          coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+        },
+      },
+      {
+        showcaseRank: 3,
+        status: 'CONSUMING',
+        mediaTitle: {
+          id: 'media-3',
+          kind: 'ANIME',
+          canonicalTitle: 'Dungeon Meshi',
+          coverUrl: 'https://cdn.clutch.gg/dungeon-meshi.jpg',
+        },
+      },
+    ] as never);
+
+    const summary = await otakuShowcaseService.summarizeUser('user-1');
+
+    expect(summary).toEqual({
+      featured: [
+        {
+          id: 'media-1',
+          kind: 'ANIME',
+          title: 'Sousou no Frieren',
+          coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+        },
+        {
+          id: 'media-2',
+          kind: 'MANGA',
+          title: 'Blue Lock',
+          coverUrl: null,
+        },
+        {
+          id: 'media-3',
+          kind: 'ANIME',
+          title: 'Dungeon Meshi',
+          coverUrl: 'https://cdn.clutch.gg/dungeon-meshi.jpg',
+        },
+      ],
+      consumingNow: [
+        {
+          id: 'media-2',
+          kind: 'MANGA',
+          title: 'Blue Lock',
+          coverUrl: null,
+        },
+        {
+          id: 'media-3',
+          kind: 'ANIME',
+          title: 'Dungeon Meshi',
+          coverUrl: 'https://cdn.clutch.gg/dungeon-meshi.jpg',
+        },
+      ],
+      consumingCount: 2,
+      completedCount: 1,
+    });
+  });
+
+  it('retorna null quando o usuario nao tem entradas publicas no showcase', async () => {
+    vi.mocked(prisma.userMediaEntry.findMany).mockResolvedValue([] as never);
+
+    const summary = await otakuShowcaseService.summarizeUser('user-1');
+
+    expect(summary).toBeNull();
+  });
+});

--- a/frontend/src/components/profile/otaku-showcase-card.tsx
+++ b/frontend/src/components/profile/otaku-showcase-card.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import Image from 'next/image';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type OtakuShowcaseCardProps = {
+  showcase: ProfileResponse['otakuShowcase'];
+};
+
+function formatCount(value: number, singular: string, plural: string): string {
+  const normalizedValue = value.toLocaleString('pt-BR');
+  return `${normalizedValue} ${value === 1 ? singular : plural}`;
+}
+
+export function OtakuShowcaseCard({ showcase }: OtakuShowcaseCardProps) {
+  if (!showcase) {
+    return (
+      <Card data-testid="otaku-showcase-card">
+        <div className="space-y-5">
+          <SectionHeading
+            eyebrow="Anime e manga"
+            title="Showcase otaku"
+            description="Espaco reservado para obras destacadas e consumo publico quando o usuario decidir expor esse repertorio no perfil."
+          />
+
+          <div
+            data-testid="otaku-showcase-empty"
+            className="rounded-control border border-border bg-background-tertiary/65 px-4 py-4 text-sm text-secondary"
+          >
+            <p className="font-medium text-primary">
+              Ainda nao ha showcase anime/manga publico neste perfil.
+            </p>
+            <p className="mt-2 leading-6">
+              Quando o usuario destacar obras ou consumo atual de forma explicita, esse resumo
+              aparece aqui sem abrir uma watchlist completa.
+            </p>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="otaku-showcase-card">
+      <div className="space-y-5">
+        <SectionHeading
+          eyebrow="Anime e manga"
+          title="Showcase otaku"
+          description="Recorte publico de obras e consumo atual que complementa a identidade gamer sem dominar o perfil."
+        />
+
+        <div className="flex flex-wrap gap-2">
+          <Badge tone="neutral">
+            {formatCount(showcase.featured.length, 'destaque publico', 'destaques publicos')}
+          </Badge>
+          <Badge tone="neutral">
+            {formatCount(showcase.consumingCount, 'obra em consumo', 'obras em consumo')}
+          </Badge>
+          <Badge tone="neutral">
+            {formatCount(showcase.completedCount, 'obra concluida', 'obras concluidas')}
+          </Badge>
+        </div>
+
+        <ul className="grid gap-3 sm:grid-cols-3">
+          {showcase.featured.map((item) => (
+            <li
+              key={item.id}
+              data-testid="otaku-showcase-featured-item"
+              className="overflow-hidden rounded-control border border-border bg-background-tertiary/70"
+            >
+              <div className="relative h-36 w-full">
+                {item.coverUrl ? (
+                  <Image
+                    src={item.coverUrl}
+                    alt={item.title}
+                    fill
+                    sizes="(min-width: 640px) 33vw, 100vw"
+                    className="object-cover"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center bg-background-primary text-xs uppercase tracking-[0.25em] text-secondary">
+                    Sem capa
+                  </div>
+                )}
+              </div>
+
+              <div className="space-y-3 px-4 py-4">
+                <Badge tone="neutral">{item.kind}</Badge>
+                <p className="line-clamp-2 text-sm font-semibold leading-6 text-primary">
+                  {item.title}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <div
+          data-testid="otaku-showcase-consuming"
+          className="rounded-control border border-border bg-background-secondary/50 px-4 py-4"
+        >
+          <p className="text-xs uppercase tracking-[0.3em] text-secondary">Consumindo agora</p>
+          <p className="mt-2 text-sm leading-6 text-secondary">
+            {showcase.consumingNow.length > 0
+              ? showcase.consumingNow.map((item) => item.title).join(', ')
+              : 'Sem obra em consumo publico neste momento.'}
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/profile-page-content.tsx
+++ b/frontend/src/components/profile/profile-page-content.tsx
@@ -6,6 +6,7 @@ import { FriendsList } from '@/components/friends/friends-list';
 import { Card } from '@/components/ui/card';
 import { GamerCard } from '@/components/profile/gamer-card';
 import { GameLibraryPreview } from '@/components/profile/game-library-preview';
+import { OtakuShowcaseCard } from '@/components/profile/otaku-showcase-card';
 import { ProfileShareButton } from '@/components/profile/profile-share-button';
 import { ProfileSkeleton } from '@/components/profile/profile-skeleton';
 import { ProfileStats } from '@/components/profile/profile-stats';
@@ -93,6 +94,7 @@ export function ProfilePageContent({ username }: ProfilePageContentProps) {
           games={profileQuery.data.gameLibrary}
         />
       </div>
+      <OtakuShowcaseCard showcase={profileQuery.data.otakuShowcase} />
       <FriendsList
         userId={profileQuery.data.id}
         title={`Amigos de @${profileQuery.data.username}`}

--- a/frontend/src/schemas/profile.ts
+++ b/frontend/src/schemas/profile.ts
@@ -31,6 +31,22 @@ export const socialContinuitySchema = z.object({
   strongestFriendOffensive: strongestFriendOffensiveSchema.nullable(),
 });
 
+export const otakuShowcaseItemSchema = z.object({
+  id: z.string().min(1),
+  kind: z.enum(['ANIME', 'MANGA']),
+  title: z.string().min(1),
+  coverUrl: z.string().nullable(),
+});
+
+export const otakuShowcaseSchema = z
+  .object({
+    featured: z.array(otakuShowcaseItemSchema),
+    consumingNow: z.array(otakuShowcaseItemSchema),
+    consumingCount: z.number().int().min(0),
+    completedCount: z.number().int().min(0),
+  })
+  .nullable();
+
 export const profileResponseSchema = z.object({
   id: z.string().min(1),
   username: z.string().min(1),
@@ -73,6 +89,7 @@ export const profileResponseSchema = z.object({
     }),
   ),
   socialContinuity: socialContinuitySchema,
+  otakuShowcase: otakuShowcaseSchema,
 });
 
 export const profileUpdateRequestSchema = z.object({

--- a/frontend/tests/unit/components/app-shell-route-warmup.test.tsx
+++ b/frontend/tests/unit/components/app-shell-route-warmup.test.tsx
@@ -108,6 +108,7 @@ describe('AppShellRouteWarmup', () => {
         activeFriendOffensiveCount: 0,
         strongestFriendOffensive: null,
       },
+      otakuShowcase: null,
     });
   });
 

--- a/frontend/tests/unit/components/friend-button.test.tsx
+++ b/frontend/tests/unit/components/friend-button.test.tsx
@@ -84,6 +84,7 @@ function createProfileFixture({
       activeFriendOffensiveCount: 0,
       strongestFriendOffensive: null,
     },
+    otakuShowcase: null,
   };
 }
 

--- a/frontend/tests/unit/components/friend-request-card.test.tsx
+++ b/frontend/tests/unit/components/friend-request-card.test.tsx
@@ -76,6 +76,7 @@ function createProfileFixture({
       activeFriendOffensiveCount: 0,
       strongestFriendOffensive: null,
     },
+    otakuShowcase: null,
   };
 }
 

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -43,6 +43,7 @@ const profileFixture: ProfileResponse = {
       lastQualifiedAt: '2026-03-29T00:00:00.000Z',
     },
   },
+  otakuShowcase: null,
 };
 
 describe('GamerCard', () => {

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -110,6 +110,7 @@ describe('IntegrationsPageContent', () => {
         activeFriendOffensiveCount: 0,
         strongestFriendOffensive: null,
       },
+      otakuShowcase: null,
     });
 
     renderWithQuery(<IntegrationsPageContent />);

--- a/frontend/tests/unit/components/library-page-content.test.tsx
+++ b/frontend/tests/unit/components/library-page-content.test.tsx
@@ -90,6 +90,7 @@ const profileFixture: ProfileResponse = {
     activeFriendOffensiveCount: 0,
     strongestFriendOffensive: null,
   },
+  otakuShowcase: null,
 };
 
 function renderWithQuery(ui: ReactElement) {

--- a/frontend/tests/unit/components/otaku-showcase-card.test.tsx
+++ b/frontend/tests/unit/components/otaku-showcase-card.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { OtakuShowcaseCard } from '@/components/profile/otaku-showcase-card';
+import { type ProfileResponse } from '@/schemas/profile';
+
+type OtakuShowcaseFixture = ProfileResponse['otakuShowcase'];
+
+describe('OtakuShowcaseCard', () => {
+  it('renders a compact social showcase when public entries exist', () => {
+    const showcase: OtakuShowcaseFixture = {
+      featured: [
+        {
+          id: 'media-1',
+          kind: 'ANIME',
+          title: 'Sousou no Frieren',
+          coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+        },
+        {
+          id: 'media-2',
+          kind: 'MANGA',
+          title: 'Blue Lock',
+          coverUrl: null,
+        },
+      ],
+      consumingNow: [
+        {
+          id: 'media-2',
+          kind: 'MANGA',
+          title: 'Blue Lock',
+          coverUrl: null,
+        },
+      ],
+      consumingCount: 1,
+      completedCount: 1,
+    };
+
+    render(<OtakuShowcaseCard showcase={showcase} />);
+
+    expect(screen.getByTestId('otaku-showcase-card')).toBeInTheDocument();
+    expect(screen.getByText(/showcase otaku/i)).toBeInTheDocument();
+    expect(screen.getByText(/sousou no frieren/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/blue lock/i)).toHaveLength(2);
+    expect(screen.getByText(/2 destaques publicos/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 obra em consumo/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 obra concluida/i)).toBeInTheDocument();
+  });
+
+  it('renders an honest empty state when the profile has no public showcase', () => {
+    render(<OtakuShowcaseCard showcase={null} />);
+
+    expect(screen.getByTestId('otaku-showcase-card')).toBeInTheDocument();
+    expect(screen.getByTestId('otaku-showcase-empty')).toBeInTheDocument();
+    expect(
+      screen.getByText(/ainda nao ha showcase anime\/manga publico neste perfil/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -88,6 +88,32 @@ const profileFixture: ProfileResponse = {
       lastQualifiedAt: '2026-03-29T00:00:00.000Z',
     },
   },
+  otakuShowcase: {
+    featured: [
+      {
+        id: 'media-1',
+        kind: 'ANIME',
+        title: 'Sousou no Frieren',
+        coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+      },
+      {
+        id: 'media-2',
+        kind: 'MANGA',
+        title: 'Blue Lock',
+        coverUrl: null,
+      },
+    ],
+    consumingNow: [
+      {
+        id: 'media-2',
+        kind: 'MANGA',
+        title: 'Blue Lock',
+        coverUrl: null,
+      },
+    ],
+    consumingCount: 1,
+    completedCount: 1,
+  },
 };
 
 function renderWithQuery(ui: ReactElement) {
@@ -160,6 +186,10 @@ describe('ProfilePageContent', () => {
     expect(within(libraryPreview).getByText(/1 jogo no payload atual/i)).toBeInTheDocument();
     const libraryCard = within(libraryPreview).getByTestId('profile-library-game');
     expect(within(libraryCard).getByText(/120h jogadas/i)).toBeInTheDocument();
+    expect(screen.getByTestId('otaku-showcase-card')).toBeInTheDocument();
+    expect(screen.getByText(/showcase otaku/i)).toBeInTheDocument();
+    expect(screen.getByText(/sousou no frieren/i)).toBeInTheDocument();
+    expect(screen.getByTestId('otaku-showcase-consuming')).toHaveTextContent(/blue lock/i);
   });
 
   it('renders not found state', async () => {

--- a/frontend/tests/unit/components/profile-settings-form.test.tsx
+++ b/frontend/tests/unit/components/profile-settings-form.test.tsx
@@ -109,6 +109,7 @@ describe('ProfileSettingsForm', () => {
         activeFriendOffensiveCount: 0,
         strongestFriendOffensive: null,
       },
+      otakuShowcase: null,
     });
     vi.stubGlobal('navigator', {
       clipboard: {

--- a/frontend/tests/unit/lib/public-library-share.test.ts
+++ b/frontend/tests/unit/lib/public-library-share.test.ts
@@ -65,6 +65,7 @@ const profileFixture: ProfileResponse = {
       lastQualifiedAt: '2026-03-29T00:00:00.000Z',
     },
   },
+  otakuShowcase: null,
 };
 
 const originalNextPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;

--- a/frontend/tests/unit/lib/public-profile-share.test.ts
+++ b/frontend/tests/unit/lib/public-profile-share.test.ts
@@ -58,6 +58,7 @@ const profileFixture: ProfileResponse = {
       lastQualifiedAt: '2026-03-29T00:00:00.000Z',
     },
   },
+  otakuShowcase: null,
 };
 
 const originalNextPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;

--- a/frontend/tests/unit/services/profile.test.ts
+++ b/frontend/tests/unit/services/profile.test.ts
@@ -53,6 +53,7 @@ describe('profile service', () => {
             activeFriendOffensiveCount: 0,
             strongestFriendOffensive: null,
           },
+          otakuShowcase: null,
         }),
         {
           status: 200,


### PR DESCRIPTION
## Resumo
Implementa o primeiro slice funcional do `otakuShowcase` no perfil público, alinhado à modelagem da `#229` e ao planejamento da `#230`. A entrega adiciona uma fonte de verdade mínima no backend, expõe um resumo pequeno em `GET /profiles/:username` e renderiza um card compacto abaixo de stats/library, sem provider externo e sem watchlist pública completa.

## O que foi alterado
- Adicionada modelagem mínima no Prisma com `MediaTitle` e `UserMediaEntry`, incluindo migration e seed de dados de showcase.
- Criado o `otakuShowcaseService` para resumir apenas entradas públicas marcadas por `showcaseRank`.
- Estendido o payload de `GET /profiles/:username` com `otakuShowcase` anulável.
- Estendido o schema de profile no frontend para validar `otakuShowcase`.
- Adicionado o componente `OtakuShowcaseCard` e integrado o card ao perfil público abaixo da faixa de stats/library.
- Atualizados testes de backend e frontend para o novo contrato e para o fallback honesto sem showcase.

## Motivação
A trilha arquitetural já havia fechado que o perfil é a primeira superfície correta para anime/otaku no CLUTCH, desde que o showcase nasça pequeno, opt-in e complementar à identidade gamer. Esta PR materializa esse recorte mínimo sem abrir feed, provider ou um rastreador público completo.

## Como validar
- No diretório `backend`:
  - `npm exec prisma generate`
  - `npm run test -- tests/unit/services/otaku-showcase.service.test.ts tests/integration/routes/profile.routes.test.ts`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- No diretório `frontend`:
  - `npm run test -- tests/unit/components/otaku-showcase-card.test.tsx tests/unit/components/profile-page-content.test.tsx tests/unit/components/gamer-card.test.tsx tests/unit/services/profile.test.ts`
  - `npm run test -- tests/unit/components/app-shell-route-warmup.test.tsx tests/unit/components/friend-button.test.tsx tests/unit/components/friend-request-card.test.tsx tests/unit/components/integrations-page-content.test.tsx tests/unit/components/library-page-content.test.tsx tests/unit/components/profile-settings-form.test.tsx tests/unit/lib/public-library-share.test.ts tests/unit/lib/public-profile-share.test.ts`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Smoke real em `localhost` não foi concluído nesta sessão porque não havia stack ativa nem `DATABASE_URL` local.

## Riscos e impactos
- Baixo risco de escopo: a mudança fica restrita ao contrato de profile, seed/migration mínima e um card complementar no perfil.
- O contrato de `GET /profiles/:username` mudou e agora exige `otakuShowcase`, embora ele possa vir como `null`.
- O teste `tests/integration/prisma.seed.test.ts` continua dependente de ambiente com banco configurado; nesta sessão ele falhou por ausência de `DATABASE_URL`, não por regressão funcional.
- O lint do backend segue emitindo warnings preexistentes em `backend/src/config/rate-limit.ts`.

## Evidências
- Não há evidências anexadas nesta PR.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #261
Refs #226
Refs #229
Refs #230