### PR TITLE
feat(communities): implementar eventos comunitários mínimos

### DIFF
--- a/backend/prisma/migrations/20260426113000_add_community_events/migration.sql
+++ b/backend/prisma/migrations/20260426113000_add_community_events/migration.sql
@@ -1,0 +1,36 @@
+CREATE TYPE "CommunityEventStatus" AS ENUM ('PUBLISHED', 'CANCELLED');
+CREATE TYPE "CommunityEventRsvpStatus" AS ENUM ('GOING', 'INTERESTED', 'NOT_GOING');
+
+CREATE TABLE "community_events" (
+    "id" TEXT NOT NULL,
+    "communityId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "status" "CommunityEventStatus" NOT NULL DEFAULT 'PUBLISHED',
+    "createdByUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "community_events_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "community_event_rsvps" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" "CommunityEventRsvpStatus" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "community_event_rsvps_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "community_events_communityId_status_startsAt_idx" ON "community_events"("communityId", "status", "startsAt");
+CREATE INDEX "community_event_rsvps_userId_idx" ON "community_event_rsvps"("userId");
+CREATE UNIQUE INDEX "community_event_rsvps_eventId_userId_key" ON "community_event_rsvps"("eventId", "userId");
+
+ALTER TABLE "community_events" ADD CONSTRAINT "community_events_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "communities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_events" ADD CONSTRAINT "community_events_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_event_rsvps" ADD CONSTRAINT "community_event_rsvps_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "community_events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_event_rsvps" ADD CONSTRAINT "community_event_rsvps_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -90,6 +90,17 @@ enum CommunityMemberRole {
   MEMBER
 }
 
