### PR TITLE
feat(auth): adiciona fundação de providers e identities

### DIFF
--- a/backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
+++ b/backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
@@ -1,0 +1,18 @@
+-- Detect duplicate external identities before applying the provider identity
+-- foundation migration.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
+--
+-- Any returned row means the global unique index on (platform, externalId)
+-- would reject the current data unless the duplicate is corrected first.
+SELECT
+  "platform",
+  "externalId",
+  COUNT(*) AS integration_count,
+  COUNT(DISTINCT "userId") AS affected_user_count,
+  ARRAY_AGG("userId" ORDER BY "userId") AS affected_user_ids
+FROM "platform_integrations"
+GROUP BY "platform", "externalId"
+HAVING COUNT(*) > 1
+ORDER BY affected_user_count DESC, "platform", "externalId";

--- a/backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
+++ b/backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
@@ -1,11 +1,17 @@
--- Detect duplicate external identities before applying the provider identity
--- foundation migration.
+-- Manual pre-deploy diagnostic for duplicate external identities.
 --
 -- Usage:
 --   psql "$DATABASE_URL" -f backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
 --
--- Any returned row means the global unique index on (platform, externalId)
--- would reject the current data unless the duplicate is corrected first.
+-- Run this before deploy to see whether legacy data would conflict with the
+-- global unique index on (platform, externalId). The migration itself also
+-- performs the known EPIC legacy backfill first and then runs an internal
+-- duplicate guard immediately before creating the index.
+--
+-- Expected legacy EPIC rows with externalId = 'epic' will appear here before
+-- the migration. They are handled automatically by the migration as
+-- legacy:epic:<userId>, status NEEDS_REAUTH, dataSource EXPERIMENTAL.
+-- Any duplicate row that remains after that backfill requires manual cleanup.
 SELECT
   "platform",
   "externalId",

--- a/backend/prisma/migrations/20260428170000_provider_identity_foundation/migration.sql
+++ b/backend/prisma/migrations/20260428170000_provider_identity_foundation/migration.sql
@@ -1,0 +1,15 @@
+-- Provider / identity foundation for connected accounts and future social login.
+ALTER TYPE "Platform" ADD VALUE IF NOT EXISTS 'GOOGLE';
+
+CREATE TYPE "PlatformIntegrationConnectionType" AS ENUM ('SOCIAL_LOGIN', 'CONNECTED_ACCOUNT');
+CREATE TYPE "PlatformIntegrationStatus" AS ENUM ('CONNECTED', 'NEEDS_REAUTH', 'DISCONNECTED', 'UNAVAILABLE', 'EXPERIMENTAL');
+CREATE TYPE "PlatformIntegrationDataSource" AS ENUM ('OFFICIAL', 'MANUAL', 'EXPERIMENTAL', 'LOCAL_COMPANION');
+
+ALTER TABLE "platform_integrations"
+  ADD COLUMN "connectionType" "PlatformIntegrationConnectionType" NOT NULL DEFAULT 'CONNECTED_ACCOUNT',
+  ADD COLUMN "status" "PlatformIntegrationStatus" NOT NULL DEFAULT 'CONNECTED',
+  ADD COLUMN "dataSource" "PlatformIntegrationDataSource" NOT NULL DEFAULT 'OFFICIAL',
+  ADD COLUMN "lastSyncAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX "platform_integrations_platform_externalId_key"
+  ON "platform_integrations"("platform", "externalId");

--- a/backend/prisma/migrations/20260428170000_provider_identity_foundation/migration.sql
+++ b/backend/prisma/migrations/20260428170000_provider_identity_foundation/migration.sql
@@ -11,5 +11,50 @@ ALTER TABLE "platform_integrations"
   ADD COLUMN "dataSource" "PlatformIntegrationDataSource" NOT NULL DEFAULT 'OFFICIAL',
   ADD COLUMN "lastSyncAt" TIMESTAMP(3);
 
