### PR TITLE
feat(communities): implementar slice mínimo de comunidade pública

### DIFF
--- a/backend/prisma/migrations/20260425133000_add_public_communities/migration.sql
+++ b/backend/prisma/migrations/20260425133000_add_public_communities/migration.sql
@@ -1,0 +1,36 @@
+CREATE TYPE "CommunityVisibility" AS ENUM ('PUBLIC');
+CREATE TYPE "CommunityStatus" AS ENUM ('ACTIVE', 'ARCHIVED');
+CREATE TYPE "CommunityMemberRole" AS ENUM ('OWNER', 'MEMBER');
+
+CREATE TABLE "communities" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "visibility" "CommunityVisibility" NOT NULL DEFAULT 'PUBLIC',
+    "status" "CommunityStatus" NOT NULL DEFAULT 'ACTIVE',
+    "ownerUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "communities_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "community_members" (
+    "id" TEXT NOT NULL,
+    "communityId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "CommunityMemberRole" NOT NULL DEFAULT 'MEMBER',
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "community_members_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "communities_slug_key" ON "communities"("slug");
+CREATE INDEX "communities_status_visibility_createdAt_idx" ON "communities"("status", "visibility", "createdAt");
+CREATE INDEX "community_members_userId_idx" ON "community_members"("userId");
+CREATE UNIQUE INDEX "community_members_communityId_userId_key" ON "community_members"("communityId", "userId");
+
+ALTER TABLE "communities" ADD CONSTRAINT "communities_ownerUserId_fkey" FOREIGN KEY ("ownerUserId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_members" ADD CONSTRAINT "community_members_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "communities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_members" ADD CONSTRAINT "community_members_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -76,6 +76,20 @@ enum MediaConsumptionStatus {
   DROPPED
 }
 
+enum CommunityVisibility {
+  PUBLIC
+}
+
+enum CommunityStatus {
+  ACTIVE
+  ARCHIVED
+}
+
+enum CommunityMemberRole {
+  OWNER
+  MEMBER
+}
+
 // ── User ─────────────────────────────────────────────────────
 
 model User {
@@ -104,6 +118,8 @@ model User {
   sentGameInvites      GameInvite[]          @relation("GameInviteSender")
   receivedGameInvites  GameInvite[]          @relation("GameInviteReceiver")
   mediaEntries         UserMediaEntry[]
+  ownedCommunities     Community[]           @relation("CommunityOwner")
+  communityMemberships CommunityMember[]
 
   @@map("users")
 }
@@ -227,6 +243,41 @@ model UserMediaEntry {
   @@unique([userId, mediaTitleId])
   @@index([userId, showcaseRank])
   @@map("user_media_entries")
+}
+
+// ── Community ────────────────────────────────────────────────
+
+model Community {
+  id          String              @id @default(uuid())
+  slug        String              @unique
+  name        String
+  description String?
+  visibility  CommunityVisibility @default(PUBLIC)
+  status      CommunityStatus     @default(ACTIVE)
+  ownerUserId String
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+
+  owner   User              @relation("CommunityOwner", fields: [ownerUserId], references: [id], onDelete: Cascade)
+  members CommunityMember[]
+
+  @@index([status, visibility, createdAt])
+  @@map("communities")
+}
+
+model CommunityMember {
+  id          String              @id @default(uuid())
+  communityId String
+  userId      String
+  role        CommunityMemberRole @default(MEMBER)
+  joinedAt    DateTime            @default(now())
+
+  community Community @relation(fields: [communityId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([communityId, userId])
+  @@index([userId])
+  @@map("community_members")
 }
 
 // ── Post ─────────────────────────────────────────────────────

--- a/backend/src/api/routes/communities.routes.ts
+++ b/backend/src/api/routes/communities.routes.ts
@@ -1,0 +1,165 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { extractBearerToken, type VerifiedJwtPayload } from '../../config/jwt';
+import {
+  communityService,
+  CommunityServiceError,
+} from '../../core/services/community.service';
+
+const slugParamsSchema = z.object({
+  slug: z.string().trim().min(1).max(80),
+});
+
+const createCommunitySchema = z.object({
+  name: z.string().trim().min(3).max(80),
+  description: z.string().trim().max(240).optional(),
+});
+
+function resolveOptionalViewerUserId(request: FastifyRequest): string | null {
+  const token = extractBearerToken(request.headers.authorization);
+
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const payload = request.server.verifyAccessToken(token) as VerifiedJwtPayload;
+    return payload.id;
+  } catch {
+    return null;
+  }
+}
+
+function sendCommunityServiceError(
+  error: CommunityServiceError,
+  reply: FastifyReply,
+): FastifyReply {
+  const statusByCode: Record<CommunityServiceError['code'], number> = {
+    COMMUNITY_NOT_FOUND: 404,
+    COMMUNITY_SLUG_CONFLICT: 409,
+    COMMUNITY_ALREADY_JOINED: 409,
+    COMMUNITY_OWNER_CANNOT_LEAVE: 403,
+    COMMUNITY_MEMBERSHIP_NOT_FOUND: 404,
+  };
+
+  return reply.status(statusByCode[error.code]).send({ message: error.message });
+}
+
+export async function communityRoutes(app: FastifyInstance): Promise<void> {
+  app.get('/', async () => {
+    const communities = await communityService.listPublicCommunities();
+
+    return { communities };
+  });
+
+  app.post(
+    '/',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const result = createCommunitySchema.safeParse(request.body);
+
+      if (!result.success) {
+        return reply.status(400).send({
+          message: 'Dados inválidos.',
+          errors: result.error.flatten(),
+        });
+      }
+
+      try {
+        const community = await communityService.createPublicCommunity({
+          ownerUserId: request.userId,
+          name: result.data.name,
+          description: result.data.description ?? null,
+        });
+
+        return reply.status(201).send({ community });
+      } catch (error) {
+        if (error instanceof CommunityServiceError) {
+          return sendCommunityServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.get<{ Params: { slug: string } }>('/:slug', async (request, reply) => {
+    const params = slugParamsSchema.safeParse(request.params);
+
+    if (!params.success) {
+      return reply.status(400).send({
+        message: 'Parâmetros inválidos.',
+        errors: params.error.flatten(),
+      });
+    }
+
+    try {
+      const community = await communityService.getPublicCommunity(
+        params.data.slug,
+        resolveOptionalViewerUserId(request),
+      );
+
+      return { community };
+    } catch (error) {
+      if (error instanceof CommunityServiceError) {
+        return sendCommunityServiceError(error, reply);
+      }
+
+      throw error;
+    }
+  });
+
+  app.post<{ Params: { slug: string } }>(
+    '/:slug/join',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = slugParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const community = await communityService.joinCommunity(params.data.slug, request.userId);
+
+        return reply.status(200).send({ community });
+      } catch (error) {
+        if (error instanceof CommunityServiceError) {
+          return sendCommunityServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.delete<{ Params: { slug: string } }>(
+    '/:slug/membership',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = slugParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const community = await communityService.leaveCommunity(params.data.slug, request.userId);
+
+        return reply.status(200).send({ community });
+      } catch (error) {
+        if (error instanceof CommunityServiceError) {
+          return sendCommunityServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import { integrationRoutes } from './api/routes/integrations.routes';
 import { postRoutes } from './api/routes/posts.routes';
 import { notificationRoutes } from './api/routes/notifications.routes';
 import { uploadRoutes } from './api/routes/uploads.routes';
+import { communityRoutes } from './api/routes/communities.routes';
 import { authenticate } from './api/middlewares/authenticate';
 import {
   runReadinessChecks,
@@ -179,6 +180,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await app.register(postRoutes, { prefix: '/posts' });
   await app.register(notificationRoutes, { prefix: '/notifications' });
   await app.register(uploadRoutes, { prefix: '/uploads' });
+  await app.register(communityRoutes, { prefix: '/communities' });
 
   await app.ready();
 

--- a/backend/src/core/repositories/community.repository.ts
+++ b/backend/src/core/repositories/community.repository.ts
@@ -1,0 +1,208 @@
+import {
+  CommunityMemberRole,
+  CommunityStatus,
+  CommunityVisibility,
+  type Prisma,
+} from '@prisma/client';
+import { prisma } from '../../infra/database/client';
+
+const communitySelect = {
+  id: true,
+  slug: true,
+  name: true,
+  description: true,
+  visibility: true,
+  status: true,
+  ownerUserId: true,
+  createdAt: true,
+  updatedAt: true,
+  owner: {
+    select: {
+      id: true,
+      username: true,
+      profile: {
+        select: {
+          displayName: true,
+          avatarUrl: true,
+        },
+      },
+    },
+  },
+  _count: {
+    select: {
+      members: true,
+    },
+  },
+} satisfies Prisma.CommunitySelect;
+
+type CommunityRecord = Prisma.CommunityGetPayload<{ select: typeof communitySelect }>;
+
+export type CommunityOwnerSummary = {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+export type CommunitySummary = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  visibility: CommunityVisibility;
+  status: CommunityStatus;
+  owner: CommunityOwnerSummary;
+  memberCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type CommunityDetail = CommunitySummary & {
+  viewerMembershipRole: CommunityMemberRole | null;
+};
+
+export type CreateCommunityInput = {
+  ownerUserId: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+};
+
+function toSummary(record: CommunityRecord): CommunitySummary {
+  return {
+    id: record.id,
+    slug: record.slug,
+    name: record.name,
+    description: record.description,
+    visibility: record.visibility,
+    status: record.status,
+    owner: {
+      id: record.owner.id,
+      username: record.owner.username,
+      displayName: record.owner.profile?.displayName ?? null,
+      avatarUrl: record.owner.profile?.avatarUrl ?? null,
+    },
+    memberCount: record._count.members,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+export const communityRepository = {
+  async create(input: CreateCommunityInput): Promise<CommunitySummary> {
+    const community = await prisma.$transaction(async (tx) => {
+      const created = await tx.community.create({
+        data: {
+          slug: input.slug,
+          name: input.name,
+          description: input.description ?? null,
+          visibility: CommunityVisibility.PUBLIC,
+          status: CommunityStatus.ACTIVE,
+          ownerUserId: input.ownerUserId,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      await tx.communityMember.create({
+        data: {
+          communityId: created.id,
+          userId: input.ownerUserId,
+          role: CommunityMemberRole.OWNER,
+        },
+      });
+
+      return tx.community.findUniqueOrThrow({
+        where: { id: created.id },
+        select: communitySelect,
+      });
+    });
+
+    return toSummary(community);
+  },
+
+  async findPublicActive(limit = 50): Promise<CommunitySummary[]> {
+    const communities = await prisma.community.findMany({
+      where: {
+        visibility: CommunityVisibility.PUBLIC,
+        status: CommunityStatus.ACTIVE,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: limit,
+      select: communitySelect,
+    });
+
+    return communities.map(toSummary);
+  },
+
+  async findPublicActiveBySlug(slug: string): Promise<CommunitySummary | null> {
+    const community = await prisma.community.findFirst({
+      where: {
+        slug,
+        visibility: CommunityVisibility.PUBLIC,
+        status: CommunityStatus.ACTIVE,
+      },
+      select: communitySelect,
+    });
+
+    return community ? toSummary(community) : null;
+  },
+
+  async findBySlug(slug: string): Promise<CommunitySummary | null> {
+    const community = await prisma.community.findUnique({
+      where: { slug },
+      select: communitySelect,
+    });
+
+    return community ? toSummary(community) : null;
+  },
+
+  async findMembershipRole(
+    communityId: string,
+    userId: string,
+  ): Promise<CommunityMemberRole | null> {
+    const membership = await prisma.communityMember.findUnique({
+      where: {
+        communityId_userId: {
+          communityId,
+          userId,
+        },
+      },
+      select: {
+        role: true,
+      },
+    });
+
+    return membership?.role ?? null;
+  },
+
+  async addMember(communityId: string, userId: string): Promise<CommunityMemberRole> {
+    const membership = await prisma.communityMember.create({
+      data: {
+        communityId,
+        userId,
+        role: CommunityMemberRole.MEMBER,
+      },
+      select: {
+        role: true,
+      },
+    });
+
+    return membership.role;
+  },
+
+  async removeMember(communityId: string, userId: string): Promise<number> {
+    const result = await prisma.communityMember.deleteMany({
+      where: {
+        communityId,
+        userId,
+        role: CommunityMemberRole.MEMBER,
+      },
+    });
+
+    return result.count;
+  },
+};

--- a/backend/src/core/services/community.service.ts
+++ b/backend/src/core/services/community.service.ts
@@ -1,0 +1,197 @@
+import { CommunityMemberRole } from '@prisma/client';
+import {
+  communityRepository,
+  type CommunityDetail,
+  type CommunitySummary,
+} from '../repositories/community.repository';
+
+export type CommunityServiceErrorCode =
+  | 'COMMUNITY_NOT_FOUND'
+  | 'COMMUNITY_SLUG_CONFLICT'
+  | 'COMMUNITY_ALREADY_JOINED'
+  | 'COMMUNITY_OWNER_CANNOT_LEAVE'
+  | 'COMMUNITY_MEMBERSHIP_NOT_FOUND';
+
+export class CommunityServiceError extends Error {
+  readonly code: CommunityServiceErrorCode;
+
+  constructor(code: CommunityServiceErrorCode, message: string) {
+    super(message);
+    this.name = 'CommunityServiceError';
+    this.code = code;
+  }
+}
+
+export type CreateCommunityServiceInput = {
+  ownerUserId: string;
+  name: string;
+  description?: string | null;
+};
+
+function normalizeSlug(input: string): string {
+  const normalized = input
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+
+  return normalized.length > 0 ? normalized : 'community';
+}
+
+async function withViewerRole(
+  community: CommunitySummary,
+  viewerUserId?: string | null,
+): Promise<CommunityDetail> {
+  if (!viewerUserId) {
+    return {
+      ...community,
+      viewerMembershipRole: null,
+    };
+  }
+
+  const viewerMembershipRole = await communityRepository.findMembershipRole(
+    community.id,
+    viewerUserId,
+  );
+
+  return {
+    ...community,
+    viewerMembershipRole,
+  };
+}
+
+export const communityService = {
+  normalizeSlug,
+
+  async listPublicCommunities(): Promise<CommunitySummary[]> {
+    return communityRepository.findPublicActive();
+  },
+
+  async getPublicCommunity(
+    slug: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityDetail> {
+    const community = await communityRepository.findPublicActiveBySlug(slug);
+
+    if (!community) {
+      throw new CommunityServiceError(
+        'COMMUNITY_NOT_FOUND',
+        'Comunidade pública não encontrada.',
+      );
+    }
+
+    return withViewerRole(community, viewerUserId);
+  },
+
+  async createPublicCommunity(input: CreateCommunityServiceInput): Promise<CommunityDetail> {
+    const slug = normalizeSlug(input.name);
+    const description = input.description?.trim();
+    const existingCommunity = await communityRepository.findBySlug(slug);
+
+    if (existingCommunity) {
+      throw new CommunityServiceError(
+        'COMMUNITY_SLUG_CONFLICT',
+        'Já existe uma comunidade com esse nome.',
+      );
+    }
+
+    const community = await communityRepository.create({
+      ownerUserId: input.ownerUserId,
+      slug,
+      name: input.name,
+      description: description && description.length > 0 ? description : null,
+    });
+
+    return {
+      ...community,
+      viewerMembershipRole: CommunityMemberRole.OWNER,
+    };
+  },
+
+  async joinCommunity(slug: string, userId: string): Promise<CommunityDetail> {
+    const community = await communityRepository.findPublicActiveBySlug(slug);
+
+    if (!community) {
+      throw new CommunityServiceError(
+        'COMMUNITY_NOT_FOUND',
+        'Comunidade pública não encontrada.',
+      );
+    }
+
+    const existingRole = await communityRepository.findMembershipRole(community.id, userId);
+
+    if (existingRole) {
+      throw new CommunityServiceError(
+        'COMMUNITY_ALREADY_JOINED',
+        'Usuário já participa desta comunidade.',
+      );
+    }
+
+    await communityRepository.addMember(community.id, userId);
+    const updatedCommunity = await communityRepository.findPublicActiveBySlug(slug);
+
+    if (!updatedCommunity) {
+      throw new CommunityServiceError(
+        'COMMUNITY_NOT_FOUND',
+        'Comunidade pública não encontrada.',
+      );
+    }
+
+    return {
+      ...updatedCommunity,
+      viewerMembershipRole: CommunityMemberRole.MEMBER,
+    };
+  },
+
+  async leaveCommunity(slug: string, userId: string): Promise<CommunityDetail> {
+    const community = await communityRepository.findPublicActiveBySlug(slug);
+
+    if (!community) {
+      throw new CommunityServiceError(
+        'COMMUNITY_NOT_FOUND',
+        'Comunidade pública não encontrada.',
+      );
+    }
+
+    const existingRole = await communityRepository.findMembershipRole(community.id, userId);
+
+    if (existingRole === CommunityMemberRole.OWNER) {
+      throw new CommunityServiceError(
+        'COMMUNITY_OWNER_CANNOT_LEAVE',
+        'O dono da comunidade não pode sair pelo fluxo simples de membership.',
+      );
+    }
+
+    if (!existingRole) {
+      throw new CommunityServiceError(
+        'COMMUNITY_MEMBERSHIP_NOT_FOUND',
+        'Membership não encontrado para esta comunidade.',
+      );
+    }
+
+    const removedCount = await communityRepository.removeMember(community.id, userId);
+
+    if (removedCount === 0) {
+      throw new CommunityServiceError(
+        'COMMUNITY_MEMBERSHIP_NOT_FOUND',
+        'Membership não encontrado para esta comunidade.',
+      );
+    }
+
+    const updatedCommunity = await communityRepository.findPublicActiveBySlug(slug);
+
+    if (!updatedCommunity) {
+      throw new CommunityServiceError(
+        'COMMUNITY_NOT_FOUND',
+        'Comunidade pública não encontrada.',
+      );
+    }
+
+    return {
+      ...updatedCommunity,
+      viewerMembershipRole: null,
+    };
+  },
+};

--- a/backend/src/core/services/community.service.ts
+++ b/backend/src/core/services/community.service.ts
@@ -1,4 +1,5 @@
 import { CommunityMemberRole } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import {
   communityRepository,
   type CommunityDetail,
@@ -38,6 +39,10 @@ function normalizeSlug(input: string): string {
     .slice(0, 64);
 
   return normalized.length > 0 ? normalized : 'community';
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return error instanceof PrismaClientKnownRequestError && error.code === 'P2002';
 }
 
 async function withViewerRole(
@@ -97,12 +102,25 @@ export const communityService = {
       );
     }
 
-    const community = await communityRepository.create({
-      ownerUserId: input.ownerUserId,
-      slug,
-      name: input.name,
-      description: description && description.length > 0 ? description : null,
-    });
+    let community: CommunitySummary;
+
+    try {
+      community = await communityRepository.create({
+        ownerUserId: input.ownerUserId,
+        slug,
+        name: input.name,
+        description: description && description.length > 0 ? description : null,
+      });
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new CommunityServiceError(
+          'COMMUNITY_SLUG_CONFLICT',
+          'Já existe uma comunidade com esse nome.',
+        );
+      }
+
+      throw error;
+    }
 
     return {
       ...community,
@@ -129,7 +147,18 @@ export const communityService = {
       );
     }
 
-    await communityRepository.addMember(community.id, userId);
+    try {
+      await communityRepository.addMember(community.id, userId);
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new CommunityServiceError(
+          'COMMUNITY_ALREADY_JOINED',
+          'Usuário já participa desta comunidade.',
+        );
+      }
+
+      throw error;
+    }
     const updatedCommunity = await communityRepository.findPublicActiveBySlug(slug);
 
     if (!updatedCommunity) {

--- a/backend/tests/integration/routes/communities.routes.test.ts
+++ b/backend/tests/integration/routes/communities.routes.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommunityMemberRole, CommunityStatus, CommunityVisibility } from '@prisma/client';
+import { buildApp, generateTestToken } from '../../helpers/build-app';
+import {
+  communityService,
+  CommunityServiceError,
+} from '@/core/services/community.service';
+
+vi.mock('@/core/services/community.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/services/community.service')>();
+
+  return {
+    ...actual,
+    communityService: {
+      listPublicCommunities: vi.fn(),
+      getPublicCommunity: vi.fn(),
+      createPublicCommunity: vi.fn(),
+      joinCommunity: vi.fn(),
+      leaveCommunity: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/infra/integrations/steam/steam.service', () => ({ steamService: {} }));
+vi.mock('@/infra/integrations/igdb/igdb.service', () => ({ igdbService: {} }));
+vi.mock('@/infra/integrations/epic/epic.service', () => ({ epicService: {} }));
+
+const mockCommunity = {
+  id: 'community-id-1',
+  slug: 'guilda-dos-speedrunners',
+  name: 'Guilda dos Speedrunners',
+  description: 'Runs, PBs e desafios semanais.',
+  visibility: CommunityVisibility.PUBLIC,
+  status: CommunityStatus.ACTIVE,
+  owner: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+    avatarUrl: null,
+  },
+  memberCount: 12,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+  viewerMembershipRole: null,
+};
+
+describe('Communities Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lista comunidades públicas', async () => {
+    vi.mocked(communityService.listPublicCommunities).mockResolvedValue([mockCommunity]);
+
+    const app = await buildApp();
+    const response = await app.inject({ method: 'GET', url: '/communities' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      communities: [
+        {
+          slug: 'guilda-dos-speedrunners',
+          memberCount: 12,
+        },
+      ],
+    });
+    await app.close();
+  });
+
+  it('retorna detalhe público com viewer autenticado quando token existe', async () => {
+    vi.mocked(communityService.getPublicCommunity).mockResolvedValue({
+      ...mockCommunity,
+      viewerMembershipRole: CommunityMemberRole.MEMBER,
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'GET',
+      url: '/communities/guilda-dos-speedrunners',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityService.getPublicCommunity).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+    await app.close();
+  });
+
+  it('cria comunidade pública autenticada', async () => {
+    vi.mocked(communityService.createPublicCommunity).mockResolvedValue({
+      ...mockCommunity,
+      viewerMembershipRole: CommunityMemberRole.OWNER,
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        name: 'Guilda dos Speedrunners',
+        description: 'Runs, PBs e desafios semanais.',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(communityService.createPublicCommunity).toHaveBeenCalledWith({
+      ownerUserId: 'owner-id-1',
+      name: 'Guilda dos Speedrunners',
+      description: 'Runs, PBs e desafios semanais.',
+    });
+    await app.close();
+  });
+
+  it('retorna 409 ao criar comunidade com slug existente', async () => {
+    vi.mocked(communityService.createPublicCommunity).mockRejectedValue(
+      new CommunityServiceError(
+        'COMMUNITY_SLUG_CONFLICT',
+        'Já existe uma comunidade com esse nome.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        name: 'Guilda dos Speedrunners',
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it('permite entrar em comunidade autenticada', async () => {
+    vi.mocked(communityService.joinCommunity).mockResolvedValue({
+      ...mockCommunity,
+      memberCount: 13,
+      viewerMembershipRole: CommunityMemberRole.MEMBER,
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/join',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityService.joinCommunity).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+    await app.close();
+  });
+
+  it('permite sair de comunidade autenticada', async () => {
+    vi.mocked(communityService.leaveCommunity).mockResolvedValue(mockCommunity);
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/communities/guilda-dos-speedrunners/membership',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityService.leaveCommunity).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+    await app.close();
+  });
+});

--- a/backend/tests/integration/routes/communities.routes.test.ts
+++ b/backend/tests/integration/routes/communities.routes.test.ts
@@ -116,7 +116,7 @@ describe('Communities Routes', () => {
     await app.close();
   });
 
-  it('retorna 409 ao criar comunidade com slug existente', async () => {
+  it('retorna 409 ao criar comunidade com slug existente ou corrida de criação', async () => {
     vi.mocked(communityService.createPublicCommunity).mockRejectedValue(
       new CommunityServiceError(
         'COMMUNITY_SLUG_CONFLICT',
@@ -159,6 +159,26 @@ describe('Communities Routes', () => {
       'guilda-dos-speedrunners',
       'member-id-1',
     );
+    await app.close();
+  });
+
+  it('retorna 409 quando corrida de membership indica usuário já participante', async () => {
+    vi.mocked(communityService.joinCommunity).mockRejectedValue(
+      new CommunityServiceError(
+        'COMMUNITY_ALREADY_JOINED',
+        'Usuário já participa desta comunidade.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/join',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(409);
     await app.close();
   });
 

--- a/backend/tests/unit/services/community.service.test.ts
+++ b/backend/tests/unit/services/community.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CommunityMemberRole, CommunityStatus, CommunityVisibility } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { communityService } from '@/core/services/community.service';
 import { communityRepository, type CommunitySummary } from '@/core/repositories/community.repository';
 
@@ -32,6 +33,14 @@ const baseCommunity: CommunitySummary = {
   createdAt: new Date('2026-04-25T10:00:00.000Z'),
   updatedAt: new Date('2026-04-25T10:00:00.000Z'),
 };
+
+function createUniqueConstraintError(target: string[]): PrismaClientKnownRequestError {
+  return new PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: '5.22.0',
+    meta: { target },
+  });
+}
 
 describe('communityService', () => {
   beforeEach(() => {
@@ -76,6 +85,22 @@ describe('communityService', () => {
     });
   });
 
+  it('traduz corrida de slug único na criação para conflito de domínio', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(null);
+    vi.mocked(communityRepository.create).mockRejectedValue(
+      createUniqueConstraintError(['slug']),
+    );
+
+    await expect(
+      communityService.createPublicCommunity({
+        ownerUserId: 'owner-id-1',
+        name: 'Guilda dos Speedrunners',
+      }),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_SLUG_CONFLICT',
+    });
+  });
+
   it('retorna papel do viewer ao buscar comunidade pública autenticada', async () => {
     vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(baseCommunity);
     vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
@@ -106,6 +131,20 @@ describe('communityService', () => {
     );
     expect(result.memberCount).toBe(2);
     expect(result.viewerMembershipRole).toBe(CommunityMemberRole.MEMBER);
+  });
+
+  it('traduz corrida de membership único ao entrar para conflito de domínio', async () => {
+    vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(null);
+    vi.mocked(communityRepository.addMember).mockRejectedValue(
+      createUniqueConstraintError(['communityId', 'userId']),
+    );
+
+    await expect(
+      communityService.joinCommunity('guilda-dos-speedrunners', 'member-id-1'),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_ALREADY_JOINED',
+    });
   });
 
   it('impede owner de sair pelo fluxo simples de membership', async () => {

--- a/backend/tests/unit/services/community.service.test.ts
+++ b/backend/tests/unit/services/community.service.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommunityMemberRole, CommunityStatus, CommunityVisibility } from '@prisma/client';
+import { communityService } from '@/core/services/community.service';
+import { communityRepository, type CommunitySummary } from '@/core/repositories/community.repository';
+
+vi.mock('@/core/repositories/community.repository', () => ({
+  communityRepository: {
+    create: vi.fn(),
+    findPublicActive: vi.fn(),
+    findPublicActiveBySlug: vi.fn(),
+    findBySlug: vi.fn(),
+    findMembershipRole: vi.fn(),
+    addMember: vi.fn(),
+    removeMember: vi.fn(),
+  },
+}));
+
+const baseCommunity: CommunitySummary = {
+  id: 'community-id-1',
+  slug: 'guilda-dos-speedrunners',
+  name: 'Guilda dos Speedrunners',
+  description: 'Runs, PBs e desafios semanais.',
+  visibility: CommunityVisibility.PUBLIC,
+  status: CommunityStatus.ACTIVE,
+  owner: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+    avatarUrl: null,
+  },
+  memberCount: 1,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+};
+
+describe('communityService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normaliza slug a partir do nome da comunidade', () => {
+    expect(communityService.normalizeSlug('Guilda dos Speedrunners!')).toBe(
+      'guilda-dos-speedrunners',
+    );
+  });
+
+  it('cria comunidade pública com membership OWNER para o criador', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(null);
+    vi.mocked(communityRepository.create).mockResolvedValue(baseCommunity);
+
+    const result = await communityService.createPublicCommunity({
+      ownerUserId: 'owner-id-1',
+      name: 'Guilda dos Speedrunners',
+      description: 'Runs, PBs e desafios semanais.',
+    });
+
+    expect(communityRepository.create).toHaveBeenCalledWith({
+      ownerUserId: 'owner-id-1',
+      slug: 'guilda-dos-speedrunners',
+      name: 'Guilda dos Speedrunners',
+      description: 'Runs, PBs e desafios semanais.',
+    });
+    expect(result.viewerMembershipRole).toBe(CommunityMemberRole.OWNER);
+  });
+
+  it('bloqueia criação com slug já existente', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(baseCommunity);
+
+    await expect(
+      communityService.createPublicCommunity({
+        ownerUserId: 'owner-id-1',
+        name: 'Guilda dos Speedrunners',
+      }),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_SLUG_CONFLICT',
+    });
+  });
+
+  it('retorna papel do viewer ao buscar comunidade pública autenticada', async () => {
+    vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+
+    const result = await communityService.getPublicCommunity(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+
+    expect(result.viewerMembershipRole).toBe(CommunityMemberRole.MEMBER);
+  });
+
+  it('permite entrar em comunidade pública quando usuário ainda não é membro', async () => {
+    vi.mocked(communityRepository.findPublicActiveBySlug)
+      .mockResolvedValueOnce(baseCommunity)
+      .mockResolvedValueOnce({ ...baseCommunity, memberCount: 2 });
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(null);
+    vi.mocked(communityRepository.addMember).mockResolvedValue(CommunityMemberRole.MEMBER);
+
+    const result = await communityService.joinCommunity(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+
+    expect(communityRepository.addMember).toHaveBeenCalledWith(
+      'community-id-1',
+      'member-id-1',
+    );
+    expect(result.memberCount).toBe(2);
+    expect(result.viewerMembershipRole).toBe(CommunityMemberRole.MEMBER);
+  });
+
+  it('impede owner de sair pelo fluxo simples de membership', async () => {
+    vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+
+    await expect(
+      communityService.leaveCommunity('guilda-dos-speedrunners', 'owner-id-1'),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_OWNER_CANNOT_LEAVE',
+    });
+  });
+});

--- a/frontend/src/app/(app)/communities/[slug]/page.tsx
+++ b/frontend/src/app/(app)/communities/[slug]/page.tsx
@@ -1,0 +1,13 @@
+import { CommunityPageContent } from '@/components/communities/community-page-content';
+
+type CommunityPageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export default async function CommunityPage({ params }: CommunityPageProps) {
+  const { slug } = await params;
+
+  return <CommunityPageContent slug={slug} />;
+}

--- a/frontend/src/app/(app)/communities/page.tsx
+++ b/frontend/src/app/(app)/communities/page.tsx
@@ -1,0 +1,5 @@
+import { CommunitiesPageContent } from '@/components/communities/communities-page-content';
+
+export default function CommunitiesPage() {
+  return <CommunitiesPageContent />;
+}

--- a/frontend/src/components/communities/communities-page-content.tsx
+++ b/frontend/src/components/communities/communities-page-content.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  CommunitiesRequestError,
+  createCommunity,
+  fetchCommunities,
+} from '@/services/communities';
+import { CommunityCard } from './community-card';
+
+function resolveMutationErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof CommunitiesRequestError) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export function CommunitiesPageContent() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { status } = useAuth();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [formMessage, setFormMessage] = useState<string | null>(null);
+
+  const communitiesQuery = useQuery({
+    queryKey: ['communities'],
+    queryFn: fetchCommunities,
+  });
+
+  const createCommunityMutation = useMutation({
+    mutationFn: createCommunity,
+    onSuccess: async (community) => {
+      setName('');
+      setDescription('');
+      setFormMessage(null);
+      await queryClient.invalidateQueries({ queryKey: ['communities'] });
+      router.push(`/communities/${community.slug}`);
+    },
+    onError: (error) => {
+      setFormMessage(
+        resolveMutationErrorMessage(error, 'Nao foi possivel criar a comunidade agora.'),
+      );
+    },
+  });
+
+  const isAuthenticated = status === 'authenticated';
+  const canSubmit = isAuthenticated && name.trim().length >= 3 && !createCommunityMutation.isPending;
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit) {
+      return;
+    }
+
+    createCommunityMutation.mutate({
+      name,
+      description: description.trim() || undefined,
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-section">
+      <SectionHeading
+        eyebrow="Comunidades"
+        title="Guildas públicas para pertencer sem virar chat"
+        description="O primeiro slice mantém descoberta simples, identidade básica e membership mínimo. Eventos, chat e governança pesada ficam fora deste recorte."
+      />
+
+      <Card tone="accent">
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+              Criar comunidade pública
+            </p>
+            <h2 className="mt-2 font-display text-2xl font-semibold text-primary">
+              Valide pertencimento com um grupo pequeno
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-secondary">
+              Comunidades nascem públicas, com owner e membros. Sem eventos, chat ou roles
+              avançadas neste slice.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)]">
+            <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+              Nome
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                minLength={3}
+                maxLength={80}
+                placeholder="Guilda dos Speedrunners"
+                className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                disabled={!isAuthenticated || createCommunityMutation.isPending}
+              />
+            </label>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+              Descrição curta
+              <input
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                maxLength={240}
+                placeholder="Runs, PBs e desafios semanais."
+                className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                disabled={!isAuthenticated || createCommunityMutation.isPending}
+              />
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-secondary" role={formMessage ? 'alert' : undefined}>
+              {formMessage ??
+                (isAuthenticated
+                  ? 'O slug é derivado do nome e precisa ser único.'
+                  : 'Entre na sessão para criar uma comunidade pública.')}
+            </p>
+            <Button type="submit" disabled={!canSubmit}>
+              Criar comunidade
+            </Button>
+          </div>
+        </form>
+      </Card>
+
+      {communitiesQuery.isLoading ? (
+        <Card>
+          <p className="text-sm text-secondary">Carregando comunidades públicas...</p>
+        </Card>
+      ) : null}
+
+      {communitiesQuery.isError ? (
+        <Card>
+          <p className="text-sm text-secondary" role="alert">
+            Não foi possível carregar comunidades públicas agora.
+          </p>
+        </Card>
+      ) : null}
+
+      {communitiesQuery.data?.length === 0 ? (
+        <Card>
+          <p className="text-sm leading-6 text-secondary">
+            Ainda não há comunidades públicas. Crie a primeira para validar o fluxo básico
+            de pertencimento.
+          </p>
+        </Card>
+      ) : null}
+
+      {communitiesQuery.data && communitiesQuery.data.length > 0 ? (
+        <div className="grid gap-5 lg:grid-cols-2">
+          {communitiesQuery.data.map((community) => (
+            <CommunityCard key={community.id} community={community} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/communities/community-card.tsx
+++ b/frontend/src/components/communities/community-card.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import type { Community } from '@/schemas/communities';
+
+type CommunityCardProps = {
+  community: Community;
+};
+
+export function CommunityCard({ community }: CommunityCardProps) {
+  const ownerLabel = community.owner.displayName ?? community.owner.username;
+
+  return (
+    <Card className="flex h-full flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Comunidade pública
+          </p>
+          <Link
+            href={`/communities/${community.slug}`}
+            className="mt-2 block font-display text-2xl font-semibold text-primary transition hover:text-accent-cyan"
+          >
+            {community.name}
+          </Link>
+        </div>
+        <Badge tone="success">{community.memberCount} membros</Badge>
+      </div>
+
+      <p className="line-clamp-3 text-sm leading-6 text-secondary">
+        {community.description ??
+          'Espaço público para reunir jogadores em torno de um interesse compartilhado.'}
+      </p>
+
+      <div className="mt-auto flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+        <span className="text-xs uppercase tracking-[0.28em] text-secondary">
+          Owner: {ownerLabel}
+        </span>
+        <Link
+          href={`/communities/${community.slug}`}
+          className="text-sm font-medium text-accent-cyan transition hover:text-primary"
+        >
+          Ver comunidade
+        </Link>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/communities/community-page-content.tsx
+++ b/frontend/src/components/communities/community-page-content.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  CommunitiesRequestError,
+  fetchCommunityBySlug,
+  joinCommunity,
+  leaveCommunity,
+} from '@/services/communities';
+
+type CommunityPageContentProps = {
+  slug: string;
+};
+
+function resolveErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof CommunitiesRequestError) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export function CommunityPageContent({ slug }: CommunityPageContentProps) {
+  const queryClient = useQueryClient();
+  const { status } = useAuth();
+  const communityQuery = useQuery({
+    queryKey: ['communities', slug],
+    queryFn: () => fetchCommunityBySlug(slug),
+  });
+
+  const joinMutation = useMutation({
+    mutationFn: () => joinCommunity(slug),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['communities'] }),
+        queryClient.invalidateQueries({ queryKey: ['communities', slug] }),
+      ]);
+    },
+  });
+
+  const leaveMutation = useMutation({
+    mutationFn: () => leaveCommunity(slug),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['communities'] }),
+        queryClient.invalidateQueries({ queryKey: ['communities', slug] }),
+      ]);
+    },
+  });
+
+  if (communityQuery.isLoading) {
+    return (
+      <Card>
+        <p className="text-sm text-secondary">Carregando comunidade pública...</p>
+      </Card>
+    );
+  }
+
+  if (communityQuery.isError || !communityQuery.data) {
+    return (
+      <Card>
+        <p className="text-sm text-secondary" role="alert">
+          Não foi possível carregar esta comunidade pública.
+        </p>
+        <Link
+          href="/communities"
+          className="mt-4 inline-flex text-sm font-medium text-accent-cyan transition hover:text-primary"
+        >
+          Voltar para comunidades
+        </Link>
+      </Card>
+    );
+  }
+
+  const community = communityQuery.data;
+  const isAuthenticated = status === 'authenticated';
+  const ownerLabel = community.owner.displayName ?? community.owner.username;
+  const isOwner = community.viewerMembershipRole === 'OWNER';
+  const isMember = community.viewerMembershipRole === 'MEMBER';
+  const actionIsPending = joinMutation.isPending || leaveMutation.isPending;
+  const mutationError = joinMutation.error ?? leaveMutation.error;
+
+  return (
+    <div className="flex flex-col gap-section">
+      <SectionHeading
+        eyebrow="Comunidade pública"
+        title={community.name}
+        description={
+          community.description ??
+          'Espaço público para reunir jogadores em torno de um interesse compartilhado.'
+        }
+        actions={
+          <Link
+            href="/communities"
+            className="text-sm font-medium text-accent-cyan transition hover:text-primary"
+          >
+            Ver todas
+          </Link>
+        }
+      />
+
+      <Card tone="accent" className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge tone="success">{community.memberCount} membros</Badge>
+              <Badge tone="neutral">Pública</Badge>
+              {community.viewerMembershipRole ? (
+                <Badge tone="accent">{community.viewerMembershipRole}</Badge>
+              ) : null}
+            </div>
+            <p className="mt-4 text-sm leading-6 text-secondary">
+              Owner: <span className="text-primary">{ownerLabel}</span>
+            </p>
+            <p className="mt-2 text-sm leading-6 text-secondary">
+              Este slice valida leitura pública e membership simples. Eventos, chat e
+              governança avançada ainda não fazem parte desta comunidade.
+            </p>
+          </div>
+
+          <div className="flex min-w-48 flex-col gap-2">
+            {!isAuthenticated ? (
+              <p className="text-sm leading-6 text-secondary">
+                Entre na sessão para participar desta comunidade.
+              </p>
+            ) : isOwner ? (
+              <Button type="button" variant="secondary" disabled>
+                Você é owner
+              </Button>
+            ) : isMember ? (
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={actionIsPending}
+                onClick={() => leaveMutation.mutate()}
+              >
+                Sair da comunidade
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                disabled={actionIsPending}
+                onClick={() => joinMutation.mutate()}
+              >
+                Participar
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {mutationError ? (
+          <p className="text-sm text-status-afk" role="alert">
+            {resolveErrorMessage(mutationError, 'Não foi possível atualizar o membership.')}
+          </p>
+        ) : null}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -95,6 +95,12 @@ export function Sidebar({ isOpen, onClose, className }: SidebarProps) {
       unavailableReason: 'Ainda nao existe uma pagina dedicada de amigos nesta superficie.',
     },
     {
+      label: 'Communities',
+      href: '/communities',
+      tone: pathname.startsWith('/communities') ? 'accent' : 'neutral',
+      description: 'Public guilds and basic membership',
+    },
+    {
       label: 'Notifications',
       href: '/notifications',
       tone: pathname === '/notifications' ? 'accent' : 'neutral',

--- a/frontend/src/schemas/communities.ts
+++ b/frontend/src/schemas/communities.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+export const communityRoleSchema = z.enum(['OWNER', 'MEMBER']);
+export const communityVisibilitySchema = z.enum(['PUBLIC']);
+export const communityStatusSchema = z.enum(['ACTIVE', 'ARCHIVED']);
+
+export const communityOwnerSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+});
+
+export const communitySchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  visibility: communityVisibilitySchema,
+  status: communityStatusSchema,
+  owner: communityOwnerSchema,
+  memberCount: z.number().int().nonnegative(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  viewerMembershipRole: communityRoleSchema.nullable().optional(),
+});
+
+export const communitiesResponseSchema = z.object({
+  communities: z.array(communitySchema),
+});
+
+export const communityResponseSchema = z.object({
+  community: communitySchema,
+});
+
+export const createCommunityRequestSchema = z.object({
+  name: z.string().trim().min(3).max(80),
+  description: z.string().trim().max(240).optional(),
+});
+
+export type CommunityRole = z.infer<typeof communityRoleSchema>;
+export type Community = z.infer<typeof communitySchema>;
+export type CommunitiesResponse = z.infer<typeof communitiesResponseSchema>;
+export type CommunityResponse = z.infer<typeof communityResponseSchema>;
+export type CreateCommunityValues = z.infer<typeof createCommunityRequestSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -9,6 +9,15 @@ export {
   registerSessionSchema,
 } from './auth';
 export {
+  communitiesResponseSchema,
+  communityResponseSchema,
+  communityRoleSchema,
+  communitySchema,
+  communityStatusSchema,
+  communityVisibilitySchema,
+  createCommunityRequestSchema,
+} from './communities';
+export {
   commentContentSchema,
   createPostRequestSchema,
   createPostCommentRequestSchema,

--- a/frontend/src/services/communities.ts
+++ b/frontend/src/services/communities.ts
@@ -1,0 +1,135 @@
+import { apiRequest } from '@/lib/api';
+import {
+  communitiesResponseSchema,
+  communityResponseSchema,
+  createCommunityRequestSchema,
+  type Community,
+  type CreateCommunityValues,
+} from '@/schemas/communities';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+export class CommunitiesRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'CommunitiesRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchCommunities(): Promise<Community[]> {
+  const response = await apiRequest('/communities', {
+    method: 'GET',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar as comunidades.'),
+    );
+  }
+
+  return communitiesResponseSchema.parse(payload).communities;
+}
+
+export async function fetchCommunityBySlug(slug: string): Promise<Community> {
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}`, {
+    method: 'GET',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar esta comunidade.'),
+    );
+  }
+
+  return communityResponseSchema.parse(payload).community;
+}
+
+export async function createCommunity(input: CreateCommunityValues): Promise<Community> {
+  const payload = createCommunityRequestSchema.parse(input);
+  const normalizedPayload = {
+    name: payload.name.trim(),
+    description: payload.description?.trim() || undefined,
+  };
+
+  const response = await apiRequest('/communities', {
+    method: 'POST',
+    body: normalizedPayload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel criar a comunidade.'),
+    );
+  }
+
+  return communityResponseSchema.parse(responsePayload).community;
+}
+
+export async function joinCommunity(slug: string): Promise<Community> {
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}/join`, {
+    method: 'POST',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel participar desta comunidade.'),
+    );
+  }
+
+  return communityResponseSchema.parse(payload).community;
+}
+
+export async function leaveCommunity(slug: string): Promise<Community> {
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}/membership`, {
+    method: 'DELETE',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel sair desta comunidade.'),
+    );
+  }
+
+  return communityResponseSchema.parse(payload).community;
+}

--- a/frontend/tests/unit/components/communities-page-content.test.tsx
+++ b/frontend/tests/unit/components/communities-page-content.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommunitiesPageContent } from '@/components/communities/communities-page-content';
+import { useAuth } from '@/hooks/use-auth';
+import { createCommunity, fetchCommunities } from '@/services/communities';
+
+const routerPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPush,
+  }),
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/communities', () => ({
+  createCommunity: vi.fn(),
+  fetchCommunities: vi.fn(),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchCommunities = vi.mocked(fetchCommunities);
+const mockedCreateCommunity = vi.mocked(createCommunity);
+
+const community = {
+  id: 'community-id-1',
+  slug: 'guilda-dos-speedrunners',
+  name: 'Guilda dos Speedrunners',
+  description: 'Runs, PBs e desafios semanais.',
+  visibility: 'PUBLIC' as const,
+  status: 'ACTIVE' as const,
+  owner: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+    avatarUrl: null,
+  },
+  memberCount: 12,
+  createdAt: '2026-04-25T10:00:00.000Z',
+  updatedAt: '2026-04-25T10:00:00.000Z',
+  viewerMembershipRole: null,
+};
+
+function renderCommunitiesPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CommunitiesPageContent />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CommunitiesPageContent', () => {
+  beforeEach(() => {
+    routerPush.mockReset();
+    mockedUseAuth.mockReset();
+    mockedFetchCommunities.mockReset();
+    mockedCreateCommunity.mockReset();
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-id-1', username: 'clutchplayer', email: 'player@clutch.gg' },
+      status: 'authenticated',
+      logout: vi.fn(),
+    });
+  });
+
+  it('renders public communities with member count', async () => {
+    mockedFetchCommunities.mockResolvedValue([community]);
+
+    renderCommunitiesPage();
+
+    expect(await screen.findByText('Guilda dos Speedrunners')).toBeInTheDocument();
+    expect(screen.getByText(/12 membros/i)).toBeInTheDocument();
+    expect(screen.getByText(/owner: owner/i)).toBeInTheDocument();
+  });
+
+  it('creates a community and navigates to its public page', async () => {
+    mockedFetchCommunities.mockResolvedValue([]);
+    mockedCreateCommunity.mockResolvedValue(community);
+
+    renderCommunitiesPage();
+
+    fireEvent.change(screen.getByLabelText(/^nome$/i), {
+      target: { value: 'Guilda dos Speedrunners' },
+    });
+    fireEvent.change(screen.getByLabelText(/^descrição curta$/i), {
+      target: { value: 'Runs, PBs e desafios semanais.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /criar comunidade/i }));
+
+    await waitFor(() => {
+      expect(mockedCreateCommunity).toHaveBeenCalled();
+    });
+    expect(mockedCreateCommunity.mock.calls[0]?.[0]).toEqual({
+      name: 'Guilda dos Speedrunners',
+      description: 'Runs, PBs e desafios semanais.',
+    });
+    expect(routerPush).toHaveBeenCalledWith('/communities/guilda-dos-speedrunners');
+  });
+});

--- a/frontend/tests/unit/components/community-page-content.test.tsx
+++ b/frontend/tests/unit/components/community-page-content.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommunityPageContent } from '@/components/communities/community-page-content';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchCommunityBySlug,
+  joinCommunity,
+  leaveCommunity,
+} from '@/services/communities';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/communities', () => ({
+  fetchCommunityBySlug: vi.fn(),
+  joinCommunity: vi.fn(),
+  leaveCommunity: vi.fn(),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchCommunityBySlug = vi.mocked(fetchCommunityBySlug);
+const mockedJoinCommunity = vi.mocked(joinCommunity);
+const mockedLeaveCommunity = vi.mocked(leaveCommunity);
+
+const community = {
+  id: 'community-id-1',
+  slug: 'guilda-dos-speedrunners',
+  name: 'Guilda dos Speedrunners',
+  description: 'Runs, PBs e desafios semanais.',
+  visibility: 'PUBLIC' as const,
+  status: 'ACTIVE' as const,
+  owner: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+    avatarUrl: null,
+  },
+  memberCount: 12,
+  createdAt: '2026-04-25T10:00:00.000Z',
+  updatedAt: '2026-04-25T10:00:00.000Z',
+  viewerMembershipRole: null,
+};
+
+function renderCommunityPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CommunityPageContent slug="guilda-dos-speedrunners" />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CommunityPageContent', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchCommunityBySlug.mockReset();
+    mockedJoinCommunity.mockReset();
+    mockedLeaveCommunity.mockReset();
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-id-1', username: 'clutchplayer', email: 'player@clutch.gg' },
+      status: 'authenticated',
+      logout: vi.fn(),
+    });
+  });
+
+  it('renders public community identity and membership CTA', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue(community);
+
+    renderCommunityPage();
+
+    expect(await screen.findByRole('heading', {
+      name: 'Guilda dos Speedrunners',
+    })).toBeInTheDocument();
+    expect(screen.getByText(/12 membros/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /participar/i })).toBeInTheDocument();
+  });
+
+  it('joins community when authenticated viewer is not a member', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue(community);
+    mockedJoinCommunity.mockResolvedValue({
+      ...community,
+      memberCount: 13,
+      viewerMembershipRole: 'MEMBER',
+    });
+
+    renderCommunityPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /participar/i }));
+
+    await waitFor(() => {
+      expect(mockedJoinCommunity).toHaveBeenCalledWith('guilda-dos-speedrunners');
+    });
+  });
+
+  it('leaves community when authenticated viewer is member', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'MEMBER',
+    });
+    mockedLeaveCommunity.mockResolvedValue(community);
+
+    renderCommunityPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /sair da comunidade/i }));
+
+    await waitFor(() => {
+      expect(mockedLeaveCommunity).toHaveBeenCalledWith('guilda-dos-speedrunners');
+    });
+  });
+});

--- a/frontend/tests/unit/services/communities.test.ts
+++ b/frontend/tests/unit/services/communities.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import {
+  createCommunity,
+  fetchCommunities,
+  fetchCommunityBySlug,
+  joinCommunity,
+  leaveCommunity,
+} from '@/services/communities';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+const communityPayload = {
+  id: 'community-id-1',
+  slug: 'guilda-dos-speedrunners',
+  name: 'Guilda dos Speedrunners',
+  description: 'Runs, PBs e desafios semanais.',
+  visibility: 'PUBLIC',
+  status: 'ACTIVE',
+  owner: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+    avatarUrl: null,
+  },
+  memberCount: 12,
+  createdAt: '2026-04-25T10:00:00.000Z',
+  updatedAt: '2026-04-25T10:00:00.000Z',
+  viewerMembershipRole: null,
+};
+
+describe('communities service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('returns parsed public communities list', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ communities: [communityPayload] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await fetchCommunities();
+
+    expect(response).toHaveLength(1);
+    expect(response[0]?.slug).toBe('guilda-dos-speedrunners');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/communities', {
+      method: 'GET',
+    });
+  });
+
+  it('returns parsed public community detail', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ community: communityPayload }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await fetchCommunityBySlug('guilda-dos-speedrunners');
+
+    expect(response.name).toBe('Guilda dos Speedrunners');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/communities/guilda-dos-speedrunners', {
+      method: 'GET',
+    });
+  });
+
+  it('creates a community with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ community: communityPayload }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await createCommunity({
+      name: 'Guilda dos Speedrunners',
+      description: 'Runs, PBs e desafios semanais.',
+    });
+
+    expect(response.slug).toBe('guilda-dos-speedrunners');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/communities', {
+      method: 'POST',
+      body: {
+        name: 'Guilda dos Speedrunners',
+        description: 'Runs, PBs e desafios semanais.',
+      },
+    });
+  });
+
+  it('joins a community by slug', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          community: { ...communityPayload, viewerMembershipRole: 'MEMBER' },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await joinCommunity('guilda-dos-speedrunners');
+
+    expect(response.viewerMembershipRole).toBe('MEMBER');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/communities/guilda-dos-speedrunners/join', {
+      method: 'POST',
+    });
+  });
+
+  it('leaves a community by slug', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ community: communityPayload }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await leaveCommunity('guilda-dos-speedrunners');
+
+    expect(response.viewerMembershipRole).toBeNull();
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/membership',
+      {
+        method: 'DELETE',
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Resumo
Implementa o primeiro slice funcional de comunidades públicas no CLUTCH, alinhado às definições de #224 e #225. A mudança adiciona modelo mínimo, API de leitura/criação/membership simples e UI básica para listar e visualizar comunidades.

## O que foi alterado
- Backend: adiciona `Community`, `CommunityMember` e enums mínimos de visibilidade, status e role no Prisma.
- Backend: adiciona repository, service e rotas `/communities` para listagem pública, detalhe por slug, criação autenticada, join e leave.
- Frontend: adiciona schemas/service de comunidades e páginas `/communities` e `/communities/[slug]`.
- Frontend: adiciona card/listagem, página pública de detalhe e CTA simples de membership quando há sessão.
- Navegação: adiciona item `Communities` no sidebar.
- Testes: adiciona testes unitários e de rota para backend e testes de service/componentes no frontend.

## Motivação
As issues #224 e #225 consolidaram que o primeiro recorte deve validar pertencimento básico antes de chat, eventos, moderação avançada ou descoberta complexa. Este PR materializa esse recorte com contrato pequeno e verificável.

## Como validar
- `cd backend && npm run test -- tests/unit/services/community.service.test.ts tests/integration/routes/communities.routes.test.ts`
- `cd frontend && npm run test -- tests/unit/services/communities.test.ts tests/unit/components/communities-page-content.test.tsx tests/unit/components/community-page-content.test.tsx`
- `cd backend && npm run typecheck && npm run lint && npm run build`
- `cd frontend && npm run typecheck && npm run lint && npm run build`
- Com a stack local ativa, acessar `/communities`, criar uma comunidade autenticado, abrir `/communities/:slug`, entrar e sair como membro não-owner.

## Riscos e impactos
- Há alteração de banco com nova migration Prisma para comunidades e memberships.
- O slug inicial é derivado do nome e conflita quando já existe comunidade com o mesmo slug; não há estratégia de sufixo automático neste slice.
- O owner não pode sair pelo fluxo simples de membership; transferência/arquivamento ficam fora do escopo.
- Eventos, chat, roles avançadas, moderação e descoberta avançada permanecem fora desta PR.
- O smoke com stack real depende de Docker/serviços locais; nesta validação local o Docker não estava ativo.

## Evidências
- Testes focados de backend: 12 testes passaram.
- Testes focados de frontend: 10 testes passaram.
- Typecheck, lint e build passaram em backend e frontend.
- Smoke estático com `next start` retornou 200 para `/communities` e `/communities/guilda-dos-speedrunners`.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #266
Refs #224
Refs #225