+enum CommunityEventStatus {
+  PUBLISHED
+  CANCELLED
+}
+
+enum CommunityEventRsvpStatus {
+  GOING
+  INTERESTED
+  NOT_GOING
+}
+
 // ── User ─────────────────────────────────────────────────────
 
 model User {
@@ -120,6 +131,8 @@ model User {
   mediaEntries         UserMediaEntry[]
   ownedCommunities     Community[]           @relation("CommunityOwner")
   communityMemberships CommunityMember[]
+  createdCommunityEvents CommunityEvent[]    @relation("CommunityEventCreator")
+  communityEventRsvps CommunityEventRsvp[]
 
   @@map("users")
 }
@@ -260,6 +273,7 @@ model Community {
 
   owner   User              @relation("CommunityOwner", fields: [ownerUserId], references: [id], onDelete: Cascade)
   members CommunityMember[]
+  events  CommunityEvent[]
 
   @@index([status, visibility, createdAt])
   @@map("communities")
@@ -278,6 +292,41 @@ model CommunityMember {
   @@unique([communityId, userId])
   @@index([userId])
   @@map("community_members")
+}
+
+model CommunityEvent {
+  id              String               @id @default(uuid())
+  communityId     String
+  title           String
+  description     String?
+  startsAt        DateTime
+  status          CommunityEventStatus @default(PUBLISHED)
+  createdByUserId String
+  createdAt       DateTime             @default(now())
+  updatedAt       DateTime             @updatedAt
+
+  community Community            @relation(fields: [communityId], references: [id], onDelete: Cascade)
+  createdBy User                 @relation("CommunityEventCreator", fields: [createdByUserId], references: [id], onDelete: Cascade)
+  rsvps     CommunityEventRsvp[]
+
+  @@index([communityId, status, startsAt])
+  @@map("community_events")
+}
+
+model CommunityEventRsvp {
+  id        String                   @id @default(uuid())
+  eventId   String
+  userId    String
+  status    CommunityEventRsvpStatus
+  createdAt DateTime                 @default(now())
+  updatedAt DateTime                 @updatedAt
+
+  event CommunityEvent @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  user  User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([eventId, userId])
+  @@index([userId])
+  @@map("community_event_rsvps")
 }
 
 // ── Post ─────────────────────────────────────────────────────

--- a/backend/src/api/routes/communities.routes.ts
+++ b/backend/src/api/routes/communities.routes.ts
@@ -5,6 +5,10 @@ import {
   communityService,
   CommunityServiceError,
 } from '../../core/services/community.service';
+import {
+  communityEventService,
+  CommunityEventServiceError,
+} from '../../core/services/community-event.service';
 
 const slugParamsSchema = z.object({
   slug: z.string().trim().min(1).max(80),
@@ -13,6 +17,21 @@ const slugParamsSchema = z.object({
 const createCommunitySchema = z.object({
   name: z.string().trim().min(3).max(80),
   description: z.string().trim().max(240).optional(),
+});
+
+const eventParamsSchema = z.object({
+  slug: z.string().trim().min(1).max(80),
+  eventId: z.string().trim().min(1).max(80),
+});
+
+const createCommunityEventSchema = z.object({
+  title: z.string().trim().min(3).max(100),
+  description: z.string().trim().max(280).optional(),
+  startsAt: z.string().datetime(),
+});
+
+const communityEventRsvpSchema = z.object({
+  status: z.enum(['GOING', 'INTERESTED', 'NOT_GOING']),
 });
 
 function resolveOptionalViewerUserId(request: FastifyRequest): string | null {
@@ -40,6 +59,22 @@ function sendCommunityServiceError(
     COMMUNITY_ALREADY_JOINED: 409,
     COMMUNITY_OWNER_CANNOT_LEAVE: 403,
     COMMUNITY_MEMBERSHIP_NOT_FOUND: 404,
+  };
+
+  return reply.status(statusByCode[error.code]).send({ message: error.message });
+}
+
+function sendCommunityEventServiceError(
+  error: CommunityEventServiceError,
+  reply: FastifyReply,
+): FastifyReply {
+  const statusByCode: Record<CommunityEventServiceError['code'], number> = {
+    COMMUNITY_NOT_FOUND: 404,
+    COMMUNITY_EVENT_NOT_FOUND: 404,
+    COMMUNITY_EVENT_FORBIDDEN: 403,
+    COMMUNITY_EVENT_INVALID_START: 400,
+    COMMUNITY_EVENT_CANCELLED: 409,
+    COMMUNITY_MEMBERSHIP_REQUIRED: 403,
   };
 
   return reply.status(statusByCode[error.code]).send({ message: error.message });
@@ -156,6 +191,176 @@ export async function communityRoutes(app: FastifyInstance): Promise<void> {
       } catch (error) {
         if (error instanceof CommunityServiceError) {
           return sendCommunityServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.get<{ Params: { slug: string } }>('/:slug/events', async (request, reply) => {
+    const params = slugParamsSchema.safeParse(request.params);
+
+    if (!params.success) {
+      return reply.status(400).send({
+        message: 'Parâmetros inválidos.',
+        errors: params.error.flatten(),
+      });
+    }
+
+    try {
+      const events = await communityEventService.listEvents(
+        params.data.slug,
+        resolveOptionalViewerUserId(request),
+      );
+
+      return { events };
+    } catch (error) {
+      if (error instanceof CommunityEventServiceError) {
+        return sendCommunityEventServiceError(error, reply);
+      }
+
+      throw error;
+    }
+  });
+
+  app.post<{ Params: { slug: string } }>(
+    '/:slug/events',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = slugParamsSchema.safeParse(request.params);
+      const body = createCommunityEventSchema.safeParse(request.body);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      if (!body.success) {
+        return reply.status(400).send({
+          message: 'Dados inválidos.',
+          errors: body.error.flatten(),
+        });
+      }
+
+      try {
+        const event = await communityEventService.createEvent(
+          params.data.slug,
+          request.userId,
+          {
+            title: body.data.title,
+            description: body.data.description ?? null,
+            startsAt: new Date(body.data.startsAt),
+          },
+        );
+
+        return reply.status(201).send({ event });
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.get<{ Params: { slug: string; eventId: string } }>(
+    '/:slug/events/:eventId',
+    async (request, reply) => {
+      const params = eventParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const event = await communityEventService.getEvent(
+          params.data.slug,
+          params.data.eventId,
+          resolveOptionalViewerUserId(request),
+        );
+
+        return { event };
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.post<{ Params: { slug: string; eventId: string } }>(
+    '/:slug/events/:eventId/rsvp',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = eventParamsSchema.safeParse(request.params);
+      const body = communityEventRsvpSchema.safeParse(request.body);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      if (!body.success) {
+        return reply.status(400).send({
+          message: 'Dados inválidos.',
+          errors: body.error.flatten(),
+        });
+      }
+
+      try {
+        const event = await communityEventService.setRsvp(
+          params.data.slug,
+          params.data.eventId,
+          request.userId,
+          body.data.status,
+        );
+
+        return reply.status(200).send({ event });
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.delete<{ Params: { slug: string; eventId: string } }>(
+    '/:slug/events/:eventId',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = eventParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const event = await communityEventService.cancelEvent(
+          params.data.slug,
+          params.data.eventId,
+          request.userId,
+        );
+
+        return reply.status(200).send({ event });
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
         }
 
         throw error;

--- a/backend/src/core/repositories/community-event.repository.ts
+++ b/backend/src/core/repositories/community-event.repository.ts
@@ -1,0 +1,214 @@
+import {
+  CommunityEventRsvpStatus,
+  CommunityEventStatus,
+  type Prisma,
+} from '@prisma/client';
+import { prisma } from '../../infra/database/client';
+
+const communityEventSelect = {
+  id: true,
+  communityId: true,
+  title: true,
+  description: true,
+  startsAt: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+  createdBy: {
+    select: {
+      id: true,
+      username: true,
+      profile: {
+        select: {
+          displayName: true,
+        },
+      },
+    },
+  },
+  rsvps: {
+    select: {
+      userId: true,
+      status: true,
+    },
+  },
+} satisfies Prisma.CommunityEventSelect;
+
+type CommunityEventRecord = Prisma.CommunityEventGetPayload<{
+  select: typeof communityEventSelect;
+}>;
+
+export type CommunityEventCreatorSummary = {
+  id: string;
+  username: string;
+  displayName: string | null;
+};
+
+export type CommunityEventRsvpCounts = {
+  going: number;
+  interested: number;
+  notGoing: number;
+};
+
+export type CommunityEventSummary = {
+  id: string;
+  communityId: string;
+  title: string;
+  description: string | null;
+  startsAt: Date;
+  status: CommunityEventStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: CommunityEventCreatorSummary;
+  viewerRsvp: CommunityEventRsvpStatus | null;
+  rsvpCounts: CommunityEventRsvpCounts;
+};
+
+export type CreateCommunityEventInput = {
+  communityId: string;
+  title: string;
+  description?: string | null;
+  startsAt: Date;
+  createdByUserId: string;
+};
+
+function toSummary(
+  record: CommunityEventRecord,
+  viewerUserId?: string | null,
+): CommunityEventSummary {
+  const rsvpCounts: CommunityEventRsvpCounts = {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  };
+  let viewerRsvp: CommunityEventRsvpStatus | null = null;
+
+  for (const rsvp of record.rsvps) {
+    if (rsvp.status === CommunityEventRsvpStatus.GOING) {
+      rsvpCounts.going++;
+    }
+
+    if (rsvp.status === CommunityEventRsvpStatus.INTERESTED) {
+      rsvpCounts.interested++;
+    }
+
+    if (rsvp.status === CommunityEventRsvpStatus.NOT_GOING) {
+      rsvpCounts.notGoing++;
+    }
+
+    if (viewerUserId && rsvp.userId === viewerUserId) {
+      viewerRsvp = rsvp.status;
+    }
+  }
+
+  return {
+    id: record.id,
+    communityId: record.communityId,
+    title: record.title,
+    description: record.description,
+    startsAt: record.startsAt,
+    status: record.status,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    createdBy: {
+      id: record.createdBy.id,
+      username: record.createdBy.username,
+      displayName: record.createdBy.profile?.displayName ?? null,
+    },
+    viewerRsvp,
+    rsvpCounts,
+  };
+}
+
+export const communityEventRepository = {
+  async create(input: CreateCommunityEventInput): Promise<CommunityEventSummary> {
+    const event = await prisma.communityEvent.create({
+      data: {
+        communityId: input.communityId,
+        title: input.title,
+        description: input.description ?? null,
+        startsAt: input.startsAt,
+        status: CommunityEventStatus.PUBLISHED,
+        createdByUserId: input.createdByUserId,
+      },
+      select: communityEventSelect,
+    });
+
+    return toSummary(event, input.createdByUserId);
+  },
+
+  async findByCommunityId(
+    communityId: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary[]> {
+    const events = await prisma.communityEvent.findMany({
+      where: {
+        communityId,
+      },
+      orderBy: [
+        { startsAt: 'asc' },
+        { createdAt: 'desc' },
+      ],
+      select: communityEventSelect,
+    });
+
+    return events.map((event) => toSummary(event, viewerUserId));
+  },
+
+  async findById(
+    communityId: string,
+    eventId: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary | null> {
+    const event = await prisma.communityEvent.findFirst({
+      where: {
+        id: eventId,
+        communityId,
+      },
+      select: communityEventSelect,
+    });
+
+    return event ? toSummary(event, viewerUserId) : null;
+  },
+
+  async upsertRsvp(
+    eventId: string,
+    userId: string,
+    status: CommunityEventRsvpStatus,
+  ): Promise<void> {
+    await prisma.communityEventRsvp.upsert({
+      where: {
+        eventId_userId: {
+          eventId,
+          userId,
+        },
+      },
+      create: {
+        eventId,
+        userId,
+        status,
+      },
+      update: {
+        status,
+      },
+    });
+  },
+
+  async cancelEvent(communityId: string, eventId: string): Promise<CommunityEventSummary | null> {
+    const event = await prisma.communityEvent.updateMany({
+      where: {
+        id: eventId,
+        communityId,
+        status: CommunityEventStatus.PUBLISHED,
+      },
+      data: {
+        status: CommunityEventStatus.CANCELLED,
+      },
+    });
+
+    if (event.count === 0) {
+      return null;
+    }
+
+    return this.findById(communityId, eventId);
+  },
+};

--- a/backend/src/core/services/community-event.service.ts
+++ b/backend/src/core/services/community-event.service.ts
@@ -1,0 +1,198 @@
+import { CommunityEventRsvpStatus, CommunityEventStatus, CommunityMemberRole } from '@prisma/client';
+import { communityEventRepository, type CommunityEventSummary } from '../repositories/community-event.repository';
+import { communityRepository, type CommunitySummary } from '../repositories/community.repository';
+
+export type CommunityEventServiceErrorCode =
+  | 'COMMUNITY_NOT_FOUND'
+  | 'COMMUNITY_EVENT_NOT_FOUND'
+  | 'COMMUNITY_EVENT_FORBIDDEN'
+  | 'COMMUNITY_EVENT_INVALID_START'
+  | 'COMMUNITY_EVENT_CANCELLED'
+  | 'COMMUNITY_MEMBERSHIP_REQUIRED';
+
+export class CommunityEventServiceError extends Error {
+  readonly code: CommunityEventServiceErrorCode;
+
+  constructor(code: CommunityEventServiceErrorCode, message: string) {
+    super(message);
+    this.name = 'CommunityEventServiceError';
+    this.code = code;
+  }
+}
+
+export type CreateCommunityEventServiceInput = {
+  title: string;
+  description?: string | null;
+  startsAt: Date;
+};
+
+async function findActiveCommunity(slug: string): Promise<CommunitySummary> {
+  const community = await communityRepository.findPublicActiveBySlug(slug);
+
+  if (!community) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_NOT_FOUND',
+      'Comunidade pública não encontrada.',
+    );
+  }
+
+  return community;
+}
+
+async function requireOwner(communityId: string, userId: string): Promise<void> {
+  const role = await communityRepository.findMembershipRole(communityId, userId);
+
+  if (role !== CommunityMemberRole.OWNER) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_EVENT_FORBIDDEN',
+      'Apenas o owner pode gerenciar eventos desta comunidade.',
+    );
+  }
+}
+
+async function requireMember(communityId: string, userId: string): Promise<void> {
+  const role = await communityRepository.findMembershipRole(communityId, userId);
+
+  if (!role) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_MEMBERSHIP_REQUIRED',
+      'Apenas membros podem responder RSVP nesta comunidade.',
+    );
+  }
+}
+
+function assertFutureStart(startsAt: Date): void {
+  if (startsAt.getTime() <= Date.now()) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_EVENT_INVALID_START',
+      'O evento precisa começar no futuro.',
+    );
+  }
+}
+
+export const communityEventService = {
+  async listEvents(
+    slug: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary[]> {
+    const community = await findActiveCommunity(slug);
+
+    return communityEventRepository.findByCommunityId(community.id, viewerUserId);
+  },
+
+  async getEvent(
+    slug: string,
+    eventId: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary> {
+    const community = await findActiveCommunity(slug);
+    const event = await communityEventRepository.findById(
+      community.id,
+      eventId,
+      viewerUserId,
+    );
+
+    if (!event) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    return event;
+  },
+
+  async createEvent(
+    slug: string,
+    userId: string,
+    input: CreateCommunityEventServiceInput,
+  ): Promise<CommunityEventSummary> {
+    const community = await findActiveCommunity(slug);
+    await requireOwner(community.id, userId);
+    assertFutureStart(input.startsAt);
+
+    const description = input.description?.trim();
+
+    return communityEventRepository.create({
+      communityId: community.id,
+      title: input.title.trim(),
+      description: description && description.length > 0 ? description : null,
+      startsAt: input.startsAt,
+      createdByUserId: userId,
+    });
+  },
+
+  async setRsvp(
+    slug: string,
+    eventId: string,
+    userId: string,
+    status: CommunityEventRsvpStatus,
+  ): Promise<CommunityEventSummary> {
+    const community = await findActiveCommunity(slug);
+    await requireMember(community.id, userId);
+
+    const event = await communityEventRepository.findById(community.id, eventId, userId);
+
+    if (!event) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    if (event.status === CommunityEventStatus.CANCELLED) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_CANCELLED',
+        'Evento cancelado não aceita RSVP.',
+      );
+    }
+
+    await communityEventRepository.upsertRsvp(event.id, userId, status);
+    const updatedEvent = await communityEventRepository.findById(community.id, eventId, userId);
+
+    if (!updatedEvent) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    return updatedEvent;
+  },
+
+  async cancelEvent(
+    slug: string,
+    eventId: string,
+    userId: string,
+  ): Promise<CommunityEventSummary> {
+    const community = await findActiveCommunity(slug);
+    await requireOwner(community.id, userId);
+
+    const existingEvent = await communityEventRepository.findById(community.id, eventId, userId);
+
+    if (!existingEvent) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    if (existingEvent.status === CommunityEventStatus.CANCELLED) {
+      return existingEvent;
+    }
+
+    const cancelledEvent = await communityEventRepository.cancelEvent(community.id, eventId);
+
+    if (!cancelledEvent) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    return {
+      ...cancelledEvent,
+      viewerRsvp: existingEvent.viewerRsvp,
+    };
+  },
+};

--- a/backend/tests/integration/routes/communities.routes.test.ts
+++ b/backend/tests/integration/routes/communities.routes.test.ts
@@ -1,10 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CommunityMemberRole, CommunityStatus, CommunityVisibility } from '@prisma/client';
+import {
+  CommunityEventRsvpStatus,
+  CommunityEventStatus,
+  CommunityMemberRole,
+  CommunityStatus,
+  CommunityVisibility,
+} from '@prisma/client';
 import { buildApp, generateTestToken } from '../../helpers/build-app';
 import {
   communityService,
   CommunityServiceError,
 } from '@/core/services/community.service';
+import {
+  communityEventService,
+  CommunityEventServiceError,
+} from '@/core/services/community-event.service';
 
 vi.mock('@/core/services/community.service', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/core/services/community.service')>();
@@ -17,6 +27,21 @@ vi.mock('@/core/services/community.service', async (importOriginal) => {
       createPublicCommunity: vi.fn(),
       joinCommunity: vi.fn(),
       leaveCommunity: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/core/services/community-event.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/services/community-event.service')>();
+
+  return {
+    ...actual,
+    communityEventService: {
+      listEvents: vi.fn(),
+      getEvent: vi.fn(),
+      createEvent: vi.fn(),
+      setRsvp: vi.fn(),
+      cancelEvent: vi.fn(),
     },
   };
 });
@@ -42,6 +67,28 @@ const mockCommunity = {
   createdAt: new Date('2026-04-25T10:00:00.000Z'),
   updatedAt: new Date('2026-04-25T10:00:00.000Z'),
   viewerMembershipRole: null,
+};
+
+const mockEvent = {
+  id: 'event-id-1',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: new Date('2099-05-01T23:00:00.000Z'),
+  status: CommunityEventStatus.PUBLISHED,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
 };
 
 describe('Communities Routes', () => {
@@ -197,6 +244,152 @@ describe('Communities Routes', () => {
     expect(communityService.leaveCommunity).toHaveBeenCalledWith(
       'guilda-dos-speedrunners',
       'member-id-1',
+    );
+    await app.close();
+  });
+
+  it('lista eventos da comunidade pública', async () => {
+    vi.mocked(communityEventService.listEvents).mockResolvedValue([mockEvent]);
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/communities/guilda-dos-speedrunners/events',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      events: [
+        {
+          id: 'event-id-1',
+          title: 'Noite de ranked',
+          rsvpCounts: { going: 0, interested: 0, notGoing: 0 },
+        },
+      ],
+    });
+    await app.close();
+  });
+
+  it('cria evento como owner autenticado', async () => {
+    vi.mocked(communityEventService.createEvent).mockResolvedValue(mockEvent);
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/events',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        title: 'Noite de ranked',
+        description: 'Fila fechada para subir elo.',
+        startsAt: '2099-05-01T23:00:00.000Z',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(communityEventService.createEvent).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'owner-id-1',
+      {
+        title: 'Noite de ranked',
+        description: 'Fila fechada para subir elo.',
+        startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      },
+    );
+    await app.close();
+  });
+
+  it('retorna 403 quando membro tenta criar evento', async () => {
+    vi.mocked(communityEventService.createEvent).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_EVENT_FORBIDDEN',
+        'Apenas o owner pode gerenciar eventos desta comunidade.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/events',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        title: 'Noite de ranked',
+        startsAt: '2099-05-01T23:00:00.000Z',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('retorna detalhe básico do evento', async () => {
+    vi.mocked(communityEventService.getEvent).mockResolvedValue(mockEvent);
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/communities/guilda-dos-speedrunners/events/event-id-1',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      event: {
+        id: 'event-id-1',
+        title: 'Noite de ranked',
+      },
+    });
+    await app.close();
+  });
+
+  it('permite RSVP básico para membro autenticado', async () => {
+    vi.mocked(communityEventService.setRsvp).mockResolvedValue({
+      ...mockEvent,
+      viewerRsvp: CommunityEventRsvpStatus.GOING,
+      rsvpCounts: { going: 1, interested: 0, notGoing: 0 },
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/events/event-id-1/rsvp',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { status: 'GOING' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityEventService.setRsvp).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'member-id-1',
+      CommunityEventRsvpStatus.GOING,
+    );
+    await app.close();
+  });
+
+  it('cancela evento como owner autenticado', async () => {
+    vi.mocked(communityEventService.cancelEvent).mockResolvedValue({
+      ...mockEvent,
+      status: CommunityEventStatus.CANCELLED,
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/communities/guilda-dos-speedrunners/events/event-id-1',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      event: { status: CommunityEventStatus.CANCELLED },
+    });
+    expect(communityEventService.cancelEvent).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'owner-id-1',
     );
     await app.close();
   });

--- a/backend/tests/unit/services/community-event.service.test.ts
+++ b/backend/tests/unit/services/community-event.service.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CommunityEventRsvpStatus,
+  CommunityEventStatus,
+  CommunityMemberRole,
+  CommunityStatus,
+  CommunityVisibility,
+} from '@prisma/client';
+import {
+  communityEventService,
+} from '@/core/services/community-event.service';
+import { communityRepository, type CommunitySummary } from '@/core/repositories/community.repository';
+import {
+  communityEventRepository,
+  type CommunityEventSummary,
+} from '@/core/repositories/community-event.repository';
+
+vi.mock('@/core/repositories/community.repository', () => ({
+  communityRepository: {
+    findPublicActiveBySlug: vi.fn(),
+    findMembershipRole: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/community-event.repository', () => ({
+  communityEventRepository: {
+    create: vi.fn(),
+    findByCommunityId: vi.fn(),
+    findById: vi.fn(),
+    upsertRsvp: vi.fn(),
+    cancelEvent: vi.fn(),
+  },
+}));
+
+const community: CommunitySummary = {
+  id: 'community-id-1',
+  slug: 'guilda-dos-speedrunners',
+  name: 'Guilda dos Speedrunners',
+  description: 'Runs, PBs e desafios semanais.',
+  visibility: CommunityVisibility.PUBLIC,
+  status: CommunityStatus.ACTIVE,
+  owner: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+    avatarUrl: null,
+  },
+  memberCount: 12,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+};
+
+const event: CommunityEventSummary = {
+  id: 'event-id-1',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: new Date('2099-05-01T23:00:00.000Z'),
+  status: CommunityEventStatus.PUBLISHED,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
+};
+
+describe('communityEventService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(community);
+  });
+
+  it('permite owner criar evento publicado com data futura', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+    vi.mocked(communityEventRepository.create).mockResolvedValue(event);
+
+    const result = await communityEventService.createEvent(
+      'guilda-dos-speedrunners',
+      'owner-id-1',
+      {
+        title: 'Noite de ranked',
+        description: 'Fila fechada para subir elo.',
+        startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      },
+    );
+
+    expect(communityEventRepository.create).toHaveBeenCalledWith({
+      communityId: 'community-id-1',
+      title: 'Noite de ranked',
+      description: 'Fila fechada para subir elo.',
+      startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      createdByUserId: 'owner-id-1',
+    });
+    expect(result.status).toBe(CommunityEventStatus.PUBLISHED);
+  });
+
+  it('bloqueia criação por membro não-owner', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+
+    await expect(
+      communityEventService.createEvent('guilda-dos-speedrunners', 'member-id-1', {
+        title: 'Noite de ranked',
+        startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_FORBIDDEN',
+    });
+  });
+
+  it('bloqueia criação com data no passado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+
+    await expect(
+      communityEventService.createEvent('guilda-dos-speedrunners', 'owner-id-1', {
+        title: 'Noite de ranked',
+        startsAt: new Date('2020-05-01T23:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_INVALID_START',
+    });
+  });
+
+  it('permite membro responder RSVP em evento publicado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+    vi.mocked(communityEventRepository.findById)
+      .mockResolvedValueOnce(event)
+      .mockResolvedValueOnce({
+        ...event,
+        viewerRsvp: CommunityEventRsvpStatus.GOING,
+        rsvpCounts: { going: 1, interested: 0, notGoing: 0 },
+      });
+    vi.mocked(communityEventRepository.upsertRsvp).mockResolvedValue(undefined);
+
+    const result = await communityEventService.setRsvp(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'member-id-1',
+      CommunityEventRsvpStatus.GOING,
+    );
+
+    expect(communityEventRepository.upsertRsvp).toHaveBeenCalledWith(
+      'event-id-1',
+      'member-id-1',
+      CommunityEventRsvpStatus.GOING,
+    );
+    expect(result.viewerRsvp).toBe(CommunityEventRsvpStatus.GOING);
+  });
+
+  it('bloqueia RSVP em evento cancelado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+    vi.mocked(communityEventRepository.findById).mockResolvedValue({
+      ...event,
+      status: CommunityEventStatus.CANCELLED,
+    });
+
+    await expect(
+      communityEventService.setRsvp(
+        'guilda-dos-speedrunners',
+        'event-id-1',
+        'member-id-1',
+        CommunityEventRsvpStatus.GOING,
+      ),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_CANCELLED',
+    });
+  });
+
+  it('permite owner cancelar evento publicado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+    vi.mocked(communityEventRepository.findById).mockResolvedValue(event);
+    vi.mocked(communityEventRepository.cancelEvent).mockResolvedValue({
+      ...event,
+      status: CommunityEventStatus.CANCELLED,
+    });
+
+    const result = await communityEventService.cancelEvent(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'owner-id-1',
+    );
+
+    expect(communityEventRepository.cancelEvent).toHaveBeenCalledWith(
+      'community-id-1',
+      'event-id-1',
+    );
+    expect(result.status).toBe(CommunityEventStatus.CANCELLED);
+  });
+});