+-- Legacy EPIC connections used the literal externalId "epic" for every user.
+-- Backfill them to a unique, clearly legacy fallback before the global identity
+-- index is created. This does not claim to be a real Epic account id; it only
+-- preserves the existing connected-account row until a future reconnect can
+-- normalize Epic with a trustworthy provider identity.
+UPDATE "platform_integrations"
+SET
+  "externalId" = 'legacy:epic:' || "userId",
+  "status" = 'NEEDS_REAUTH',
+  "dataSource" = 'EXPERIMENTAL',
+  "metadata" = COALESCE("metadata", '{}'::jsonb) || jsonb_build_object(
+    'legacyExternalIdBackfilled', true,
+    'legacyExternalId', 'epic',
+    'requiresReconnectForStableIdentity', true
+  ),
+  "updatedAt" = CURRENT_TIMESTAMP
+WHERE "platform" = 'EPIC'
+  AND "externalId" = 'epic';
+
+-- Keep the unique index honest: after the known EPIC legacy backfill, any
+-- remaining duplicate external identity requires manual data correction.
+DO $$
+DECLARE
+  duplicate_identity RECORD;
+BEGIN
+  SELECT
+    "platform"::text AS platform,
+    "externalId" AS external_id,
+    COUNT(DISTINCT "userId") AS affected_user_count
+  INTO duplicate_identity
+  FROM "platform_integrations"
+  GROUP BY "platform", "externalId"
+  HAVING COUNT(*) > 1
+  LIMIT 1;
+
+  IF FOUND THEN
+    RAISE EXCEPTION
+      'platform_integrations contains duplicate external identity for platform %, externalId %, affected users %',
+      duplicate_identity.platform,
+      duplicate_identity.external_id,
+      duplicate_identity.affected_user_count
+      USING HINT = 'Run backend/prisma/diagnostics/platform-integration-identity-duplicates.sql and resolve duplicates before applying this migration.';
+  END IF;
+END $$;
+
 CREATE UNIQUE INDEX "platform_integrations_platform_externalId_key"
   ON "platform_integrations"("platform", "externalId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,6 +21,7 @@ enum PresenceStatus {
 }
 
 enum Platform {
+  GOOGLE
   STEAM
   EPIC
   DISCORD
@@ -29,6 +30,26 @@ enum Platform {
   RIOT
   ANILIST
   MYANIMELIST
+}
+
+enum PlatformIntegrationConnectionType {
+  SOCIAL_LOGIN
+  CONNECTED_ACCOUNT
+}
+
+enum PlatformIntegrationStatus {
+  CONNECTED
+  NEEDS_REAUTH
+  DISCONNECTED
+  UNAVAILABLE
+  EXPERIMENTAL
+}
+
+enum PlatformIntegrationDataSource {
+  OFFICIAL
+  MANUAL
+  EXPERIMENTAL
+  LOCAL_COMPANION
 }
 
 enum PostType {
@@ -179,20 +200,25 @@ model UserPresence {
 // ── PlatformIntegration ──────────────────────────────────────
 
 model PlatformIntegration {
-  id           String   @id @default(uuid())
-  userId       String
-  platform     Platform
-  externalId   String
-  accessToken  String?
-  refreshToken String?
-  metadata     Json?
-  isActive     Boolean  @default(true)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id             String                            @id @default(uuid())
+  userId         String
+  platform       Platform
+  externalId     String
+  connectionType PlatformIntegrationConnectionType @default(CONNECTED_ACCOUNT)
+  status         PlatformIntegrationStatus         @default(CONNECTED)
+  dataSource     PlatformIntegrationDataSource     @default(OFFICIAL)
+  accessToken    String?
+  refreshToken   String?
+  metadata       Json?
+  isActive       Boolean                           @default(true)
+  lastSyncAt     DateTime?
+  createdAt      DateTime                          @default(now())
+  updatedAt      DateTime                          @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, platform])
+  @@unique([platform, externalId])
   @@map("platform_integrations")
 }
 

--- a/backend/src/config/protected-token.ts
+++ b/backend/src/config/protected-token.ts
@@ -1,0 +1,86 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from 'node:crypto';
+
+const TOKEN_PREFIX = 'enc:v1';
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const DEFAULT_DEVELOPMENT_SECRET = 'clutch-connected-account-dev-secret';
+
+function resolveTokenProtectionSecret(): string {
+  const configuredSecret = process.env['CONNECTED_ACCOUNT_TOKEN_SECRET']?.trim()
+    ?? process.env['JWT_SECRET']?.trim();
+
+  if (configuredSecret && configuredSecret.length > 0) {
+    return configuredSecret;
+  }
+
+  if (process.env['NODE_ENV'] === 'production') {
+    throw new Error('CONNECTED_ACCOUNT_TOKEN_SECRET deve ser configurado em produção.');
+  }
+
+  return DEFAULT_DEVELOPMENT_SECRET;
+}
+
+function resolveEncryptionKey(): Buffer {
+  return createHash('sha256').update(resolveTokenProtectionSecret()).digest();
+}
+
+export function protectSensitiveToken(token: string | null | undefined): string | null {
+  if (typeof token !== 'string' || token.length === 0) {
+    return null;
+  }
+
+  if (token.startsWith(`${TOKEN_PREFIX}:`)) {
+    return token;
+  }
+
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', resolveEncryptionKey(), iv, {
+    authTagLength: AUTH_TAG_BYTES,
+  });
+  const ciphertext = Buffer.concat([
+    cipher.update(token, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    TOKEN_PREFIX,
+    iv.toString('base64url'),
+    authTag.toString('base64url'),
+    ciphertext.toString('base64url'),
+  ].join(':');
+}
+
+export function revealSensitiveToken(protectedToken: string | null | undefined): string | null {
+  if (typeof protectedToken !== 'string' || protectedToken.length === 0) {
+    return null;
+  }
+
+  if (!protectedToken.startsWith(`${TOKEN_PREFIX}:`)) {
+    return protectedToken;
+  }
+
+  const [, , encodedIv, encodedAuthTag, encodedCiphertext] = protectedToken.split(':');
+
+  if (!encodedIv || !encodedAuthTag || !encodedCiphertext) {
+    throw new Error('Token protegido inválido.');
+  }
+
+  const decipher = createDecipheriv(
+    'aes-256-gcm',
+    resolveEncryptionKey(),
+    Buffer.from(encodedIv, 'base64url'),
+    { authTagLength: AUTH_TAG_BYTES },
+  );
+  decipher.setAuthTag(Buffer.from(encodedAuthTag, 'base64url'));
+
+  return Buffer.concat([
+    decipher.update(Buffer.from(encodedCiphertext, 'base64url')),
+    decipher.final(),
+  ]).toString('utf8');
+}

--- a/backend/src/core/providers/README.md
+++ b/backend/src/core/providers/README.md
@@ -28,10 +28,10 @@ A unicidade global de `provider + externalId` e parte da fundacao: a mesma ident
 
 Antes desta fundacao, a integracao Epic gravava `externalId = "epic"` para toda conexao. A migration converte esses registros para `legacy:epic:<userId>`, marca `status = NEEDS_REAUTH` e `dataSource = EXPERIMENTAL`. Esse valor e apenas um fallback legado para preservar a linha existente; ele nao representa uma identidade Epic confiavel.
 
-Para procurar duplicidades antes da migration, rode:
+Para procurar duplicidades antes do deploy, rode:
 
 ```bash
 psql "$DATABASE_URL" -f backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
 ```
 
-Qualquer linha retornada depois do backfill Epic exige correcao manual antes do indice unico global.
+Antes da migration, registros Epic legados com `externalId = "epic"` podem aparecer nesse diagnostico e sao tratados automaticamente pelo backfill. A propria migration tambem executa uma checagem interna depois desse backfill e antes do indice. Qualquer duplicidade que restar nesse ponto exige correcao manual antes do indice unico global.

--- a/backend/src/core/providers/README.md
+++ b/backend/src/core/providers/README.md
@@ -1,0 +1,23 @@
+# Providers, identities e contas conectadas
+
+Esta fundacao separa tres conceitos:
+
+- Provider: origem externa registrada no `provider-registry`, com status, fonte de dados e capabilities.
+- Identidade externa: par unico `provider + externalId`, pertencente a no maximo um usuario CLUTCH.
+- Conta conectada: vinculo persistido em `PlatformIntegration` entre `userId` e uma identidade externa.
+
+Login social e conta conectada usam a mesma base de identidade, mas finalidades diferentes:
+
+- `SOCIAL_LOGIN`: provider pode autenticar uma sessao CLUTCH futura.
+- `CONNECTED_ACCOUNT`: provider agrega biblioteca, presenca, showcase ou dados sociais a uma conta existente.
+
+## Como adicionar um provider
+
+1. Adicione o provider ao enum `Platform` e crie migration.
+2. Registre o provider em `provider-registry.ts` com `capabilities`, `dataSource` e `status`.
+3. Implemente o client externo em `infra/integrations` sem expor secrets ou tokens ao frontend.
+4. Persistir o vinculo deve passar por `connected-account.service.ts`.
+5. Trate conflitos de ownership como erro de dominio, nunca como sucesso silencioso.
+6. Cubra a capability matrix, conflitos e compatibilidade com testes.
+
+Tokens externos devem ser protegidos antes de persistir. Rotas e frontends devem consumir apenas contratos de dominio, sem payload bruto do provider.

--- a/backend/src/core/providers/README.md
+++ b/backend/src/core/providers/README.md
@@ -21,3 +21,17 @@ Login social e conta conectada usam a mesma base de identidade, mas finalidades 
 6. Cubra a capability matrix, conflitos e compatibilidade com testes.
 
 Tokens externos devem ser protegidos antes de persistir. Rotas e frontends devem consumir apenas contratos de dominio, sem payload bruto do provider.
+
+## Dados legados e diagnostico
+
+A unicidade global de `provider + externalId` e parte da fundacao: a mesma identidade externa nao pode pertencer a dois usuarios CLUTCH.
+
+Antes desta fundacao, a integracao Epic gravava `externalId = "epic"` para toda conexao. A migration converte esses registros para `legacy:epic:<userId>`, marca `status = NEEDS_REAUTH` e `dataSource = EXPERIMENTAL`. Esse valor e apenas um fallback legado para preservar a linha existente; ele nao representa uma identidade Epic confiavel.
+
+Para procurar duplicidades antes da migration, rode:
+
+```bash
+psql "$DATABASE_URL" -f backend/prisma/diagnostics/platform-integration-identity-duplicates.sql
+```
+
+Qualquer linha retornada depois do backfill Epic exige correcao manual antes do indice unico global.

--- a/backend/src/core/providers/epic-identity.ts
+++ b/backend/src/core/providers/epic-identity.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'node:crypto';
+
+const LEGACY_EPIC_EXTERNAL_ID_PREFIX = 'legacy:epic:';
+const EXPERIMENTAL_EPIC_EXTERNAL_ID_PREFIX = 'epic:';
+
+export function buildLegacyEpicExternalId(userId: string): string {
+  return `${LEGACY_EPIC_EXTERNAL_ID_PREFIX}${userId}`;
+}
+
+export function isLegacyEpicExternalId(externalId: string): boolean {
+  return externalId.startsWith(LEGACY_EPIC_EXTERNAL_ID_PREFIX);
+}
+
+export function buildExperimentalEpicExternalId(authToken: string): string {
+  return `${EXPERIMENTAL_EPIC_EXTERNAL_ID_PREFIX}${createHash('sha256').update(authToken).digest('hex')}`;
+}

--- a/backend/src/core/providers/provider-registry.ts
+++ b/backend/src/core/providers/provider-registry.ts
@@ -1,0 +1,107 @@
+import type {
+  Platform,
+  PlatformIntegrationDataSource,
+  PlatformIntegrationStatus,
+} from '@prisma/client';
+
+export type ProviderCapability =
+  | 'SOCIAL_LOGIN'
+  | 'CONNECTED_ACCOUNT'
+  | 'OAUTH_CONNECT'
+  | 'TOKEN_CONNECT'
+  | 'LIBRARY_IMPORT'
+  | 'PRESENCE_INGESTION';
+
+export type ProviderDefinition = {
+  provider: Platform;
+  displayName: string;
+  dataSource: PlatformIntegrationDataSource;
+  status: PlatformIntegrationStatus;
+  capabilities: ProviderCapability[];
+};
+
+const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
+  {
+    provider: 'GOOGLE',
+    displayName: 'Google',
+    dataSource: 'OFFICIAL',
+    status: 'UNAVAILABLE',
+    capabilities: ['SOCIAL_LOGIN', 'OAUTH_CONNECT'],
+  },
+  {
+    provider: 'DISCORD',
+    displayName: 'Discord',
+    dataSource: 'OFFICIAL',
+    status: 'CONNECTED',
+    capabilities: ['SOCIAL_LOGIN', 'CONNECTED_ACCOUNT', 'OAUTH_CONNECT', 'PRESENCE_INGESTION'],
+  },
+  {
+    provider: 'STEAM',
+    displayName: 'Steam',
+    dataSource: 'OFFICIAL',
+    status: 'CONNECTED',
+    capabilities: ['CONNECTED_ACCOUNT', 'LIBRARY_IMPORT'],
+  },
+  {
+    provider: 'EPIC',
+    displayName: 'Epic Games',
+    dataSource: 'EXPERIMENTAL',
+    status: 'EXPERIMENTAL',
+    capabilities: ['CONNECTED_ACCOUNT', 'TOKEN_CONNECT', 'LIBRARY_IMPORT'],
+  },
+  {
+    provider: 'MYANIMELIST',
+    displayName: 'MyAnimeList',
+    dataSource: 'OFFICIAL',
+    status: 'UNAVAILABLE',
+    capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+  },
+  {
+    provider: 'ANILIST',
+    displayName: 'AniList',
+    dataSource: 'OFFICIAL',
+    status: 'UNAVAILABLE',
+    capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+  },
+  {
+    provider: 'XBOX',
+    displayName: 'Xbox',
+    dataSource: 'OFFICIAL',
+    status: 'UNAVAILABLE',
+    capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+  },
+  {
+    provider: 'PSN',
+    displayName: 'PlayStation Network',
+    dataSource: 'OFFICIAL',
+    status: 'UNAVAILABLE',
+    capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+  },
+  {
+    provider: 'RIOT',
+    displayName: 'Riot Games',
+    dataSource: 'OFFICIAL',
+    status: 'UNAVAILABLE',
+    capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+  },
+];
+
+export function listProviderDefinitions(): ProviderDefinition[] {
+  return PROVIDER_DEFINITIONS.map((definition) => ({
+    ...definition,
+    capabilities: [...definition.capabilities],
+  }));
+}
+
+export function getProviderDefinition(provider: Platform): ProviderDefinition {
+  const definition = PROVIDER_DEFINITIONS.find((candidate) => candidate.provider === provider);
+
+  if (!definition) {
+    throw new Error(`Provider ${provider} não está registrado.`);
+  }
+
+  return {
+    ...definition,
+    capabilities: [...definition.capabilities],
+  };
+}