--- a/frontend/src/components/communities/community-events-panel.tsx
+++ b/frontend/src/components/communities/community-events-panel.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import type { CommunityRole, CommunityEventRsvpStatus } from '@/schemas/communities';
+import {
+  cancelCommunityEvent,
+  CommunitiesRequestError,
+  createCommunityEvent,
+  fetchCommunityEvents,
+  setCommunityEventRsvp,
+} from '@/services/communities';
+
+type CommunityEventsPanelProps = {
+  slug: string;
+  isAuthenticated: boolean;
+  viewerMembershipRole: CommunityRole | null;
+};
+
+const rsvpOptions: Array<{ status: CommunityEventRsvpStatus; label: string }> = [
+  { status: 'GOING', label: 'Vou' },
+  { status: 'INTERESTED', label: 'Tenho interesse' },
+  { status: 'NOT_GOING', label: 'Não vou' },
+];
+
+function resolveErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof CommunitiesRequestError) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+function formatUtcDateTime(value: string): string {
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+export function CommunityEventsPanel({
+  slug,
+  isAuthenticated,
+  viewerMembershipRole,
+}: CommunityEventsPanelProps) {
+  const queryClient = useQueryClient();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [startsAt, setStartsAt] = useState('');
+  const [formMessage, setFormMessage] = useState<string | null>(null);
+  const isOwner = viewerMembershipRole === 'OWNER';
+  const isMember = viewerMembershipRole === 'OWNER' || viewerMembershipRole === 'MEMBER';
+
+  const eventsQuery = useQuery({
+    queryKey: ['communities', slug, 'events'],
+    queryFn: () => fetchCommunityEvents(slug),
+  });
+
+  const invalidateEvents = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['communities', slug, 'events'] });
+  };
+
+  const createEventMutation = useMutation({
+    mutationFn: () =>
+      createCommunityEvent(slug, {
+        title,
+        description: description.trim() || undefined,
+        startsAt: new Date(startsAt).toISOString(),
+      }),
+    onSuccess: async () => {
+      setTitle('');
+      setDescription('');
+      setStartsAt('');
+      setFormMessage(null);
+      await invalidateEvents();
+    },
+    onError: (error) => {
+      setFormMessage(resolveErrorMessage(error, 'Não foi possível criar o evento.'));
+    },
+  });
+
+  const rsvpMutation = useMutation({
+    mutationFn: ({
+      eventId,
+      status,
+    }: {
+      eventId: string;
+      status: CommunityEventRsvpStatus;
+    }) => setCommunityEventRsvp(slug, eventId, status),
+    onSuccess: invalidateEvents,
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (eventId: string) => cancelCommunityEvent(slug, eventId),
+    onSuccess: invalidateEvents,
+  });
+
+  const canCreate =
+    isOwner &&
+    title.trim().length >= 3 &&
+    startsAt.length > 0 &&
+    !createEventMutation.isPending;
+  const actionError = rsvpMutation.error ?? cancelMutation.error;
+
+  function handleCreateEvent(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canCreate) {
+      return;
+    }
+
+    createEventMutation.mutate();
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeading
+        eyebrow="Eventos"
+        title="Agenda comunitária mínima"
+        description="Eventos ficam dentro da comunidade, com RSVP simples. Sem calendário, recorrência, chat ou reminders neste slice."
+        level="h2"
+      />
+
+      {isOwner ? (
+        <Card>
+          <form className="flex flex-col gap-4" onSubmit={handleCreateEvent}>
+            <div>
+              <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+                Criar evento
+              </p>
+              <p className="mt-2 text-sm leading-6 text-secondary">
+                Owner cria eventos publicados diretamente. A moderação avançada fica fora.
+              </p>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+                Título
+                <input
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  minLength={3}
+                  maxLength={100}
+                  placeholder="Noite de ranked"
+                  className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                  disabled={createEventMutation.isPending}
+                />
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+                Início
+                <input
+                  type="datetime-local"
+                  value={startsAt}
+                  onChange={(event) => setStartsAt(event.target.value)}
+                  className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                  disabled={createEventMutation.isPending}
+                />
+              </label>
+            </div>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+              Descrição curta
+              <input
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                maxLength={280}
+                placeholder="Fila fechada para subir elo."
+                className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                disabled={createEventMutation.isPending}
+              />
+            </label>
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm text-secondary" role={formMessage ? 'alert' : undefined}>
+                {formMessage ?? 'O horário é enviado como instante UTC para o backend.'}
+              </p>
+              <Button type="submit" disabled={!canCreate}>
+                Criar evento
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
+
+      {eventsQuery.isLoading ? (
+        <Card>
+          <p className="text-sm text-secondary">Carregando eventos da comunidade...</p>
+        </Card>
+      ) : null}
+
+      {eventsQuery.isError ? (
+        <Card>
+          <p className="text-sm text-secondary" role="alert">
+            Não foi possível carregar os eventos desta comunidade.
+          </p>
+        </Card>
+      ) : null}
+
+      {eventsQuery.data?.length === 0 ? (
+        <Card>
+          <p className="text-sm leading-6 text-secondary">
+            Ainda não há eventos publicados nesta comunidade. Quando o owner criar o
+            primeiro, ele aparecerá aqui.
+          </p>
+        </Card>
+      ) : null}
+
+      {eventsQuery.data && eventsQuery.data.length > 0 ? (
+        <div className="grid gap-4">
+          {eventsQuery.data.map((event) => {
+            const isCancelled = event.status === 'CANCELLED';
+
+            return (
+              <Card key={event.id} className="flex flex-col gap-4">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge tone={isCancelled ? 'warning' : 'success'}>
+                        {isCancelled ? 'Cancelado' : 'Publicado'}
+                      </Badge>
+                      {event.viewerRsvp ? <Badge tone="accent">{event.viewerRsvp}</Badge> : null}
+                    </div>
+                    <h3 className="mt-3 font-display text-2xl font-semibold text-primary">
+                      {event.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-secondary">
+                      {event.description ?? 'Evento sem descrição adicional.'}
+                    </p>
+                  </div>
+
+                  <div className="text-right text-sm text-secondary">
+                    <p className="font-medium text-primary">{formatUtcDateTime(event.startsAt)}</p>
+                    <p className="mt-1">UTC</p>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.24em] text-secondary">
+                  <span>{event.rsvpCounts.going} vou</span>
+                  <span>{event.rsvpCounts.interested} interesse</span>
+                  <span>{event.rsvpCounts.notGoing} não vou</span>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+                  <p className="text-sm text-secondary">
+                    Criado por {event.createdBy.displayName ?? event.createdBy.username}
+                  </p>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {isAuthenticated && isMember && !isCancelled
+                      ? rsvpOptions.map((option) => (
+                          <Button
+                            key={option.status}
+                            type="button"
+                            size="sm"
+                            variant={event.viewerRsvp === option.status ? 'primary' : 'secondary'}
+                            disabled={rsvpMutation.isPending}
+                            onClick={() =>
+                              rsvpMutation.mutate({ eventId: event.id, status: option.status })
+                            }
+                          >
+                            {option.label}
+                          </Button>
+                        ))
+                      : null}
+
+                    {isOwner && !isCancelled ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={cancelMutation.isPending}
+                        onClick={() => cancelMutation.mutate(event.id)}
+                      >
+                        Cancelar evento
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {actionError ? (
+        <p className="text-sm text-status-afk" role="alert">
+          {resolveErrorMessage(actionError, 'Não foi possível atualizar o evento.')}
+        </p>
+      ) : null}
+
+      {!isAuthenticated ? (
+        <p className="text-sm text-secondary">
+          Entre na sessão para responder RSVP nos eventos da comunidade.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/communities/community-page-content.tsx
+++ b/frontend/src/components/communities/community-page-content.tsx
@@ -13,6 +13,7 @@ import {
   joinCommunity,
   leaveCommunity,
 } from '@/services/communities';
+import { CommunityEventsPanel } from './community-events-panel';
 
 type CommunityPageContentProps = {
   slug: string;
@@ -40,6 +41,7 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['communities'] }),
         queryClient.invalidateQueries({ queryKey: ['communities', slug] }),
+        queryClient.invalidateQueries({ queryKey: ['communities', slug, 'events'] }),
       ]);
     },
   });
@@ -50,6 +52,7 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['communities'] }),
         queryClient.invalidateQueries({ queryKey: ['communities', slug] }),
+        queryClient.invalidateQueries({ queryKey: ['communities', slug, 'events'] }),
       ]);
     },
   });
@@ -160,6 +163,12 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
           </p>
         ) : null}
       </Card>
+
+      <CommunityEventsPanel
+        slug={slug}
+        isAuthenticated={isAuthenticated}
+        viewerMembershipRole={community.viewerMembershipRole ?? null}
+      />
     </div>
   );
 }

--- a/frontend/src/schemas/communities.ts
+++ b/frontend/src/schemas/communities.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 export const communityRoleSchema = z.enum(['OWNER', 'MEMBER']);
 export const communityVisibilitySchema = z.enum(['PUBLIC']);
 export const communityStatusSchema = z.enum(['ACTIVE', 'ARCHIVED']);
+export const communityEventStatusSchema = z.enum(['PUBLISHED', 'CANCELLED']);
+export const communityEventRsvpStatusSchema = z.enum(['GOING', 'INTERESTED', 'NOT_GOING']);
 
 export const communityOwnerSchema = z.object({
   id: z.string(),
@@ -38,8 +40,53 @@ export const createCommunityRequestSchema = z.object({
   description: z.string().trim().max(240).optional(),
 });
 
+export const communityEventSchema = z.object({
+  id: z.string(),
+  communityId: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  startsAt: z.string(),
+  status: communityEventStatusSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  createdBy: z.object({
+    id: z.string(),
+    username: z.string(),
+    displayName: z.string().nullable(),
+  }),
+  viewerRsvp: communityEventRsvpStatusSchema.nullable(),
+  rsvpCounts: z.object({
+    going: z.number().int().nonnegative(),
+    interested: z.number().int().nonnegative(),
+    notGoing: z.number().int().nonnegative(),
+  }),
+});
+
+export const communityEventsResponseSchema = z.object({
+  events: z.array(communityEventSchema),
+});
+
+export const communityEventResponseSchema = z.object({
+  event: communityEventSchema,
+});
+
+export const createCommunityEventRequestSchema = z.object({
+  title: z.string().trim().min(3).max(100),
+  description: z.string().trim().max(280).optional(),
+  startsAt: z.string().datetime(),
+});
+
+export const communityEventRsvpRequestSchema = z.object({
+  status: communityEventRsvpStatusSchema,
+});
+
 export type CommunityRole = z.infer<typeof communityRoleSchema>;
 export type Community = z.infer<typeof communitySchema>;
 export type CommunitiesResponse = z.infer<typeof communitiesResponseSchema>;
 export type CommunityResponse = z.infer<typeof communityResponseSchema>;
 export type CreateCommunityValues = z.infer<typeof createCommunityRequestSchema>;
+export type CommunityEventRsvpStatus = z.infer<typeof communityEventRsvpStatusSchema>;
+export type CommunityEvent = z.infer<typeof communityEventSchema>;
+export type CommunityEventsResponse = z.infer<typeof communityEventsResponseSchema>;
+export type CommunityEventResponse = z.infer<typeof communityEventResponseSchema>;
+export type CreateCommunityEventValues = z.infer<typeof createCommunityEventRequestSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -10,11 +10,18 @@ export {
 } from './auth';
 export {
   communitiesResponseSchema,
+  communityEventResponseSchema,
+  communityEventRsvpRequestSchema,
+  communityEventRsvpStatusSchema,
+  communityEventSchema,
+  communityEventStatusSchema,
+  communityEventsResponseSchema,
   communityResponseSchema,
   communityRoleSchema,
   communitySchema,
   communityStatusSchema,
   communityVisibilitySchema,
+  createCommunityEventRequestSchema,
   createCommunityRequestSchema,
 } from './communities';
 export {

--- a/frontend/src/services/communities.ts
+++ b/frontend/src/services/communities.ts
@@ -1,9 +1,16 @@
 import { apiRequest } from '@/lib/api';
 import {
   communitiesResponseSchema,
+  communityEventResponseSchema,
+  communityEventRsvpRequestSchema,
+  communityEventsResponseSchema,
   communityResponseSchema,
+  createCommunityEventRequestSchema,
   createCommunityRequestSchema,
   type Community,
+  type CommunityEvent,
+  type CommunityEventRsvpStatus,
+  type CreateCommunityEventValues,
   type CreateCommunityValues,
 } from '@/schemas/communities';
 
@@ -132,4 +139,116 @@ export async function leaveCommunity(slug: string): Promise<Community> {
   }
 
   return communityResponseSchema.parse(payload).community;
+}
+
+export async function fetchCommunityEvents(slug: string): Promise<CommunityEvent[]> {
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}/events`, {
+    method: 'GET',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar os eventos da comunidade.'),
+    );
+  }
+
+  return communityEventsResponseSchema.parse(payload).events;
+}
+
+export async function fetchCommunityEventById(
+  slug: string,
+  eventId: string,
+): Promise<CommunityEvent> {
+  const response = await apiRequest(
+    `/communities/${encodeURIComponent(slug)}/events/${encodeURIComponent(eventId)}`,
+    {
+      method: 'GET',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar este evento.'),
+    );
+  }
+
+  return communityEventResponseSchema.parse(payload).event;
+}
+
+export async function createCommunityEvent(
+  slug: string,
+  input: CreateCommunityEventValues,
+): Promise<CommunityEvent> {
+  const payload = createCommunityEventRequestSchema.parse(input);
+  const normalizedPayload = {
+    title: payload.title.trim(),
+    description: payload.description?.trim() || undefined,
+    startsAt: payload.startsAt,
+  };
+
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}/events`, {
+    method: 'POST',
+    body: normalizedPayload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel criar o evento.'),
+    );
+  }
+
+  return communityEventResponseSchema.parse(responsePayload).event;
+}
+
+export async function setCommunityEventRsvp(
+  slug: string,
+  eventId: string,
+  status: CommunityEventRsvpStatus,
+): Promise<CommunityEvent> {
+  const payload = communityEventRsvpRequestSchema.parse({ status });
+  const response = await apiRequest(
+    `/communities/${encodeURIComponent(slug)}/events/${encodeURIComponent(eventId)}/rsvp`,
+    {
+      method: 'POST',
+      body: payload,
+    },
+  );
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel atualizar o RSVP.'),
+    );
+  }
+
+  return communityEventResponseSchema.parse(responsePayload).event;
+}
+
+export async function cancelCommunityEvent(
+  slug: string,
+  eventId: string,
+): Promise<CommunityEvent> {
+  const response = await apiRequest(
+    `/communities/${encodeURIComponent(slug)}/events/${encodeURIComponent(eventId)}`,
+    {
+      method: 'DELETE',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel cancelar o evento.'),
+    );
+  }
+
+  return communityEventResponseSchema.parse(payload).event;
 }