--- a/backend/src/core/repositories/connected-account.repository.ts
+++ b/backend/src/core/repositories/connected-account.repository.ts
@@ -1,0 +1,190 @@
+/* eslint-disable no-unused-vars */
+import {
+  Prisma,
+  type Platform,
+  type PlatformIntegrationConnectionType,
+  type PlatformIntegrationDataSource,
+  type PlatformIntegrationStatus,
+} from '@prisma/client';
+import { prisma } from '../../infra/database/client';
+
+export type ConnectedAccountRecord = {
+  id: string;
+  userId: string;
+  provider: Platform;
+  externalId: string;
+  connectionType: PlatformIntegrationConnectionType;
+  status: PlatformIntegrationStatus;
+  dataSource: PlatformIntegrationDataSource;
+  metadata: Prisma.JsonValue | null;
+  createdAt: Date;
+  updatedAt: Date;
+  lastSyncAt: Date | null;
+};
+
+export type ConnectedAccountOwnershipRecord = Pick<
+  ConnectedAccountRecord,
+  'id' | 'userId' | 'provider' | 'externalId' | 'status'
+>;
+
+export class ConnectedAccountUniquenessError extends Error {
+  readonly owner: ConnectedAccountOwnershipRecord | null;
+
+  constructor(owner: ConnectedAccountOwnershipRecord | null) {
+    super('Identidade externa já vinculada.');
+    this.name = 'ConnectedAccountUniquenessError';
+    this.owner = owner;
+  }
+}
+
+export type UpsertConnectedAccountInput = {
+  userId: string;
+  provider: Platform;
+  externalId: string;
+  connectionType: PlatformIntegrationConnectionType;
+  status: PlatformIntegrationStatus;
+  dataSource: PlatformIntegrationDataSource;
+  accessToken?: string | null;
+  refreshToken?: string | null;
+  metadata?: Prisma.InputJsonValue | null;
+  lastSyncAt?: Date | null;
+};
+
+function toConnectedAccountRecord(account: {
+  id: string;
+  userId: string;
+  platform: Platform;
+  externalId: string;
+  connectionType: PlatformIntegrationConnectionType;
+  status: PlatformIntegrationStatus;
+  dataSource: PlatformIntegrationDataSource;
+  metadata: Prisma.JsonValue | null;
+  createdAt: Date;
+  updatedAt: Date;
+  lastSyncAt: Date | null;
+}): ConnectedAccountRecord {
+  return {
+    id: account.id,
+    userId: account.userId,
+    provider: account.platform,
+    externalId: account.externalId,
+    connectionType: account.connectionType,
+    status: account.status,
+    dataSource: account.dataSource,
+    metadata: account.metadata,
+    createdAt: account.createdAt,
+    updatedAt: account.updatedAt,
+    lastSyncAt: account.lastSyncAt,
+  };
+}
+
+export type ConnectedAccountRepository = {
+  findByProviderExternalId(
+    provider: Platform,
+    externalId: string,
+  ): Promise<ConnectedAccountOwnershipRecord | null>;
+  findByUserProvider(userId: string, provider: Platform): Promise<ConnectedAccountRecord | null>;
+  upsertConnectedAccount(input: UpsertConnectedAccountInput): Promise<ConnectedAccountRecord>;
+};
+
+export function createConnectedAccountRepository(): ConnectedAccountRepository {
+  async function findByProviderExternalId(
+    provider: Platform,
+    externalId: string,
+  ): Promise<ConnectedAccountOwnershipRecord | null> {
+    const account = await prisma.platformIntegration.findUnique({
+      where: {
+        platform_externalId: {
+          platform: provider,
+          externalId,
+        },
+      },
+      select: {
+        id: true,
+        userId: true,
+        platform: true,
+        externalId: true,
+        status: true,
+      },
+    });
+
+    if (!account) {
+      return null;
+    }
+
+    return {
+      id: account.id,
+      userId: account.userId,
+      provider: account.platform,
+      externalId: account.externalId,
+      status: account.status,
+    };
+  }
+
+  return {
+    findByProviderExternalId,
+
+    async findByUserProvider(
+      userId: string,
+      provider: Platform,
+    ): Promise<ConnectedAccountRecord | null> {
+      const account = await prisma.platformIntegration.findUnique({
+        where: {
+          userId_platform: {
+            userId,
+            platform: provider,
+          },
+        },
+      });
+
+      return account ? toConnectedAccountRecord(account) : null;
+    },
+
+    async upsertConnectedAccount(input: UpsertConnectedAccountInput): Promise<ConnectedAccountRecord> {
+      try {
+        const account = await prisma.platformIntegration.upsert({
+          where: {
+            userId_platform: {
+              userId: input.userId,
+              platform: input.provider,
+            },
+          },
+          create: {
+            userId: input.userId,
+            platform: input.provider,
+            externalId: input.externalId,
+            connectionType: input.connectionType,
+            status: input.status,
+            dataSource: input.dataSource,
+            accessToken: input.accessToken ?? null,
+            refreshToken: input.refreshToken ?? null,
+            metadata: input.metadata ?? Prisma.JsonNull,
+            isActive: input.status === 'CONNECTED',
+            lastSyncAt: input.lastSyncAt ?? null,
+          },
+          update: {
+            externalId: input.externalId,
+            connectionType: input.connectionType,
+            status: input.status,
+            dataSource: input.dataSource,
+            accessToken: input.accessToken ?? null,
+            refreshToken: input.refreshToken ?? null,
+            metadata: input.metadata ?? Prisma.JsonNull,
+            isActive: input.status === 'CONNECTED',
+            ...(input.lastSyncAt !== undefined ? { lastSyncAt: input.lastSyncAt } : {}),
+          },
+        });
+
+        return toConnectedAccountRecord(account);
+      } catch (error) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          throw new ConnectedAccountUniquenessError(
+            await findByProviderExternalId(input.provider, input.externalId),
+          );
+        }
+
+        throw error;
+      }
+    },
+  };
+}