--- a/frontend/tests/unit/components/community-page-content.test.tsx
+++ b/frontend/tests/unit/components/community-page-content.test.tsx
@@ -5,9 +5,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CommunityPageContent } from '@/components/communities/community-page-content';
 import { useAuth } from '@/hooks/use-auth';
 import {
+  cancelCommunityEvent,
+  createCommunityEvent,
   fetchCommunityBySlug,
+  fetchCommunityEvents,
   joinCommunity,
   leaveCommunity,
+  setCommunityEventRsvp,
 } from '@/services/communities';
 
 vi.mock('@/hooks/use-auth', () => ({
@@ -15,15 +19,23 @@ vi.mock('@/hooks/use-auth', () => ({
 }));
 
 vi.mock('@/services/communities', () => ({
+  cancelCommunityEvent: vi.fn(),
+  createCommunityEvent: vi.fn(),
   fetchCommunityBySlug: vi.fn(),
+  fetchCommunityEvents: vi.fn(),
   joinCommunity: vi.fn(),
   leaveCommunity: vi.fn(),
+  setCommunityEventRsvp: vi.fn(),
 }));
 
 const mockedUseAuth = vi.mocked(useAuth);
+const mockedCancelCommunityEvent = vi.mocked(cancelCommunityEvent);
+const mockedCreateCommunityEvent = vi.mocked(createCommunityEvent);
 const mockedFetchCommunityBySlug = vi.mocked(fetchCommunityBySlug);
+const mockedFetchCommunityEvents = vi.mocked(fetchCommunityEvents);
 const mockedJoinCommunity = vi.mocked(joinCommunity);
 const mockedLeaveCommunity = vi.mocked(leaveCommunity);
+const mockedSetCommunityEventRsvp = vi.mocked(setCommunityEventRsvp);
 
 const community = {
   id: 'community-id-1',
@@ -44,6 +56,28 @@ const community = {
   viewerMembershipRole: null,
 };
 
+const event = {
+  id: 'event-id-1',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: '2099-05-01T23:00:00.000Z',
+  status: 'PUBLISHED' as const,
+  createdAt: '2026-04-25T10:00:00.000Z',
+  updatedAt: '2026-04-25T10:00:00.000Z',
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
+};
+
 function renderCommunityPage() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -62,9 +96,14 @@ function renderCommunityPage() {
 describe('CommunityPageContent', () => {
   beforeEach(() => {
     mockedUseAuth.mockReset();
+    mockedCancelCommunityEvent.mockReset();
+    mockedCreateCommunityEvent.mockReset();
     mockedFetchCommunityBySlug.mockReset();
+    mockedFetchCommunityEvents.mockReset();
     mockedJoinCommunity.mockReset();
     mockedLeaveCommunity.mockReset();
+    mockedSetCommunityEventRsvp.mockReset();
+    mockedFetchCommunityEvents.mockResolvedValue([]);
     mockedUseAuth.mockReturnValue({
       user: { id: 'user-id-1', username: 'clutchplayer', email: 'player@clutch.gg' },
       status: 'authenticated',
@@ -114,6 +153,85 @@ describe('CommunityPageContent', () => {
 
     await waitFor(() => {
       expect(mockedLeaveCommunity).toHaveBeenCalledWith('guilda-dos-speedrunners');
+    });
+  });
+
+  it('renders community events inside the community page', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'MEMBER',
+    });
+    mockedFetchCommunityEvents.mockResolvedValue([event]);
+
+    renderCommunityPage();
+
+    expect(await screen.findByText('Noite de ranked')).toBeInTheDocument();
+    expect(screen.getByText(/0 vou/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^vou$/i })).toBeInTheDocument();
+  });
+
+  it('updates RSVP from the community event block', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'MEMBER',
+    });
+    mockedFetchCommunityEvents.mockResolvedValue([event]);
+    mockedSetCommunityEventRsvp.mockResolvedValue({
+      ...event,
+      viewerRsvp: 'GOING',
+      rsvpCounts: { going: 1, interested: 0, notGoing: 0 },
+    });
+
+    renderCommunityPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^vou$/i }));
+
+    await waitFor(() => {
+      expect(mockedSetCommunityEventRsvp).toHaveBeenCalledWith(
+        'guilda-dos-speedrunners',
+        'event-id-1',
+        'GOING',
+      );
+    });
+  });
+
+  it('lets owner create and cancel events from the community page', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'OWNER',
+    });
+    mockedFetchCommunityEvents.mockResolvedValue([event]);
+    mockedCreateCommunityEvent.mockResolvedValue(event);
+    mockedCancelCommunityEvent.mockResolvedValue({
+      ...event,
+      status: 'CANCELLED',
+    });
+
+    renderCommunityPage();
+
+    fireEvent.change(await screen.findByLabelText(/^título$/i), {
+      target: { value: 'Noite de ranked' },
+    });
+    fireEvent.change(screen.getByLabelText(/^início$/i), {
+      target: { value: '2099-05-01T23:00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /criar evento/i }));
+
+    await waitFor(() => {
+      expect(mockedCreateCommunityEvent).toHaveBeenCalled();
+    });
+    expect(mockedCreateCommunityEvent.mock.calls[0]?.[0]).toBe('guilda-dos-speedrunners');
+    expect(mockedCreateCommunityEvent.mock.calls[0]?.[1]).toMatchObject({
+      title: 'Noite de ranked',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /cancelar evento/i }));
+
+    await waitFor(() => {
+      expect(mockedCancelCommunityEvent).toHaveBeenCalledWith(
+        'guilda-dos-speedrunners',
+        'event-id-1',
+      );
     });
   });
 });

--- a/frontend/tests/unit/services/communities.test.ts
+++ b/frontend/tests/unit/services/communities.test.ts
@@ -2,10 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiRequest } from '@/lib/api';
 import {
   createCommunity,
+  createCommunityEvent,
+  fetchCommunityEventById,
+  fetchCommunityEvents,
   fetchCommunities,
   fetchCommunityBySlug,
   joinCommunity,
   leaveCommunity,
+  setCommunityEventRsvp,
+  cancelCommunityEvent,
 } from '@/services/communities';
 
 vi.mock('@/lib/api', () => ({
@@ -31,6 +36,28 @@ const communityPayload = {
   createdAt: '2026-04-25T10:00:00.000Z',
   updatedAt: '2026-04-25T10:00:00.000Z',
   viewerMembershipRole: null,
+};
+
+const eventPayload = {
+  id: 'event-id-1',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: '2099-05-01T23:00:00.000Z',
+  status: 'PUBLISHED',
+  createdAt: '2026-04-25T10:00:00.000Z',
+  updatedAt: '2026-04-25T10:00:00.000Z',
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
 };
 
 describe('communities service', () => {
@@ -131,6 +158,119 @@ describe('communities service', () => {
       {
         method: 'DELETE',
       },
+    );
+  });
+
+  it('returns parsed community events list', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ events: [eventPayload] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await fetchCommunityEvents('guilda-dos-speedrunners');
+
+    expect(response).toHaveLength(1);
+    expect(response[0]?.title).toBe('Noite de ranked');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events',
+      { method: 'GET' },
+    );
+  });
+
+  it('returns parsed community event detail', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ event: eventPayload }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await fetchCommunityEventById(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+    );
+
+    expect(response.id).toBe('event-id-1');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events/event-id-1',
+      { method: 'GET' },
+    );
+  });
+
+  it('creates a community event with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ event: eventPayload }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await createCommunityEvent('guilda-dos-speedrunners', {
+      title: 'Noite de ranked',
+      description: 'Fila fechada para subir elo.',
+      startsAt: '2099-05-01T23:00:00.000Z',
+    });
+
+    expect(response.title).toBe('Noite de ranked');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events',
+      {
+        method: 'POST',
+        body: {
+          title: 'Noite de ranked',
+          description: 'Fila fechada para subir elo.',
+          startsAt: '2099-05-01T23:00:00.000Z',
+        },
+      },
+    );
+  });
+
+  it('updates RSVP for a community event', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({ event: { ...eventPayload, viewerRsvp: 'GOING' } }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await setCommunityEventRsvp(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'GOING',
+    );
+
+    expect(response.viewerRsvp).toBe('GOING');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events/event-id-1/rsvp',
+      {
+        method: 'POST',
+        body: { status: 'GOING' },
+      },
+    );
+  });
+
+  it('cancels a community event', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({ event: { ...eventPayload, status: 'CANCELLED' } }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await cancelCommunityEvent('guilda-dos-speedrunners', 'event-id-1');
+
+    expect(response.status).toBe('CANCELLED');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events/event-id-1',
+      { method: 'DELETE' },
     );
   });
 });