--- a/backend/src/core/services/connected-account.service.ts
+++ b/backend/src/core/services/connected-account.service.ts
@@ -1,0 +1,97 @@
+/* eslint-disable no-unused-vars */
+import type {
+  Platform,
+  PlatformIntegrationConnectionType,
+  PlatformIntegrationDataSource,
+  PlatformIntegrationStatus,
+  Prisma,
+} from '@prisma/client';
+import { protectSensitiveToken } from '../../config/protected-token';
+import {
+  createConnectedAccountRepository,
+  type ConnectedAccountRecord,
+  type ConnectedAccountRepository,
+  ConnectedAccountUniquenessError,
+} from '../repositories/connected-account.repository';
+
+export class ConnectedAccountConflictError extends Error {
+  readonly provider: Platform;
+  readonly externalId: string;
+  readonly ownerUserId: string;
+
+  constructor(provider: Platform, externalId: string, ownerUserId: string) {
+    super('Identidade externa já vinculada a outro usuário.');
+    this.name = 'ConnectedAccountConflictError';
+    this.provider = provider;
+    this.externalId = externalId;
+    this.ownerUserId = ownerUserId;
+  }
+}
+
+export type ConnectExternalIdentityInput = {
+  userId: string;
+  provider: Platform;
+  externalId: string;
+  connectionType: PlatformIntegrationConnectionType;
+  dataSource: PlatformIntegrationDataSource;
+  status?: PlatformIntegrationStatus;
+  accessToken?: string | null;
+  refreshToken?: string | null;
+  metadata?: Prisma.InputJsonValue | null;
+  lastSyncAt?: Date | null;
+};
+
+export type ConnectedAccountService = {
+  connectExternalIdentity(input: ConnectExternalIdentityInput): Promise<ConnectedAccountRecord>;
+};
+
+export function createConnectedAccountService(dependencies?: {
+  repository?: Pick<
+    ConnectedAccountRepository,
+    'findByProviderExternalId' | 'upsertConnectedAccount'
+  >;
+}): ConnectedAccountService {
+  const repository = dependencies?.repository ?? createConnectedAccountRepository();
+
+  return {
+    async connectExternalIdentity(input: ConnectExternalIdentityInput): Promise<ConnectedAccountRecord> {
+      const existingIdentity = await repository.findByProviderExternalId(
+        input.provider,
+        input.externalId,
+      );
+
+      if (existingIdentity && existingIdentity.userId !== input.userId) {
+        throw new ConnectedAccountConflictError(
+          input.provider,
+          input.externalId,
+          existingIdentity.userId,
+        );
+      }
+
+      try {
+        return await repository.upsertConnectedAccount({
+          userId: input.userId,
+          provider: input.provider,
+          externalId: input.externalId,
+          connectionType: input.connectionType,
+          status: input.status ?? 'CONNECTED',
+          dataSource: input.dataSource,
+          accessToken: protectSensitiveToken(input.accessToken),
+          refreshToken: protectSensitiveToken(input.refreshToken),
+          metadata: input.metadata ?? null,
+          lastSyncAt: input.lastSyncAt,
+        });
+      } catch (error) {
+        if (error instanceof ConnectedAccountUniquenessError && error.owner) {
+          throw new ConnectedAccountConflictError(
+            input.provider,
+            input.externalId,
+            error.owner.userId,
+          );
+        }
+
+        throw error;
+      }
+    },
+  };
+}