### PR DESCRIPTION
## Resumo
Implementa o primeiro slice funcional de eventos comunitários dentro de comunidades públicas. A PR adiciona modelo mínimo de evento/RSVP, rotas aninhadas em `/communities/:slug/events` e um bloco compacto de eventos na página da comunidade.

## O que foi alterado
- Backend: adiciona `CommunityEvent`, `CommunityEventRsvp`, `CommunityEventStatus` e `CommunityEventRsvpStatus` no Prisma.
- Backend: adiciona repository e service de eventos comunitários com criação owner-only, listagem, detalhe, RSVP e cancelamento lógico.
- Backend: adiciona rotas aninhadas em comunidades para eventos e RSVP.
- Frontend: adiciona schemas e services de eventos comunitários no contrato de comunidades.
- Frontend: adiciona bloco `CommunityEventsPanel` dentro da página pública da comunidade.
- Testes: adiciona cobertura de service/rotas no backend e service/componente no frontend.

## Motivação
A #225 definiu que eventos devem validar agenda social básica dentro de uma comunidade, sem calendário complexo, recorrência, reminders, chat ou moderação pesada. Esta PR materializa esse primeiro recorte sobre a base funcional da #266.

## Como validar
- `cd backend && npm run test -- tests/unit/services/community-event.service.test.ts tests/integration/routes/communities.routes.test.ts`
- `cd frontend && npm run test -- tests/unit/services/communities.test.ts tests/unit/components/community-page-content.test.tsx`
- `cd backend && npm run typecheck && npm run lint && npm run build`
- `cd frontend && npm run typecheck && npm run lint && npm run build`
- Com a stack local ativa, abrir uma comunidade, criar evento como owner, responder RSVP como membro e cancelar evento como owner.

## Riscos e impactos
- Esta é uma PR empilhada sobre `feat/public-community-slice` porque depende do domínio de comunidades da #266.
- Há alteração de banco com nova migration Prisma para eventos e RSVPs.
- O slice usa apenas `PUBLISHED` e `CANCELLED`; estados como live/past são derivados e não persistidos.
- O horário é armazenado como instante UTC; timezone customizada por evento fica fora do escopo.
- Criação e cancelamento são owner-only; membros apenas respondem RSVP.
- Não há calendário, recorrência, reminders, chat, notificações de evento ou moderação avançada.

## Evidências
- Backend testes afetados: 19 testes passaram.
- Frontend testes afetados: 16 testes passaram.
- Typecheck, lint e build passaram em backend e frontend.
- Backend lint mantém 3 warnings preexistentes em `src/config/rate-limit.ts`.
- Smoke estático com `next start` retornou 200 para `/communities/guilda-dos-speedrunners`.
- Smoke completo com backend real e banco não foi executado porque Docker Desktop não estava ativo no ambiente local.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #268
Refs #224
Refs #225
Refs #266