--- a/backend/src/core/services/connected-account.service.ts
+++ b/backend/src/core/services/connected-account.service.ts
@@ -28,6 +28,16 @@ export class ConnectedAccountConflictError extends Error {
   }
 }
 
+export class ConnectedAccountInvalidExternalIdError extends Error {
+  readonly provider: Platform;
+
+  constructor(provider: Platform) {
+    super('Identidade externa exige externalId válido.');
+    this.name = 'ConnectedAccountInvalidExternalIdError';
+    this.provider = provider;
+  }
+}
+
 export type ConnectExternalIdentityInput = {
   userId: string;
   provider: Platform;
@@ -55,15 +65,21 @@ export function createConnectedAccountService(dependencies?: {
 
   return {
     async connectExternalIdentity(input: ConnectExternalIdentityInput): Promise<ConnectedAccountRecord> {
+      const externalId = input.externalId.trim();
+
+      if (externalId.length === 0) {
+        throw new ConnectedAccountInvalidExternalIdError(input.provider);
+      }
+
       const existingIdentity = await repository.findByProviderExternalId(
         input.provider,
-        input.externalId,
+        externalId,
       );
 
       if (existingIdentity && existingIdentity.userId !== input.userId) {
         throw new ConnectedAccountConflictError(
           input.provider,
-          input.externalId,
+          externalId,
           existingIdentity.userId,
         );
       }
@@ -72,7 +88,7 @@ export function createConnectedAccountService(dependencies?: {
         return await repository.upsertConnectedAccount({
           userId: input.userId,
           provider: input.provider,
-          externalId: input.externalId,
+          externalId,
           connectionType: input.connectionType,
           status: input.status ?? 'CONNECTED',
           dataSource: input.dataSource,
@@ -85,7 +101,7 @@ export function createConnectedAccountService(dependencies?: {
         if (error instanceof ConnectedAccountUniquenessError && error.owner) {
           throw new ConnectedAccountConflictError(
             input.provider,
-            input.externalId,
+            externalId,
             error.owner.userId,
           );
         }

--- a/backend/src/core/services/discord-oauth.service.ts
+++ b/backend/src/core/services/discord-oauth.service.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-unused-vars */
 import { Prisma } from '@prisma/client';
-import { prisma } from '../../infra/database/client';
 import {
   createIntegrationError,
   type IntegrationError,
@@ -11,6 +10,10 @@ import {
   type DiscordTokenSet,
 } from '../../infra/integrations/discord/discord.service';
 import { writeBackendRuntimeLog } from '../../config/logging';
+import {
+  ConnectedAccountConflictError,
+  createConnectedAccountService,
+} from './connected-account.service';
 
 type PersistDiscordIntegrationInput = {
   externalId: string;
@@ -47,32 +50,33 @@ type CompleteDiscordOAuthInput = {
 };
 
 function createPrismaDiscordOAuthPersistence(): DiscordOAuthPersistence {
+  const connectedAccountService = createConnectedAccountService();
+
   return {
     async upsertDiscordIntegration(userId, data): Promise<void> {
-      await prisma.platformIntegration.upsert({
-        where: {
-          userId_platform: {
-            userId,
-            platform: 'DISCORD',
-          },
-        },
-        create: {
+      try {
+        await connectedAccountService.connectExternalIdentity({
           userId,
-          platform: 'DISCORD',
+          provider: 'DISCORD',
           externalId: data.externalId,
+          connectionType: 'CONNECTED_ACCOUNT',
+          dataSource: 'OFFICIAL',
           accessToken: data.accessToken,
           refreshToken: data.refreshToken,
           metadata: data.metadata,
-          isActive: true,
-        },
-        update: {
-          externalId: data.externalId,
-          accessToken: data.accessToken,
-          refreshToken: data.refreshToken,
-          metadata: data.metadata,
-          isActive: true,
-        },
-      });
+        });
+      } catch (error) {
+        if (error instanceof ConnectedAccountConflictError) {
+          throw createIntegrationError(
+            'discord',
+            409,
+            'conflict',
+            'Esta conta Discord já está vinculada a outro usuário.',
+          );
+        }
+
+        throw error;
+      }
     },
   };
 }

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-unused-vars */
+import { createHash } from 'node:crypto';
 import { prisma } from '../../infra/database/client';
+import type {
+  PlatformIntegrationDataSource,
+} from '@prisma/client';
 import {
   createIntegrationError,
   type IntegrationError,
@@ -9,6 +13,10 @@ import { epicService, type EpicGame } from '../../infra/integrations/epic/epic.s
 import { igdbService, type IgdbGame } from '../../infra/integrations/igdb/igdb.service';
 import { steamService, type SteamGame } from '../../infra/integrations/steam/steam.service';
 import { writeBackendRuntimeLog } from '../../config/logging';
+import {
+  ConnectedAccountConflictError,
+  createConnectedAccountService,
+} from './connected-account.service';
 
 type PlatformIntegrationPlatform = 'STEAM' | 'EPIC';
 
@@ -20,6 +28,7 @@ type PersistedIntegration = {
 type PersistIntegrationInput = {
   externalId: string;
   accessToken?: string | null;
+  dataSource?: PlatformIntegrationDataSource;
 };
 
 type SteamIntegrationClient = Pick<typeof steamService, 'validateSteamId' | 'getOwnedGames'>;
@@ -50,31 +59,32 @@ type IntegrationsPersistence = {
 export type IntegrationsService = ReturnType<typeof createIntegrationsService>;
 
 export function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
+  const connectedAccountService = createConnectedAccountService();
+
   return {
     async upsertPlatformIntegration(userId, platform, data): Promise<void> {
-      await prisma.platformIntegration.upsert({
-        where: {
-          userId_platform: {
-            userId,
-            platform,
-          },
-        },
-        create: {
+      try {
+        await connectedAccountService.connectExternalIdentity({
           userId,
-          platform,
+          provider: platform,
           externalId: data.externalId,
-          ...(typeof data.accessToken === 'string'
-            ? { accessToken: data.accessToken }
-            : {}),
-        },
-        update: {
-          externalId: data.externalId,
-          isActive: true,
-          ...(typeof data.accessToken === 'string'
-            ? { accessToken: data.accessToken }
-            : {}),
-        },
-      });
+          connectionType: 'CONNECTED_ACCOUNT',
+          dataSource: data.dataSource ?? 'OFFICIAL',
+          accessToken: data.accessToken,
+          lastSyncAt: new Date(),
+        });
+      } catch (error) {
+        if (error instanceof ConnectedAccountConflictError) {
+          throw createIntegrationError(
+            platform.toLowerCase() as 'steam' | 'epic',
+            409,
+            'conflict',
+            'Esta conta externa já está vinculada a outro usuário.',
+          );
+        }
+
+        throw error;
+      }
     },
     async findPlatformIntegration(userId, platform): Promise<PersistedIntegration | null> {
       const integration = await prisma.platformIntegration.findUnique({
@@ -189,6 +199,10 @@ export function createIntegrationsService(dependencies?: {
   const epicClient = dependencies?.epicClient ?? epicService;
   const persistence = dependencies?.persistence ?? createPrismaIntegrationsPersistence();
 
+  function buildEpicExternalId(authToken: string): string {
+    return `epic:${createHash('sha256').update(authToken).digest('hex')}`;
+  }
+
   return {
     async connectSteam(userId: string, steamId: string): Promise<{ imported: number; message: string }> {
       const isValidSteamId = await steamClient.validateSteamId(steamId);
@@ -261,8 +275,9 @@ export function createIntegrationsService(dependencies?: {
       const games = await epicClient.getLibrary(authToken);
 
       await persistence.upsertPlatformIntegration(userId, 'EPIC', {
-        externalId: 'epic',
+        externalId: buildEpicExternalId(authToken),
         accessToken: authToken,
+        dataSource: 'EXPERIMENTAL',
       });
 
       for (const game of games) {

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-vars */
-import { createHash } from 'node:crypto';
 import { prisma } from '../../infra/database/client';
 import type {
   PlatformIntegrationDataSource,
 } from '@prisma/client';
+import { buildExperimentalEpicExternalId } from '../providers/epic-identity';
 import {
   createIntegrationError,
   type IntegrationError,
@@ -199,10 +199,6 @@ export function createIntegrationsService(dependencies?: {
   const epicClient = dependencies?.epicClient ?? epicService;
   const persistence = dependencies?.persistence ?? createPrismaIntegrationsPersistence();
 
-  function buildEpicExternalId(authToken: string): string {
-    return `epic:${createHash('sha256').update(authToken).digest('hex')}`;
-  }
-
   return {
     async connectSteam(userId: string, steamId: string): Promise<{ imported: number; message: string }> {
       const isValidSteamId = await steamClient.validateSteamId(steamId);
@@ -275,7 +271,7 @@ export function createIntegrationsService(dependencies?: {
       const games = await epicClient.getLibrary(authToken);
 
       await persistence.upsertPlatformIntegration(userId, 'EPIC', {
-        externalId: buildEpicExternalId(authToken),
+        externalId: buildExperimentalEpicExternalId(authToken),
         accessToken: authToken,
         dataSource: 'EXPERIMENTAL',
       });

--- a/backend/src/infra/integrations/integration.errors.ts
+++ b/backend/src/infra/integrations/integration.errors.ts
@@ -8,6 +8,7 @@ export type IntegrationName = 'steam' | 'igdb' | 'epic' | 'discord';
 export type IntegrationErrorReason =
   | 'invalid_request'
   | 'invalid_credentials'
+  | 'conflict'
   | 'not_found'
   | 'not_connected'
   | 'timeout'

--- a/backend/tests/unit/providers/epic-identity.test.ts
+++ b/backend/tests/unit/providers/epic-identity.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildExperimentalEpicExternalId,
+  buildLegacyEpicExternalId,
+  isLegacyEpicExternalId,
+} from '@/core/providers/epic-identity';
+
+describe('epic identity helpers', () => {
+  it('marca identidades Epic legadas como fallback por usuario', () => {
+    const externalId = buildLegacyEpicExternalId('user-id-1');
+
+    expect(externalId).toBe('legacy:epic:user-id-1');
+    expect(isLegacyEpicExternalId(externalId)).toBe(true);
+    expect(isLegacyEpicExternalId('epic')).toBe(false);
+  });
+
+  it('gera identificador experimental deterministico sem manter token bruto', () => {
+    const firstExternalId = buildExperimentalEpicExternalId('valid-token');
+    const secondExternalId = buildExperimentalEpicExternalId('valid-token');
+
+    expect(firstExternalId).toBe(secondExternalId);
+    expect(firstExternalId).toMatch(/^epic:[a-f0-9]{64}$/u);
+    expect(firstExternalId).not.toContain('valid-token');
+  });
+});

--- a/backend/tests/unit/providers/provider-identity-migration.test.ts
+++ b/backend/tests/unit/providers/provider-identity-migration.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('provider identity migration', () => {
+  it('backfills Epic legacy identities before creating the global unique index', () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        'prisma/migrations/20260428170000_provider_identity_foundation/migration.sql',
+      ),
+      'utf8',
+    );
+    const epicBackfillIndex = migration.indexOf("'legacy:epic:' || \"userId\"");
+    const duplicateGuardIndex = migration.indexOf('platform_integrations contains duplicate external identity');
+    const uniqueIndexIndex = migration.indexOf('CREATE UNIQUE INDEX "platform_integrations_platform_externalId_key"');
+
+    expect(epicBackfillIndex).toBeGreaterThan(-1);
+    expect(duplicateGuardIndex).toBeGreaterThan(epicBackfillIndex);
+    expect(uniqueIndexIndex).toBeGreaterThan(duplicateGuardIndex);
+  });
+
+  it('documents duplicate diagnostics by platform, externalId and affected users', () => {
+    const diagnostics = readFileSync(
+      join(process.cwd(), 'prisma/diagnostics/platform-integration-identity-duplicates.sql'),
+      'utf8',
+    );
+
+    expect(diagnostics).toContain('"platform"');
+    expect(diagnostics).toContain('"externalId"');
+    expect(diagnostics).toContain('affected_user_count');
+    expect(diagnostics).toContain('GROUP BY "platform", "externalId"');
+    expect(diagnostics).toContain('HAVING COUNT(*) > 1');
+  });
+});

--- a/backend/tests/unit/providers/provider-registry.test.ts
+++ b/backend/tests/unit/providers/provider-registry.test.ts
@@ -38,4 +38,15 @@ describe('provider registry', () => {
       expect.arrayContaining(['CONNECTED_ACCOUNT', 'OAUTH_CONNECT']),
     );
   });
+
+  it('mantem Epic como provider experimental sem login social', () => {
+    const epic = getProviderDefinition('EPIC');
+
+    expect(epic.status).toBe('EXPERIMENTAL');
+    expect(epic.dataSource).toBe('EXPERIMENTAL');
+    expect(epic.capabilities).toContain('CONNECTED_ACCOUNT');
+    expect(epic.capabilities).toContain('TOKEN_CONNECT');
+    expect(epic.capabilities).not.toContain('SOCIAL_LOGIN');
+    expect(epic.capabilities).not.toContain('OAUTH_CONNECT');
+  });
 });

--- a/backend/tests/unit/providers/provider-registry.test.ts
+++ b/backend/tests/unit/providers/provider-registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getProviderDefinition,
+  listProviderDefinitions,
+} from '@/core/providers/provider-registry';
+
+describe('provider registry', () => {
+  it('descreve providers sem depender de implementacao de rota especifica', () => {
+    const discord = getProviderDefinition('DISCORD');
+
+    expect(discord).toMatchObject({
+      provider: 'DISCORD',
+      displayName: 'Discord',
+      dataSource: 'OFFICIAL',
+    });
+    expect(discord.capabilities).toEqual(
+      expect.arrayContaining(['OAUTH_CONNECT', 'SOCIAL_LOGIN']),
+    );
+  });
+
+  it('diferencia login social de conta conectada por capability', () => {
+    const providers = listProviderDefinitions();
+    const steam = providers.find((provider) => provider.provider === 'STEAM');
+    const google = providers.find((provider) => provider.provider === 'GOOGLE');
+
+    expect(steam?.capabilities).toContain('CONNECTED_ACCOUNT');
+    expect(steam?.capabilities).not.toContain('SOCIAL_LOGIN');
+    expect(google?.capabilities).toEqual(
+      expect.arrayContaining(['SOCIAL_LOGIN', 'OAUTH_CONNECT']),
+    );
+  });
+
+  it('mantem providers futuros indisponiveis sem remover capabilities declaradas', () => {
+    const myAnimeList = getProviderDefinition('MYANIMELIST');
+
+    expect(myAnimeList.status).toBe('UNAVAILABLE');
+    expect(myAnimeList.capabilities).toEqual(
+      expect.arrayContaining(['CONNECTED_ACCOUNT', 'OAUTH_CONNECT']),
+    );
+  });
+});

--- a/backend/tests/unit/services/connected-account.service.test.ts
+++ b/backend/tests/unit/services/connected-account.service.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ConnectedAccountConflictError,
+  createConnectedAccountService,
+} from '@/core/services/connected-account.service';
+
+const createRepository = () => ({
+  findByProviderExternalId: vi.fn(),
+  upsertConnectedAccount: vi.fn(),
+});
+
+describe('connected account service', () => {
+  it('cria uma identidade externa conectada com contrato normalizado', async () => {
+    const repository = createRepository();
+    repository.findByProviderExternalId.mockResolvedValue(null);
+    repository.upsertConnectedAccount.mockResolvedValue({
+      id: 'account-id-1',
+      userId: 'user-id-1',
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      connectionType: 'CONNECTED_ACCOUNT',
+      status: 'CONNECTED',
+      dataSource: 'OFFICIAL',
+      metadata: null,
+      createdAt: new Date('2026-04-28T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+      lastSyncAt: null,
+    });
+    const service = createConnectedAccountService({ repository });
+
+    const account = await service.connectExternalIdentity({
+      userId: 'user-id-1',
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      connectionType: 'CONNECTED_ACCOUNT',
+      dataSource: 'OFFICIAL',
+    });
+
+    expect(repository.upsertConnectedAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-id-1',
+        provider: 'STEAM',
+        externalId: '76561198000000000',
+        connectionType: 'CONNECTED_ACCOUNT',
+        status: 'CONNECTED',
+      }),
+    );
+    expect(account).toMatchObject({
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      connectionType: 'CONNECTED_ACCOUNT',
+    });
+    expect(account).not.toHaveProperty('accessToken');
+    expect(account).not.toHaveProperty('refreshToken');
+  });
+
+  it('bloqueia ownership duplicado da mesma identidade externa', async () => {
+    const repository = createRepository();
+    repository.findByProviderExternalId.mockResolvedValue({
+      id: 'account-id-1',
+      userId: 'other-user-id',
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      status: 'CONNECTED',
+    });
+    const service = createConnectedAccountService({ repository });
+
+    await expect(service.connectExternalIdentity({
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+      dataSource: 'OFFICIAL',
+    })).rejects.toBeInstanceOf(ConnectedAccountConflictError);
+
+    expect(repository.upsertConnectedAccount).not.toHaveBeenCalled();
+  });
+
+  it('permite reconectar a mesma identidade externa ao mesmo usuario', async () => {
+    const repository = createRepository();
+    repository.findByProviderExternalId.mockResolvedValue({
+      id: 'account-id-1',
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      status: 'CONNECTED',
+    });
+    repository.upsertConnectedAccount.mockResolvedValue({
+      id: 'account-id-1',
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+      status: 'CONNECTED',
+      dataSource: 'OFFICIAL',
+      metadata: { username: 'clutchdiscord' },
+      createdAt: new Date('2026-04-28T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+      lastSyncAt: null,
+    });
+    const service = createConnectedAccountService({ repository });
+
+    await service.connectExternalIdentity({
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+      dataSource: 'OFFICIAL',
+      accessToken: 'discord-access-token',
+      refreshToken: 'discord-refresh-token',
+      metadata: { username: 'clutchdiscord' },
+    });
+
+    expect(repository.upsertConnectedAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: expect.stringMatching(/^enc:v1:/u),
+        refreshToken: expect.stringMatching(/^enc:v1:/u),
+      }),
+    );
+  });
+});

--- a/backend/tests/unit/services/connected-account.service.test.ts
+++ b/backend/tests/unit/services/connected-account.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   ConnectedAccountConflictError,
+  ConnectedAccountInvalidExternalIdError,
   createConnectedAccountService,
 } from '@/core/services/connected-account.service';
 import { ConnectedAccountUniquenessError } from '@/core/repositories/connected-account.repository';
@@ -53,6 +54,57 @@ describe('connected account service', () => {
     });
     expect(account).not.toHaveProperty('accessToken');
     expect(account).not.toHaveProperty('refreshToken');
+  });
+
+  it('rejeita identidade conectada sem externalId material', async () => {
+    const repository = createRepository();
+    const service = createConnectedAccountService({ repository });
+
+    await expect(service.connectExternalIdentity({
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: '   ',
+      connectionType: 'CONNECTED_ACCOUNT',
+      dataSource: 'OFFICIAL',
+    })).rejects.toBeInstanceOf(ConnectedAccountInvalidExternalIdError);
+
+    expect(repository.findByProviderExternalId).not.toHaveBeenCalled();
+    expect(repository.upsertConnectedAccount).not.toHaveBeenCalled();
+  });
+
+  it('normaliza externalId com espacos antes de aplicar ownership', async () => {
+    const repository = createRepository();
+    repository.findByProviderExternalId.mockResolvedValue(null);
+    repository.upsertConnectedAccount.mockResolvedValue({
+      id: 'account-id-1',
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+      status: 'CONNECTED',
+      dataSource: 'OFFICIAL',
+      metadata: null,
+      createdAt: new Date('2026-04-28T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+      lastSyncAt: null,
+    });
+    const service = createConnectedAccountService({ repository });
+
+    await service.connectExternalIdentity({
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: ' discord-user-id ',
+      connectionType: 'CONNECTED_ACCOUNT',
+      dataSource: 'OFFICIAL',
+    });
+
+    expect(repository.findByProviderExternalId).toHaveBeenCalledWith(
+      'DISCORD',
+      'discord-user-id',
+    );
+    expect(repository.upsertConnectedAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ externalId: 'discord-user-id' }),
+    );
   });
 
   it('bloqueia ownership duplicado da mesma identidade externa', async () => {

--- a/backend/tests/unit/services/connected-account.service.test.ts
+++ b/backend/tests/unit/services/connected-account.service.test.ts
@@ -3,6 +3,7 @@ import {
   ConnectedAccountConflictError,
   createConnectedAccountService,
 } from '@/core/services/connected-account.service';
+import { ConnectedAccountUniquenessError } from '@/core/repositories/connected-account.repository';
 
 const createRepository = () => ({
   findByProviderExternalId: vi.fn(),
@@ -74,6 +75,33 @@ describe('connected account service', () => {
     })).rejects.toBeInstanceOf(ConnectedAccountConflictError);
 
     expect(repository.upsertConnectedAccount).not.toHaveBeenCalled();
+  });
+
+  it('traduz corrida de unicidade global para conflito de dominio', async () => {
+    const repository = createRepository();
+    repository.findByProviderExternalId.mockResolvedValue(null);
+    repository.upsertConnectedAccount.mockRejectedValue(
+      new ConnectedAccountUniquenessError({
+        id: 'account-id-1',
+        userId: 'other-user-id',
+        provider: 'STEAM',
+        externalId: '76561198000000000',
+        status: 'CONNECTED',
+      }),
+    );
+    const service = createConnectedAccountService({ repository });
+
+    await expect(service.connectExternalIdentity({
+      userId: 'user-id-1',
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      connectionType: 'CONNECTED_ACCOUNT',
+      dataSource: 'OFFICIAL',
+    })).rejects.toMatchObject({
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      ownerUserId: 'other-user-id',
+    });
   });
 
   it('permite reconectar a mesma identidade externa ao mesmo usuario', async () => {

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -393,6 +393,28 @@ describe('createPrismaIntegrationsPersistence', () => {
       }),
     );
   });
+
+  it('traduz conflito global de identidade externa para erro de dominio', async () => {
+    vi.mocked(prisma.platformIntegration.findUnique).mockResolvedValueOnce({
+      id: 'integration-id-1',
+      userId: 'other-user-id',
+      platform: 'STEAM',
+      externalId: '76561198000000000',
+      status: 'CONNECTED',
+    } as never);
+    const persistence = createPrismaIntegrationsPersistence();
+
+    await expect(persistence.upsertPlatformIntegration(
+      'user-id-1',
+      'STEAM',
+      { externalId: '76561198000000000' },
+    )).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'conflict',
+    });
+
+    expect(prisma.platformIntegration.upsert).not.toHaveBeenCalled();
+  });
 });
 
 describe('steamService', () => {

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -259,7 +259,11 @@ describe('integrations service layer', () => {
     expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
       'user-id-1',
       'EPIC',
-      { externalId: 'epic', accessToken: 'valid-token' },
+      {
+        externalId: expect.stringMatching(/^epic:[a-f0-9]{64}$/u),
+        accessToken: 'valid-token',
+        dataSource: 'EXPERIMENTAL',
+      },
     );
   });
 });


### PR DESCRIPTION
## Resumo
Cria a fundação backend para providers, identidades externas e contas conectadas, sem implementar login social completo ou Connection Center. A mudança centraliza ownership de identidades externas, registry de providers e persistência protegida de tokens, reaproveitando os fluxos existentes de Discord, Steam e Epic.

Esta atualização também corrige o hardening da migration: dados Epic legados que usavam `externalId = epic` agora são backfilled para um fallback único e explicitamente legado antes da criação do índice global.

Closes #271

## O que foi alterado
- Modelo de dados: adiciona `connectionType`, `status`, `dataSource`, `lastSyncAt`, `GOOGLE` e unicidade global por `platform + externalId` em `PlatformIntegration`.
- Contrato de identidade: `externalId` permanece não nulo no schema e o service comum rejeita valor vazio/whitespace antes de consultar ownership ou persistir a conexão.
- Migration segura: converte `EPIC` legado de `externalId = epic` para `legacy:epic:<userId>`, marca `status = NEEDS_REAUTH` e `dataSource = EXPERIMENTAL`, e só então cria o índice único global.
- Diagnóstico: adiciona query SQL para detectar duplicidades por `platform`, `externalId` e usuários afetados antes do deploy; a migration também executa guard interno depois do backfill Epic.
- Providers: adiciona registry com capabilities e documentação curta para novos providers.
- Segurança: adiciona proteção AES-256-GCM para tokens externos antes da persistência.
- Boundary backend: adiciona repository/service de connected accounts para normalizar conexão, ownership e conflito de identidade externa.
- Integrações existentes: Discord OAuth, Steam e Epic passam a persistir via foundation comum sem duplicar regras por rota.
- Testes: adiciona cobertura para registry, contrato de connected account, externalId vazio, conflito de ownership, Epic legado, migration e compatibilidade de integrações.

## Motivação
A próxima etapa de Auth Social & Connected Accounts precisa de uma base única para diferenciar login social, conta conectada e identidade externa. Sem essa fundação, Google/Discord login, account linking e Connection Center tenderiam a duplicar integrações existentes e permitir ownership ambíguo de identidades externas.

A unicidade global por `platform + externalId` é necessária para garantir que uma identidade externa pertença a no máximo um usuário CLUTCH. O problema encontrado no review era que dados antigos de Epic usavam o mesmo `externalId = epic` para múltiplos usuários, o que quebraria o deploy ao criar o índice único.

## Como validar
- `cd backend && npm exec prisma validate`
- `cd backend && npm exec prisma generate`
- `cd backend && npm run test -- tests/unit/providers/provider-registry.test.ts tests/unit/providers/epic-identity.test.ts tests/unit/providers/provider-identity-migration.test.ts tests/unit/services/connected-account.service.test.ts tests/unit/services/discord-oauth.service.test.ts tests/unit/services/integrations.service.test.ts tests/integration/routes/integrations.routes.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Diagnóstico manual recomendado antes do deploy:
- `psql $DATABASE_URL -f backend/prisma/diagnostics/platform-integration-identity-duplicates.sql`

## Riscos e impactos
- A migration mantém a unicidade global por `platform + externalId`; se ainda houver duplicidade real depois do backfill Epic, a migration falha com erro explícito e aponta para a query diagnóstica.
- O fallback `legacy:epic:<userId>` não é identidade Epic confiável. Ele preserva a linha legada sem fingir ownership real do provider; reconexão futura pode ser necessária para normalizar Epic corretamente.
- Epic segue `EXPERIMENTAL`, sem capability de login social ou OAuth connect nesta PR.
- `CONNECTED_ACCOUNT_TOKEN_SECRET` deve ser configurado em produção para proteger tokens externos; há fallback local apenas fora de produção.
- O lint backend ainda reporta warnings preexistentes em `src/config/rate-limit.ts`, sem erro novo nesta PR.
- #272, #273, #275 e #276 seguem fora do escopo: login social completo, linking/unlink/reauth, Connection Center frontend e privacidade/visibilidade.

## Evidências
- Testes backend afetados: 7 arquivos, 61 testes passando.
- Typecheck backend: passou.
- Lint backend: passou com 3 warnings preexistentes em `rate-limit.ts`.
- Build backend: passou.
- Typecheck, lint e build frontend: passaram.
- Execução da query diagnóstica em Postgres local não foi possível neste ambiente porque `psql` não está instalado e Docker Desktop não está ativo; a migration e a query foram cobertas por teste de arquivo/ordem e validação Prisma do schema.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados