### PR TITLE
feat(auth): implemente login social com Google e Discord

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,8 +35,22 @@ DISCORD_CLIENT_SECRET=
 # URL pública registrada no app Discord.
 # Exemplo local: http://localhost/api/integrations/discord/callback
 DISCORD_REDIRECT_URI=
+# URL pública registrada para login social Discord.
+# Exemplo local: http://localhost/api/auth/social/discord/callback
+DISCORD_SOCIAL_REDIRECT_URI=
 # Opcional. Não é usado pelo fluxo OAuth de vinculação atual.
 DISCORD_BOT_TOKEN=
+
+# ── Google Social Login ──────────────────────────────────────
+# Obter em: https://console.cloud.google.com/apis/credentials
+# Exemplo local: http://localhost/api/auth/social/google/callback
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=
+
+# Segredo HMAC para state OAuth social. Se ausente fora de produção,
+# o backend usa fallback local de desenvolvimento.
+SOCIAL_OAUTH_STATE_SECRET=
 
 # ── IGDB (Twitch) ────────────────────────────────────────────
 # Obter em: https://dev.twitch.tv/console

--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -14,6 +14,7 @@ import {
   RefreshTokenRevokedError,
   RefreshTokenReuseError,
 } from '../../core/services/refresh-token.service';
+import { SocialAuthError } from '../../core/services/social-auth.service';
 import { AUTH_RATE_LIMIT_POLICIES } from '../../config/rate-limit';
 
 // ─────────────────────────────────────────────────────────────
@@ -41,6 +42,52 @@ const loginSchema = z.object({
   email:    z.string().email('Email inválido'),
   password: z.string().min(1, 'Senha obrigatória'),
 });
+
+const socialProviderParamsSchema = z.object({
+  provider: z.string().min(1),
+});
+
+const socialCallbackSchema = z.object({
+  code: z.string().min(1).optional(),
+  state: z.string().min(1).optional(),
+  error: z.string().min(1).optional(),
+}).refine(
+  (input) => Boolean(input.error) || (Boolean(input.code) && Boolean(input.state)),
+  {
+    message: 'Callback social inválido.',
+  },
+);
+
+function replyWithSocialAuthError(error: unknown): { statusCode: number; payload: { message: string } } {
+  if (error instanceof SocialAuthError) {
+    return {
+      statusCode: error.statusCode,
+      payload: {
+        message: error.clientMessage,
+      },
+    };
+  }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'SocialAuthError' &&
+    'statusCode' in error &&
+    typeof (error as { statusCode?: unknown }).statusCode === 'number' &&
+    'clientMessage' in error &&
+    typeof (error as { clientMessage?: unknown }).clientMessage === 'string'
+  ) {
+    return {
+      statusCode: (error as { statusCode: number }).statusCode,
+      payload: {
+        message: (error as { clientMessage: string }).clientMessage,
+      },
+    };
+  }
+
+  throw error;
+}
 
 export async function authRoutes(app: FastifyInstance): Promise<void> {
   async function issueAuthSession(
@@ -156,6 +203,100 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       message:  'Acesso autorizado.',
     });
   });
+
+  // ── GET /auth/social/:provider/start ─────────────────────
+  app.get<{ Params: { provider: string } }>(
+    '/social/:provider/start',
+    {
+      config: {
+        rateLimit: AUTH_RATE_LIMIT_POLICIES.login,
+      },
+    },
+    async (request, reply) => {
+      const paramsResult = socialProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider social inválido.' });
+      }
+
+      try {
+        const resultPayload = await app.socialAuthService.startLogin(paramsResult.data.provider);
+
+        request.log.info({
+          event: 'auth_social_login_started',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          provider: resultPayload.provider,
+          status: 200,
+        }, 'Social auth login started');
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const socialError = replyWithSocialAuthError(error);
+        return reply.status(socialError.statusCode).send(socialError.payload);
+      }
+    },
+  );
+
+  // ── GET /auth/social/:provider/callback ──────────────────
+  app.get<{
+    Params: { provider: string };
+    Querystring: { code?: string; state?: string; error?: string };
+  }>(
+    '/social/:provider/callback',
+    {
+      config: {
+        rateLimit: AUTH_RATE_LIMIT_POLICIES.login,
+      },
+    },
+    async (request, reply) => {
+      const paramsResult = socialProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider social inválido.' });
+      }
+
+      const queryResult = socialCallbackSchema.safeParse(request.query);
+
+      if (!queryResult.success) {
+        return reply.status(400).send({ message: 'Callback social inválido.' });
+      }
+
+      try {
+        const socialResult = await app.socialAuthService.completeCallback({
+          provider: paramsResult.data.provider,
+          code: queryResult.data.code,
+          state: queryResult.data.state,
+          providerError: queryResult.data.error,
+          requestId: request.id,
+        });
+        const token = await issueAuthSession(socialResult.user, reply);
+
+        request.log.info({
+          event: 'auth_social_login_succeeded',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          provider: socialResult.provider,
+          status: 200,
+          userId: socialResult.user.id,
+          username: socialResult.user.username,
+          isNewUser: socialResult.isNewUser,
+        }, 'Social auth login succeeded');
+
+        return reply.status(200).send({
+          id: socialResult.user.id,
+          username: socialResult.user.username,
+          token,
+          message: 'Acesso autorizado.',
+        });
+      } catch (error) {
+        const socialError = replyWithSocialAuthError(error);
+        return reply.status(socialError.statusCode).send(socialError.payload);
+      }
+    },
+  );
 
   // ── POST /auth/refresh ───────────────────────────────────
   app.post('/refresh', {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -43,6 +43,10 @@ import {
   createDiscordPresenceService,
   type DiscordPresenceService,
 } from './core/services/discord-presence.service';
+import {
+  createSocialAuthService,
+  type SocialAuthService,
+} from './core/services/social-auth.service';
 import { ensureMediaUploadsDirectory } from './config/media-upload';
 import type Redis from 'ioredis';
 
@@ -56,6 +60,7 @@ export type BuildAppOptions = {
   integrationsService?: IntegrationsService;
   discordOAuthService?: DiscordOAuthService;
   discordPresenceService?: DiscordPresenceService;
+  socialAuthService?: SocialAuthService;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -81,6 +86,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   const integrationsService = options.integrationsService ?? createIntegrationsService();
   const discordOAuthService = options.discordOAuthService ?? createDiscordOAuthService();
   const discordPresenceService = options.discordPresenceService ?? createDiscordPresenceService();
+  const socialAuthService = options.socialAuthService ?? createSocialAuthService();
   const resolvedRateLimitRedis =
     options.rateLimitRedis !== undefined
       ? options.rateLimitRedis
@@ -95,6 +101,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   app.decorate('integrationsService', integrationsService);
   app.decorate('discordOAuthService', discordOAuthService);
   app.decorate('discordPresenceService', discordPresenceService);
+  app.decorate('socialAuthService', socialAuthService);
 
   await app.register(
     fastifyRateLimit,

--- a/backend/src/core/providers/provider-registry.ts
+++ b/backend/src/core/providers/provider-registry.ts
@@ -25,7 +25,7 @@ const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
     provider: 'GOOGLE',
     displayName: 'Google',
     dataSource: 'OFFICIAL',
-    status: 'UNAVAILABLE',
+    status: 'CONNECTED',
     capabilities: ['SOCIAL_LOGIN', 'OAUTH_CONNECT'],
   },
   {

--- a/backend/src/core/repositories/user.repository.ts
+++ b/backend/src/core/repositories/user.repository.ts
@@ -11,6 +11,8 @@ export interface CreateUserInput {
   username: string;
   email:    string;
   password: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
 }
 
 export const userRepository = {
@@ -43,7 +45,8 @@ export const userRepository = {
         password_hash: input.password,
         profile: {
           create: {
-            displayName: input.username,
+            displayName: input.displayName ?? input.username,
+            avatarUrl: input.avatarUrl ?? null,
           },
         },
         stats: {

--- a/backend/src/core/services/social-auth.service.ts
+++ b/backend/src/core/services/social-auth.service.ts
@@ -58,6 +58,11 @@ export type SocialAuthProviderClient = {
   exchangeCodeForIdentity(code: string): Promise<SocialAuthProviderIdentity>;
 };
 
+export type SocialOAuthStateStore = {
+  store(state: string, ttlMs: number): Promise<void>;
+  consume(state: string): Promise<boolean>;
+};
+
 export type SocialAuthService = {
   startLogin(provider: string): Promise<SocialAuthStartResult>;
   completeCallback(input: {
@@ -119,6 +124,7 @@ type SocialAuthDependencies = {
     'findByProviderExternalId' | 'findByUserProvider'
   >;
   connectedAccountService?: Pick<ConnectedAccountService, 'connectExternalIdentity'>;
+  stateStore?: SocialOAuthStateStore;
   hashPassword?: (rawPassword: string) => Promise<string>;
 };
 
@@ -252,6 +258,40 @@ export function createSocialOAuthState(provider: SocialAuthProvider): { state: s
   };
 }
 
+export function createInMemorySocialOAuthStateStore(): SocialOAuthStateStore {
+  const states = new Map<string, number>();
+
+  function pruneExpiredStates(): void {
+    const now = Date.now();
+
+    for (const [state, expiresAt] of states.entries()) {
+      if (expiresAt <= now) {
+        states.delete(state);
+      }
+    }
+  }
+
+  return {
+    async store(state, ttlMs): Promise<void> {
+      pruneExpiredStates();
+      states.set(state, Date.now() + ttlMs);
+    },
+
+    async consume(state): Promise<boolean> {
+      pruneExpiredStates();
+      const expiresAt = states.get(state);
+
+      if (!expiresAt || expiresAt <= Date.now()) {
+        states.delete(state);
+        return false;
+      }
+
+      states.delete(state);
+      return true;
+    },
+  };
+}
+
 function isSocialAuthProvider(value: unknown): value is SocialAuthProvider {
   return value === 'GOOGLE' || value === 'DISCORD';
 }
@@ -316,7 +356,7 @@ async function buildAvailableUsername(
   identity: SocialAuthProviderIdentity,
   users: SocialAuthUserGateway,
 ): Promise<string> {
-  const emailLocalPart = identity.email?.split('@')[0] ?? null;
+  const emailLocalPart = identity.emailVerified ? identity.email?.split('@')[0] ?? null : null;
   const base = sanitizeUsernameSeed(identity.username ?? identity.displayName ?? emailLocalPart);
   const existingBaseUser = await users.findByUsername(base);
 
@@ -367,6 +407,7 @@ export function createSocialAuthService(
   const users = dependencies.users ?? userRepository;
   const connectedAccounts = dependencies.connectedAccounts ?? createConnectedAccountRepository();
   const connectedAccountService = dependencies.connectedAccountService ?? createConnectedAccountService();
+  const stateStore = dependencies.stateStore ?? createInMemorySocialOAuthStateStore();
   const providerClients = {
     GOOGLE: dependencies.providerClients?.GOOGLE ?? googleSocialOAuthClient,
     DISCORD: dependencies.providerClients?.DISCORD ?? discordSocialOAuthClient,
@@ -383,10 +424,12 @@ export function createSocialAuthService(
       const existingEmailUser = await users.findByEmail(verifiedEmail);
 
       if (existingEmailUser) {
-        return {
-          user: existingEmailUser,
-          isNewUser: false,
-        };
+        throw createSocialAuthError({
+          statusCode: 409,
+          reason: 'identity_conflict',
+          clientMessage: 'Já existe uma conta com este email. Entre com senha e vincule o provider depois.',
+          provider: identity.provider,
+        });
       }
     }
 
@@ -412,10 +455,13 @@ export function createSocialAuthService(
       const socialProvider = normalizeSocialAuthProvider(provider);
       const client = providerClients[socialProvider];
       const { state, nonce } = createSocialOAuthState(socialProvider);
+      const authorizationUrl = client.createAuthorizationUrl({ state, nonce });
+
+      await stateStore.store(state, SOCIAL_STATE_TTL_MS);
 
       return {
         provider: socialProvider,
-        authorizationUrl: client.createAuthorizationUrl({ state, nonce }),
+        authorizationUrl,
       };
     },
 
@@ -441,6 +487,15 @@ export function createSocialAuthService(
       }
 
       verifyStateValue(input.state, socialProvider);
+
+      if (!await stateStore.consume(input.state)) {
+        throw createSocialAuthError({
+          statusCode: 400,
+          reason: 'invalid_state',
+          clientMessage: 'Callback social inválido ou expirado.',
+          provider: socialProvider,
+        });
+      }
 
       let identity: SocialAuthProviderIdentity;
 

--- a/backend/src/core/services/social-auth.service.ts
+++ b/backend/src/core/services/social-auth.service.ts
@@ -1,0 +1,539 @@
+/* eslint-disable no-unused-vars */
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import bcrypt from 'bcrypt';
+import type { Platform, Prisma, User } from '@prisma/client';
+import { getProviderDefinition } from '../providers/provider-registry';
+import {
+  ConnectedAccountConflictError,
+  createConnectedAccountService,
+  type ConnectedAccountService,
+} from './connected-account.service';
+import {
+  createConnectedAccountRepository,
+  type ConnectedAccountRepository,
+} from '../repositories/connected-account.repository';
+import { userRepository, type CreateUserInput } from '../repositories/user.repository';
+import {
+  discordSocialOAuthClient,
+  googleSocialOAuthClient,
+} from '../../infra/integrations/social/social-oauth.clients';
+import { IntegrationError } from '../../infra/integrations/integration.errors';
+
+const SOCIAL_STATE_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_DEVELOPMENT_STATE_SECRET = 'clutch-social-oauth-dev-secret';
+const SOCIAL_PLACEHOLDER_EMAIL_DOMAIN = 'users.clutch.local';
+const USERNAME_MAX_LENGTH = 30;
+const USERNAME_SUFFIX_LENGTH = 6;
+const SOCIAL_PASSWORD_SALT_ROUNDS = 12;
+
+export type SocialAuthProvider = 'GOOGLE' | 'DISCORD';
+
+export type SocialAuthStartResult = {
+  provider: SocialAuthProvider;
+  authorizationUrl: string;
+};
+
+export type SocialAuthCallbackResult = {
+  provider: SocialAuthProvider;
+  user: Pick<User, 'id' | 'username'>;
+  isNewUser: boolean;
+};
+
+export type SocialAuthProviderIdentity = {
+  provider: SocialAuthProvider;
+  externalId: string;
+  email: string | null;
+  emailVerified: boolean;
+  displayName: string | null;
+  username: string | null;
+  avatarUrl: string | null;
+  accessToken: string;
+  refreshToken: string | null;
+  metadata: Prisma.InputJsonObject;
+};
+
+export type SocialAuthProviderClient = {
+  provider: SocialAuthProvider;
+  createAuthorizationUrl(input: { state: string; nonce: string }): string;
+  exchangeCodeForIdentity(code: string): Promise<SocialAuthProviderIdentity>;
+};
+
+export type SocialAuthService = {
+  startLogin(provider: string): Promise<SocialAuthStartResult>;
+  completeCallback(input: {
+    provider: string;
+    code?: string;
+    state?: string;
+    providerError?: string;
+    requestId?: string;
+  }): Promise<SocialAuthCallbackResult>;
+};
+
+export type SocialAuthErrorReason =
+  | 'unsupported_provider'
+  | 'invalid_request'
+  | 'invalid_state'
+  | 'provider_unavailable'
+  | 'identity_conflict';
+
+export class SocialAuthError extends Error {
+  readonly statusCode: number;
+  readonly reason: SocialAuthErrorReason;
+  readonly clientMessage: string;
+  readonly provider: SocialAuthProvider | null;
+
+  constructor(input: {
+    statusCode: number;
+    reason: SocialAuthErrorReason;
+    clientMessage: string;
+    provider?: SocialAuthProvider | null;
+  }) {
+    super(input.clientMessage);
+    this.name = 'SocialAuthError';
+    this.statusCode = input.statusCode;
+    this.reason = input.reason;
+    this.clientMessage = input.clientMessage;
+    this.provider = input.provider ?? null;
+  }
+}
+
+type SocialStatePayload = {
+  purpose: 'social_login';
+  provider: SocialAuthProvider;
+  nonce: string;
+  issuedAt: number;
+};
+
+type SocialAuthUserGateway = {
+  findById(id: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  findByUsername(username: string): Promise<User | null>;
+  create(input: CreateUserInput): Promise<User>;
+};
+
+type SocialAuthDependencies = {
+  providerClients?: Partial<Record<SocialAuthProvider, SocialAuthProviderClient>>;
+  users?: SocialAuthUserGateway;
+  connectedAccounts?: Pick<
+    ConnectedAccountRepository,
+    'findByProviderExternalId' | 'findByUserProvider'
+  >;
+  connectedAccountService?: Pick<ConnectedAccountService, 'connectExternalIdentity'>;
+  hashPassword?: (rawPassword: string) => Promise<string>;
+};
+
+function createSocialAuthError(input: {
+  statusCode: number;
+  reason: SocialAuthErrorReason;
+  clientMessage: string;
+  provider?: SocialAuthProvider | null;
+}): SocialAuthError {
+  return new SocialAuthError(input);
+}
+
+function resolveStateSecret(): string {
+  const configuredSecret = process.env['SOCIAL_OAUTH_STATE_SECRET']?.trim()
+    ?? process.env['JWT_SECRET']?.trim();
+
+  if (configuredSecret && configuredSecret.length > 0) {
+    return configuredSecret;
+  }
+
+  if (process.env['NODE_ENV'] === 'production') {
+    throw createSocialAuthError({
+      statusCode: 503,
+      reason: 'provider_unavailable',
+      clientMessage: 'Login social indisponível no runtime atual.',
+    });
+  }
+
+  return DEFAULT_DEVELOPMENT_STATE_SECRET;
+}
+
+function signState(encodedPayload: string): string {
+  return createHmac('sha256', resolveStateSecret()).update(encodedPayload).digest('base64url');
+}
+
+function encodeStatePayload(payload: SocialStatePayload): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function decodeStatePayload(value: string): SocialStatePayload {
+  let parsedPayload: Partial<SocialStatePayload>;
+
+  try {
+    parsedPayload = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Partial<SocialStatePayload>;
+  } catch {
+    throw createSocialAuthError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback social inválido.',
+    });
+  }
+
+  if (
+    parsedPayload.purpose !== 'social_login' ||
+    !isSocialAuthProvider(parsedPayload.provider) ||
+    typeof parsedPayload.nonce !== 'string' ||
+    parsedPayload.nonce.length === 0 ||
+    typeof parsedPayload.issuedAt !== 'number' ||
+    !Number.isFinite(parsedPayload.issuedAt)
+  ) {
+    throw createSocialAuthError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback social inválido.',
+    });
+  }
+
+  return {
+    purpose: 'social_login',
+    provider: parsedPayload.provider,
+    nonce: parsedPayload.nonce,
+    issuedAt: parsedPayload.issuedAt,
+  };
+}
+
+function verifyStateValue(state: string, provider: SocialAuthProvider): SocialStatePayload {
+  const segments = state.split('.');
+
+  if (segments.length !== 2 || !segments[0] || !segments[1]) {
+    throw createSocialAuthError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback social inválido.',
+      provider,
+    });
+  }
+
+  const [encodedPayload, receivedSignature] = segments;
+  const expectedSignature = signState(encodedPayload);
+  const receivedBuffer = Buffer.from(receivedSignature, 'utf8');
+  const expectedBuffer = Buffer.from(expectedSignature, 'utf8');
+
+  if (
+    receivedBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(receivedBuffer, expectedBuffer)
+  ) {
+    throw createSocialAuthError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback social inválido.',
+      provider,
+    });
+  }
+
+  const payload = decodeStatePayload(encodedPayload);
+
+  if (payload.provider !== provider || Date.now() - payload.issuedAt > SOCIAL_STATE_TTL_MS) {
+    throw createSocialAuthError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback social inválido ou expirado.',
+      provider,
+    });
+  }
+
+  return payload;
+}
+
+export function createSocialOAuthState(provider: SocialAuthProvider): { state: string; nonce: string } {
+  const nonce = randomUUID();
+  const encodedPayload = encodeStatePayload({
+    purpose: 'social_login',
+    provider,
+    nonce,
+    issuedAt: Date.now(),
+  });
+
+  return {
+    nonce,
+    state: `${encodedPayload}.${signState(encodedPayload)}`,
+  };
+}
+
+function isSocialAuthProvider(value: unknown): value is SocialAuthProvider {
+  return value === 'GOOGLE' || value === 'DISCORD';
+}
+
+function normalizeSocialAuthProvider(provider: string): SocialAuthProvider {
+  const normalizedProvider = provider.trim().toUpperCase();
+
+  if (!isSocialAuthProvider(normalizedProvider)) {
+    throw createSocialAuthError({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+      clientMessage: 'Provider social não suportado.',
+    });
+  }
+
+  const providerDefinition = getProviderDefinition(normalizedProvider as Platform);
+
+  if (
+    providerDefinition.status === 'UNAVAILABLE' ||
+    !providerDefinition.capabilities.includes('SOCIAL_LOGIN')
+  ) {
+    throw createSocialAuthError({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+      clientMessage: 'Provider social não suportado.',
+      provider: normalizedProvider,
+    });
+  }
+
+  return normalizedProvider;
+}
+
+function normalizeVerifiedEmail(identity: SocialAuthProviderIdentity): string | null {
+  if (!identity.emailVerified || !identity.email) {
+    return null;
+  }
+
+  return identity.email.trim().toLowerCase();
+}
+
+function buildPlaceholderEmail(provider: SocialAuthProvider, externalId: string): string {
+  const safeExternalId = externalId.toLowerCase().replace(/[^a-z0-9_-]+/gu, '-');
+  return `social+${provider.toLowerCase()}-${safeExternalId}@${SOCIAL_PLACEHOLDER_EMAIL_DOMAIN}`;
+}
+
+function sanitizeUsernameSeed(value: string | null): string {
+  const sanitized = (value ?? 'player')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/gu, '')
+    .replace(/[^a-zA-Z0-9_]+/gu, '_')
+    .replace(/^_+|_+$/gu, '')
+    .toLowerCase();
+
+  if (sanitized.length >= 3) {
+    return sanitized.slice(0, USERNAME_MAX_LENGTH);
+  }
+
+  return 'player';
+}
+
+async function buildAvailableUsername(
+  identity: SocialAuthProviderIdentity,
+  users: SocialAuthUserGateway,
+): Promise<string> {
+  const emailLocalPart = identity.email?.split('@')[0] ?? null;
+  const base = sanitizeUsernameSeed(identity.username ?? identity.displayName ?? emailLocalPart);
+  const existingBaseUser = await users.findByUsername(base);
+
+  if (!existingBaseUser) {
+    return base;
+  }
+
+  const suffix = createHmac('sha256', resolveStateSecret())
+    .update(`${identity.provider}:${identity.externalId}`)
+    .digest('hex')
+    .slice(0, USERNAME_SUFFIX_LENGTH);
+  const truncatedBase = base.slice(0, USERNAME_MAX_LENGTH - USERNAME_SUFFIX_LENGTH - 1);
+  const candidate = `${truncatedBase}_${suffix}`;
+  const existingCandidateUser = await users.findByUsername(candidate);
+
+  if (!existingCandidateUser) {
+    return candidate;
+  }
+
+  return `player_${randomUUID().replace(/-/gu, '').slice(0, 12)}`;
+}
+
+function mapProviderFailure(error: unknown, provider: SocialAuthProvider): never {
+  if (error instanceof SocialAuthError) {
+    throw error;
+  }
+
+  if (error instanceof IntegrationError) {
+    throw createSocialAuthError({
+      statusCode: error.statusCode,
+      reason: error.reason === 'invalid_request' ? 'invalid_request' : 'provider_unavailable',
+      clientMessage: error.clientMessage,
+      provider,
+    });
+  }
+
+  throw createSocialAuthError({
+    statusCode: 503,
+    reason: 'provider_unavailable',
+    clientMessage: `Login ${provider === 'GOOGLE' ? 'Google' : 'Discord'} indisponível no momento.`,
+    provider,
+  });
+}
+
+export function createSocialAuthService(
+  dependencies: SocialAuthDependencies = {},
+): SocialAuthService {
+  const users = dependencies.users ?? userRepository;
+  const connectedAccounts = dependencies.connectedAccounts ?? createConnectedAccountRepository();
+  const connectedAccountService = dependencies.connectedAccountService ?? createConnectedAccountService();
+  const providerClients = {
+    GOOGLE: dependencies.providerClients?.GOOGLE ?? googleSocialOAuthClient,
+    DISCORD: dependencies.providerClients?.DISCORD ?? discordSocialOAuthClient,
+  };
+  const hashPassword = dependencies.hashPassword
+    ?? ((rawPassword: string): Promise<string> => bcrypt.hash(rawPassword, SOCIAL_PASSWORD_SALT_ROUNDS));
+
+  async function resolveOrCreateUser(
+    identity: SocialAuthProviderIdentity,
+  ): Promise<{ user: User; isNewUser: boolean }> {
+    const verifiedEmail = normalizeVerifiedEmail(identity);
+
+    if (verifiedEmail) {
+      const existingEmailUser = await users.findByEmail(verifiedEmail);
+
+      if (existingEmailUser) {
+        return {
+          user: existingEmailUser,
+          isNewUser: false,
+        };
+      }
+    }
+
+    const username = await buildAvailableUsername(identity, users);
+    const email = verifiedEmail ?? buildPlaceholderEmail(identity.provider, identity.externalId);
+    const password = await hashPassword(randomUUID());
+    const user = await users.create({
+      username,
+      email,
+      password,
+      displayName: identity.displayName ?? username,
+      avatarUrl: identity.avatarUrl,
+    });
+
+    return {
+      user,
+      isNewUser: true,
+    };
+  }
+
+  return {
+    async startLogin(provider): Promise<SocialAuthStartResult> {
+      const socialProvider = normalizeSocialAuthProvider(provider);
+      const client = providerClients[socialProvider];
+      const { state, nonce } = createSocialOAuthState(socialProvider);
+
+      return {
+        provider: socialProvider,
+        authorizationUrl: client.createAuthorizationUrl({ state, nonce }),
+      };
+    },
+
+    async completeCallback(input): Promise<SocialAuthCallbackResult> {
+      const socialProvider = normalizeSocialAuthProvider(input.provider);
+
+      if (input.providerError) {
+        throw createSocialAuthError({
+          statusCode: 400,
+          reason: 'invalid_request',
+          clientMessage: 'Login social cancelado ou negado pelo provider.',
+          provider: socialProvider,
+        });
+      }
+
+      if (!input.code || !input.state) {
+        throw createSocialAuthError({
+          statusCode: 400,
+          reason: 'invalid_request',
+          clientMessage: 'Callback social inválido.',
+          provider: socialProvider,
+        });
+      }
+
+      verifyStateValue(input.state, socialProvider);
+
+      let identity: SocialAuthProviderIdentity;
+
+      try {
+        identity = await providerClients[socialProvider].exchangeCodeForIdentity(input.code);
+      } catch (error) {
+        mapProviderFailure(error, socialProvider);
+      }
+
+      if (identity.provider !== socialProvider) {
+        throw createSocialAuthError({
+          statusCode: 400,
+          reason: 'invalid_request',
+          clientMessage: 'Identidade social inválida.',
+          provider: socialProvider,
+        });
+      }
+
+      const existingIdentity = await connectedAccounts.findByProviderExternalId(
+        socialProvider,
+        identity.externalId,
+      );
+
+      if (existingIdentity) {
+        const owner = await users.findById(existingIdentity.userId);
+
+        if (!owner) {
+          throw createSocialAuthError({
+            statusCode: 409,
+            reason: 'identity_conflict',
+            clientMessage: 'Identidade social vinculada a uma conta indisponível.',
+            provider: socialProvider,
+          });
+        }
+
+        return {
+          provider: socialProvider,
+          user: owner,
+          isNewUser: false,
+        };
+      }
+
+      const { user, isNewUser } = await resolveOrCreateUser(identity);
+      const existingUserProvider = await connectedAccounts.findByUserProvider(user.id, socialProvider);
+
+      if (existingUserProvider && existingUserProvider.externalId !== identity.externalId) {
+        throw createSocialAuthError({
+          statusCode: 409,
+          reason: 'identity_conflict',
+          clientMessage: 'Este usuário já possui outro login social vinculado para este provider.',
+          provider: socialProvider,
+        });
+      }
+
+      try {
+        await connectedAccountService.connectExternalIdentity({
+          userId: user.id,
+          provider: socialProvider,
+          externalId: identity.externalId,
+          connectionType: 'SOCIAL_LOGIN',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+          accessToken: identity.accessToken,
+          refreshToken: identity.refreshToken,
+          metadata: {
+            ...identity.metadata,
+            email: identity.email,
+            emailVerified: identity.emailVerified,
+            displayName: identity.displayName,
+            username: identity.username,
+            avatarUrl: identity.avatarUrl,
+            source: 'social_login',
+          },
+          lastSyncAt: new Date(),
+        });
+      } catch (error) {
+        if (error instanceof ConnectedAccountConflictError) {
+          throw createSocialAuthError({
+            statusCode: 409,
+            reason: 'identity_conflict',
+            clientMessage: 'Esta identidade social já está vinculada a outro usuário.',
+            provider: socialProvider,
+          });
+        }
+
+        throw error;
+      }
+
+      return {
+        provider: socialProvider,
+        user,
+        isNewUser,
+      };
+    },
+  };
+}

--- a/backend/src/infra/integrations/discord/discord.service.ts
+++ b/backend/src/infra/integrations/discord/discord.service.ts
@@ -245,8 +245,9 @@ export const discordService = {
     return validateStateValue(state, config.clientSecret);
   },
 
-  async exchangeCode(code: string): Promise<DiscordTokenSet> {
+  async exchangeCodeWithRedirectUri(code: string, redirectUri: string): Promise<DiscordTokenSet> {
     const config = resolveDiscordOAuthConfig();
+    assertValidRedirectUri(redirectUri);
 
     try {
       const response = await axios.post<DiscordTokenResponse>(
@@ -256,7 +257,7 @@ export const discordService = {
           client_secret: config.clientSecret,
           grant_type: 'authorization_code',
           code,
-          redirect_uri: config.redirectUri,
+          redirect_uri: redirectUri,
         }).toString(),
         {
           headers: {
@@ -296,6 +297,11 @@ export const discordService = {
         { targetUrl: DISCORD_TOKEN_URL },
       );
     }
+  },
+
+  async exchangeCode(code: string): Promise<DiscordTokenSet> {
+    const config = resolveDiscordOAuthConfig();
+    return this.exchangeCodeWithRedirectUri(code, config.redirectUri);
   },
 
   async getCurrentUser(accessToken: string): Promise<DiscordIdentity> {

--- a/backend/src/infra/integrations/integration.errors.ts
+++ b/backend/src/infra/integrations/integration.errors.ts
@@ -3,7 +3,7 @@ import {
   writeBackendRuntimeLog,
 } from '../../config/logging';
 
-export type IntegrationName = 'steam' | 'igdb' | 'epic' | 'discord';
+export type IntegrationName = 'steam' | 'igdb' | 'epic' | 'discord' | 'google';
 
 export type IntegrationErrorReason =
   | 'invalid_request'

--- a/backend/src/infra/integrations/social/social-oauth.clients.ts
+++ b/backend/src/infra/integrations/social/social-oauth.clients.ts
@@ -1,0 +1,314 @@
+import axios from 'axios';
+import {
+  createIntegrationError,
+  logIntegrationProviderEvent,
+  translateUpstreamError,
+} from '../integration.errors';
+import {
+  discordService,
+  type DiscordTokenSet,
+} from '../discord/discord.service';
+import type {
+  SocialAuthProviderClient,
+  SocialAuthProviderIdentity,
+} from '../../../core/services/social-auth.service';
+
+const GOOGLE_AUTHORIZE_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://openidconnect.googleapis.com/v1/userinfo';
+const GOOGLE_TIMEOUT_MS = 10_000;
+
+type GoogleOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+};
+
+type DiscordSocialOAuthConfig = {
+  clientId: string;
+  redirectUri: string;
+};
+
+type GoogleTokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+};
+
+type GoogleUserInfoResponse = {
+  sub: string;
+  email?: string;
+  email_verified?: boolean | string;
+  name?: string;
+  picture?: string;
+};
+
+function assertValidRedirectUri(provider: 'google' | 'discord', redirectUri: string): void {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(redirectUri);
+  } catch {
+    throw createIntegrationError(
+      provider,
+      503,
+      'misconfigured',
+      `Login ${provider === 'google' ? 'Google' : 'Discord'} indisponível no runtime atual.`,
+    );
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol) || parsedUrl.username || parsedUrl.password) {
+    throw createIntegrationError(
+      provider,
+      503,
+      'misconfigured',
+      `Login ${provider === 'google' ? 'Google' : 'Discord'} indisponível no runtime atual.`,
+    );
+  }
+}
+
+function resolveGoogleOAuthConfig(): GoogleOAuthConfig {
+  const clientId = process.env['GOOGLE_CLIENT_ID']?.trim();
+  const clientSecret = process.env['GOOGLE_CLIENT_SECRET']?.trim();
+  const redirectUri = process.env['GOOGLE_REDIRECT_URI']?.trim();
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    logIntegrationProviderEvent(
+      'google',
+      'integration_google_unavailable',
+      'misconfigured',
+      'Google social login config is incomplete in the current runtime.',
+    );
+
+    throw createIntegrationError(
+      'google',
+      503,
+      'misconfigured',
+      'Login Google indisponível no runtime atual.',
+    );
+  }
+
+  assertValidRedirectUri('google', redirectUri);
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri,
+  };
+}
+
+function resolveDiscordSocialOAuthConfig(): DiscordSocialOAuthConfig {
+  const clientId = process.env['DISCORD_CLIENT_ID']?.trim();
+  const redirectUri = process.env['DISCORD_SOCIAL_REDIRECT_URI']?.trim();
+
+  if (!clientId || !redirectUri) {
+    logIntegrationProviderEvent(
+      'discord',
+      'integration_discord_unavailable',
+      'misconfigured',
+      'Discord social login config is incomplete in the current runtime.',
+    );
+
+    throw createIntegrationError(
+      'discord',
+      503,
+      'misconfigured',
+      'Login Discord indisponível no runtime atual.',
+    );
+  }
+
+  assertValidRedirectUri('discord', redirectUri);
+
+  return {
+    clientId,
+    redirectUri,
+  };
+}
+
+function normalizeGoogleEmailVerified(value: GoogleUserInfoResponse['email_verified']): boolean {
+  return value === true || value === 'true';
+}
+
+async function exchangeGoogleCode(code: string, config: GoogleOAuthConfig): Promise<GoogleTokenResponse> {
+  try {
+    const response = await axios.post<GoogleTokenResponse>(
+      GOOGLE_TOKEN_URL,
+      new URLSearchParams({
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: config.redirectUri,
+      }).toString(),
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        timeout: GOOGLE_TIMEOUT_MS,
+      },
+    );
+
+    return response.data;
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'response' in error &&
+      typeof (error as { response?: { status?: number } }).response?.status === 'number' &&
+      [400, 401, 403].includes((error as { response?: { status?: number } }).response?.status as number)
+    ) {
+      throw createIntegrationError(
+        'google',
+        400,
+        'invalid_request',
+        'Autorização Google inválida ou expirada.',
+      );
+    }
+
+    throw translateUpstreamError(
+      'google',
+      error,
+      'Login Google indisponível no momento.',
+      { targetUrl: GOOGLE_TOKEN_URL },
+    );
+  }
+}
+
+async function fetchGoogleUserInfo(accessToken: string): Promise<GoogleUserInfoResponse> {
+  try {
+    const response = await axios.get<GoogleUserInfoResponse>(
+      GOOGLE_USERINFO_URL,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        timeout: GOOGLE_TIMEOUT_MS,
+      },
+    );
+
+    return response.data;
+  } catch (error) {
+    throw translateUpstreamError(
+      'google',
+      error,
+      'Login Google indisponível no momento.',
+      { targetUrl: GOOGLE_USERINFO_URL },
+    );
+  }
+}
+
+function buildGoogleAuthorizationUrl(state: string, nonce: string): string {
+  const config = resolveGoogleOAuthConfig();
+  const authorizationUrl = new URL(GOOGLE_AUTHORIZE_URL);
+
+  authorizationUrl.searchParams.set('client_id', config.clientId);
+  authorizationUrl.searchParams.set('response_type', 'code');
+  authorizationUrl.searchParams.set('redirect_uri', config.redirectUri);
+  authorizationUrl.searchParams.set('scope', 'openid email profile');
+  authorizationUrl.searchParams.set('state', state);
+  authorizationUrl.searchParams.set('nonce', nonce);
+  authorizationUrl.searchParams.set('prompt', 'select_account');
+
+  return authorizationUrl.toString();
+}
+
+function buildDiscordAuthorizationUrl(state: string): string {
+  const config = resolveDiscordSocialOAuthConfig();
+  const authorizationUrl = new URL('https://discord.com/oauth2/authorize');
+
+  authorizationUrl.searchParams.set('client_id', config.clientId);
+  authorizationUrl.searchParams.set('response_type', 'code');
+  authorizationUrl.searchParams.set('redirect_uri', config.redirectUri);
+  authorizationUrl.searchParams.set('scope', 'identify');
+  authorizationUrl.searchParams.set('state', state);
+  authorizationUrl.searchParams.set('prompt', 'consent');
+
+  return authorizationUrl.toString();
+}
+
+function toDiscordIdentity(tokenSet: DiscordTokenSet, identity: {
+  id: string;
+  username: string;
+  globalName: string | null;
+  avatarUrl: string | null;
+}): SocialAuthProviderIdentity {
+  return {
+    provider: 'DISCORD',
+    externalId: identity.id,
+    email: null,
+    emailVerified: false,
+    displayName: identity.globalName ?? identity.username,
+    username: identity.username,
+    avatarUrl: identity.avatarUrl,
+    accessToken: tokenSet.accessToken,
+    refreshToken: tokenSet.refreshToken,
+    metadata: {
+      username: identity.username,
+      globalName: identity.globalName,
+      avatarUrl: identity.avatarUrl,
+      tokenType: tokenSet.tokenType,
+      scope: tokenSet.scope,
+    },
+  };
+}
+
+export const googleSocialOAuthClient: SocialAuthProviderClient = {
+  provider: 'GOOGLE',
+
+  createAuthorizationUrl({ state, nonce }): string {
+    return buildGoogleAuthorizationUrl(state, nonce);
+  },
+
+  async exchangeCodeForIdentity(code): Promise<SocialAuthProviderIdentity> {
+    const config = resolveGoogleOAuthConfig();
+    const tokenSet = await exchangeGoogleCode(code, config);
+    const userInfo = await fetchGoogleUserInfo(tokenSet.access_token);
+
+    if (typeof userInfo.sub !== 'string' || userInfo.sub.trim().length === 0) {
+      throw createIntegrationError(
+        'google',
+        400,
+        'invalid_request',
+        'Identidade Google inválida.',
+      );
+    }
+
+    return {
+      provider: 'GOOGLE',
+      externalId: userInfo.sub,
+      email: userInfo.email ?? null,
+      emailVerified: normalizeGoogleEmailVerified(userInfo.email_verified),
+      displayName: userInfo.name ?? null,
+      username: userInfo.email?.split('@')[0] ?? null,
+      avatarUrl: userInfo.picture ?? null,
+      accessToken: tokenSet.access_token,
+      refreshToken: tokenSet.refresh_token ?? null,
+      metadata: {
+        email: userInfo.email ?? null,
+        emailVerified: normalizeGoogleEmailVerified(userInfo.email_verified),
+        name: userInfo.name ?? null,
+        picture: userInfo.picture ?? null,
+        tokenType: tokenSet.token_type,
+        scope: tokenSet.scope,
+      },
+    };
+  },
+};
+
+export const discordSocialOAuthClient: SocialAuthProviderClient = {
+  provider: 'DISCORD',
+
+  createAuthorizationUrl({ state }): string {
+    return buildDiscordAuthorizationUrl(state);
+  },
+
+  async exchangeCodeForIdentity(code): Promise<SocialAuthProviderIdentity> {
+    const config = resolveDiscordSocialOAuthConfig();
+    const tokenSet = await discordService.exchangeCodeWithRedirectUri(code, config.redirectUri);
+    const identity = await discordService.getCurrentUser(tokenSet.accessToken);
+
+    return toDiscordIdentity(tokenSet, identity);
+  },
+};

--- a/backend/src/infra/integrations/social/social-oauth.clients.ts
+++ b/backend/src/infra/integrations/social/social-oauth.clients.ts
@@ -275,19 +275,21 @@ export const googleSocialOAuthClient: SocialAuthProviderClient = {
       );
     }
 
+    const emailVerified = normalizeGoogleEmailVerified(userInfo.email_verified);
+
     return {
       provider: 'GOOGLE',
       externalId: userInfo.sub,
       email: userInfo.email ?? null,
-      emailVerified: normalizeGoogleEmailVerified(userInfo.email_verified),
+      emailVerified,
       displayName: userInfo.name ?? null,
-      username: userInfo.email?.split('@')[0] ?? null,
+      username: emailVerified ? userInfo.email?.split('@')[0] ?? null : null,
       avatarUrl: userInfo.picture ?? null,
       accessToken: tokenSet.access_token,
       refreshToken: tokenSet.refresh_token ?? null,
       metadata: {
         email: userInfo.email ?? null,
-        emailVerified: normalizeGoogleEmailVerified(userInfo.email_verified),
+        emailVerified,
         name: userInfo.name ?? null,
         picture: userInfo.picture ?? null,
         tokenType: tokenSet.token_type,

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -5,6 +5,7 @@ import type { DiscordOAuthService } from '../core/services/discord-oauth.service
 import type { DiscordPresenceService } from '../core/services/discord-presence.service';
 import type { IntegrationsService } from '../core/services/integrations.service';
 import type { RefreshTokenService } from '../core/services/refresh-token.service';
+import type { SocialAuthService } from '../core/services/social-auth.service';
 
 // ─────────────────────────────────────────────────────────────
 // Type augmentation — adiciona authenticate ao FastifyInstance
@@ -20,6 +21,7 @@ declare module 'fastify' {
     integrationsService: IntegrationsService;
     discordOAuthService: DiscordOAuthService;
     discordPresenceService: DiscordPresenceService;
+    socialAuthService: SocialAuthService;
   }
 
   interface FastifyRequest {

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -812,4 +812,115 @@ describe('Auth Routes', () => {
     });
   });
 
+  describe('GET /auth/social/:provider', () => {
+    it('inicia login social para provider suportado', async () => {
+      const socialAuthService = {
+        startLogin: vi.fn().mockResolvedValue({
+          provider: 'GOOGLE',
+          authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=signed-state',
+        }),
+        completeCallback: vi.fn(),
+      };
+      const app = await buildApp({ socialAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/social/google/start',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'GOOGLE',
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=signed-state',
+      });
+      expect(socialAuthService.startLogin).toHaveBeenCalledWith('google');
+      await app.close();
+    });
+
+    it('retorna erro coerente para provider social nao suportado', async () => {
+      const socialAuthService = {
+        startLogin: vi.fn().mockRejectedValue({
+          name: 'SocialAuthError',
+          statusCode: 400,
+          reason: 'unsupported_provider',
+          clientMessage: 'Provider social não suportado.',
+        }),
+        completeCallback: vi.fn(),
+      };
+      const app = await buildApp({ socialAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/social/steam/start',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({
+        message: 'Provider social não suportado.',
+      });
+      await app.close();
+    });
+
+    it('conclui callback social e emite refresh cookie da sessao CLUTCH', async () => {
+      const socialAuthService = {
+        startLogin: vi.fn(),
+        completeCallback: vi.fn().mockResolvedValue({
+          provider: 'DISCORD',
+          user: {
+            id: 'user-id-1',
+            username: 'clutchplayer',
+          },
+          isNewUser: false,
+        }),
+      };
+      const app = await buildApp({ socialAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/social/discord/callback?code=oauth-code&state=signed-state',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        id: 'user-id-1',
+        username: 'clutchplayer',
+        message: 'Acesso autorizado.',
+      });
+      expect(response.json()).toHaveProperty('token');
+      expect(String(response.headers['set-cookie'])).toContain(REFRESH_TOKEN_COOKIE_NAME);
+      expect(socialAuthService.completeCallback).toHaveBeenCalledWith({
+        provider: 'discord',
+        code: 'oauth-code',
+        state: 'signed-state',
+        providerError: undefined,
+        requestId: expect.any(String),
+      });
+      await app.close();
+    });
+
+    it('retorna erro coerente para callback com state invalido', async () => {
+      const socialAuthService = {
+        startLogin: vi.fn(),
+        completeCallback: vi.fn().mockRejectedValue({
+          name: 'SocialAuthError',
+          statusCode: 400,
+          reason: 'invalid_state',
+          clientMessage: 'Callback social inválido.',
+        }),
+      };
+      const app = await buildApp({ socialAuthService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/social/google/callback?code=oauth-code&state=invalid-state',
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({
+        message: 'Callback social inválido.',
+      });
+      await app.close();
+    });
+  });
+
 });

--- a/backend/tests/unit/providers/provider-registry.test.ts
+++ b/backend/tests/unit/providers/provider-registry.test.ts
@@ -25,6 +25,7 @@ describe('provider registry', () => {
 
     expect(steam?.capabilities).toContain('CONNECTED_ACCOUNT');
     expect(steam?.capabilities).not.toContain('SOCIAL_LOGIN');
+    expect(google?.status).toBe('CONNECTED');
     expect(google?.capabilities).toEqual(
       expect.arrayContaining(['SOCIAL_LOGIN', 'OAUTH_CONNECT']),
     );

--- a/backend/tests/unit/providers/social-oauth-clients.test.ts
+++ b/backend/tests/unit/providers/social-oauth-clients.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('axios');
+vi.mock('@/infra/integrations/discord/discord.service', () => ({
+  discordService: {
+    exchangeCodeWithRedirectUri: vi.fn(),
+    getCurrentUser: vi.fn(),
+  },
+}));
 
 import axios from 'axios';
 import {
+  discordSocialOAuthClient,
   googleSocialOAuthClient,
 } from '@/infra/integrations/social/social-oauth.clients';
+import { discordService } from '@/infra/integrations/discord/discord.service';
 
 const originalEnv = { ...process.env };
 
@@ -17,6 +25,10 @@ describe('social OAuth provider clients', () => {
       GOOGLE_CLIENT_ID: 'google-client-id',
       GOOGLE_CLIENT_SECRET: 'google-client-secret',
       GOOGLE_REDIRECT_URI: 'http://localhost/api/auth/social/google/callback',
+      DISCORD_CLIENT_ID: 'discord-client-id',
+      DISCORD_CLIENT_SECRET: 'discord-client-secret',
+      DISCORD_REDIRECT_URI: 'http://localhost/settings/integrations/discord/callback',
+      DISCORD_SOCIAL_REDIRECT_URI: 'http://localhost/api/auth/social/discord/callback',
     };
   });
 
@@ -40,6 +52,53 @@ describe('social OAuth provider clients', () => {
     expect(parsedUrl.searchParams.get('scope')).toBe('openid email profile');
     expect(parsedUrl.searchParams.get('state')).toBe('signed-state');
     expect(parsedUrl.searchParams.get('nonce')).toBe('nonce-value');
+  });
+
+  it('gera authorization URL Discord social com state e escopo identify', () => {
+    const authorizationUrl = discordSocialOAuthClient.createAuthorizationUrl({
+      state: 'signed-state',
+      nonce: 'unused-discord-nonce',
+    });
+    const parsedUrl = new URL(authorizationUrl);
+
+    expect(parsedUrl.origin).toBe('https://discord.com');
+    expect(parsedUrl.pathname).toBe('/oauth2/authorize');
+    expect(parsedUrl.searchParams.get('client_id')).toBe('discord-client-id');
+    expect(parsedUrl.searchParams.get('response_type')).toBe('code');
+    expect(parsedUrl.searchParams.get('redirect_uri')).toBe(
+      'http://localhost/api/auth/social/discord/callback',
+    );
+    expect(parsedUrl.searchParams.get('scope')).toBe('identify');
+    expect(parsedUrl.searchParams.get('state')).toBe('signed-state');
+  });
+
+  it('falha de forma controlada quando Google social login esta sem configuracao', () => {
+    delete process.env.GOOGLE_CLIENT_SECRET;
+
+    expect(() => googleSocialOAuthClient.createAuthorizationUrl({
+      state: 'signed-state',
+      nonce: 'nonce-value',
+    })).toThrowError(
+      expect.objectContaining({
+        statusCode: 503,
+        reason: 'misconfigured',
+        clientMessage: 'Login Google indisponível no runtime atual.',
+      }),
+    );
+  });
+
+  it('rejeita redirect URI Google insegura ou malformada', () => {
+    process.env.GOOGLE_REDIRECT_URI = 'https://user:secret@app.clutch.gg/callback';
+
+    expect(() => googleSocialOAuthClient.createAuthorizationUrl({
+      state: 'signed-state',
+      nonce: 'nonce-value',
+    })).toThrowError(
+      expect.objectContaining({
+        statusCode: 503,
+        reason: 'misconfigured',
+      }),
+    );
   });
 
   it('usa sub do Google userinfo como externalId confiavel', async () => {
@@ -88,6 +147,62 @@ describe('social OAuth provider clients', () => {
     );
   });
 
+  it('mapeia erro HTTP de token Google para invalid_request', async () => {
+    vi.mocked(axios.post).mockRejectedValue({
+      response: { status: 401 },
+    });
+
+    await expect(googleSocialOAuthClient.exchangeCodeForIdentity('oauth-code')).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Autorização Google inválida ou expirada.',
+    });
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it('mapeia indisponibilidade do userinfo Google para erro de provider', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        access_token: 'google-access-token',
+        expires_in: 3600,
+        scope: 'openid email profile',
+        token_type: 'Bearer',
+      },
+    } as never);
+    vi.mocked(axios.get).mockRejectedValue({
+      response: { status: 503 },
+    });
+
+    await expect(googleSocialOAuthClient.exchangeCodeForIdentity('oauth-code')).rejects.toMatchObject({
+      statusCode: 503,
+      reason: 'upstream_unavailable',
+      clientMessage: 'Login Google indisponível no momento.',
+    });
+  });
+
+  it('rejeita userinfo Google sem sub confiavel', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        access_token: 'google-access-token',
+        expires_in: 3600,
+        scope: 'openid email profile',
+        token_type: 'Bearer',
+      },
+    } as never);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        email: 'player@clutch.gg',
+        email_verified: true,
+      },
+    } as never);
+
+    await expect(googleSocialOAuthClient.exchangeCodeForIdentity('oauth-code')).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Identidade Google inválida.',
+    });
+  });
+
   it('nao deriva username de email Google nao verificado', async () => {
     vi.mocked(axios.post).mockResolvedValue({
       data: {
@@ -110,5 +225,54 @@ describe('social OAuth provider clients', () => {
     expect(identity.externalId).toBe('google-sub-123');
     expect(identity.emailVerified).toBe(false);
     expect(identity.username).toBeNull();
+  });
+
+  it('troca code Discord com redirect social e normaliza identidade', async () => {
+    vi.mocked(discordService.exchangeCodeWithRedirectUri).mockResolvedValue({
+      accessToken: 'discord-access-token',
+      refreshToken: 'discord-refresh-token',
+      expiresIn: 3600,
+      scope: 'identify',
+      tokenType: 'Bearer',
+    });
+    vi.mocked(discordService.getCurrentUser).mockResolvedValue({
+      id: 'discord-user-id',
+      username: 'discordplayer',
+      globalName: 'Discord Player',
+      avatarUrl: 'https://cdn.discordapp.com/avatars/discord-user-id/avatar.png',
+    });
+
+    const identity = await discordSocialOAuthClient.exchangeCodeForIdentity('oauth-code');
+
+    expect(discordService.exchangeCodeWithRedirectUri).toHaveBeenCalledWith(
+      'oauth-code',
+      'http://localhost/api/auth/social/discord/callback',
+    );
+    expect(discordService.getCurrentUser).toHaveBeenCalledWith('discord-access-token');
+    expect(identity).toMatchObject({
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      email: null,
+      emailVerified: false,
+      displayName: 'Discord Player',
+      username: 'discordplayer',
+      accessToken: 'discord-access-token',
+      refreshToken: 'discord-refresh-token',
+    });
+  });
+
+  it('falha de forma controlada quando Discord social login esta sem redirect configurado', () => {
+    delete process.env.DISCORD_SOCIAL_REDIRECT_URI;
+
+    expect(() => discordSocialOAuthClient.createAuthorizationUrl({
+      state: 'signed-state',
+      nonce: 'nonce-value',
+    })).toThrowError(
+      expect.objectContaining({
+        statusCode: 503,
+        reason: 'misconfigured',
+        clientMessage: 'Login Discord indisponível no runtime atual.',
+      }),
+    );
   });
 });

--- a/backend/tests/unit/providers/social-oauth-clients.test.ts
+++ b/backend/tests/unit/providers/social-oauth-clients.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios');
+
+import axios from 'axios';
+import {
+  googleSocialOAuthClient,
+} from '@/infra/integrations/social/social-oauth.clients';
+
+const originalEnv = { ...process.env };
+
+describe('social OAuth provider clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      GOOGLE_CLIENT_ID: 'google-client-id',
+      GOOGLE_CLIENT_SECRET: 'google-client-secret',
+      GOOGLE_REDIRECT_URI: 'http://localhost/api/auth/social/google/callback',
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('gera authorization URL Google com state e nonce', () => {
+    const authorizationUrl = googleSocialOAuthClient.createAuthorizationUrl({
+      state: 'signed-state',
+      nonce: 'nonce-value',
+    });
+    const parsedUrl = new URL(authorizationUrl);
+
+    expect(parsedUrl.origin).toBe('https://accounts.google.com');
+    expect(parsedUrl.searchParams.get('client_id')).toBe('google-client-id');
+    expect(parsedUrl.searchParams.get('response_type')).toBe('code');
+    expect(parsedUrl.searchParams.get('redirect_uri')).toBe(
+      'http://localhost/api/auth/social/google/callback',
+    );
+    expect(parsedUrl.searchParams.get('scope')).toBe('openid email profile');
+    expect(parsedUrl.searchParams.get('state')).toBe('signed-state');
+    expect(parsedUrl.searchParams.get('nonce')).toBe('nonce-value');
+  });
+
+  it('usa sub do Google userinfo como externalId confiavel', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        access_token: 'google-access-token',
+        refresh_token: 'google-refresh-token',
+        expires_in: 3600,
+        scope: 'openid email profile',
+        token_type: 'Bearer',
+      },
+    } as never);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        sub: 'google-sub-123',
+        email: 'player@clutch.gg',
+        email_verified: true,
+        name: 'Clutch Player',
+        picture: 'https://lh3.googleusercontent.com/avatar.png',
+      },
+    } as never);
+
+    const identity = await googleSocialOAuthClient.exchangeCodeForIdentity('oauth-code');
+
+    expect(identity).toMatchObject({
+      provider: 'GOOGLE',
+      externalId: 'google-sub-123',
+      email: 'player@clutch.gg',
+      emailVerified: true,
+      displayName: 'Clutch Player',
+      accessToken: 'google-access-token',
+      refreshToken: 'google-refresh-token',
+    });
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://oauth2.googleapis.com/token',
+      expect.stringContaining('code=oauth-code'),
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      }),
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://openidconnect.googleapis.com/v1/userinfo',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer google-access-token' },
+      }),
+    );
+  });
+});

--- a/backend/tests/unit/providers/social-oauth-clients.test.ts
+++ b/backend/tests/unit/providers/social-oauth-clients.test.ts
@@ -87,4 +87,28 @@ describe('social OAuth provider clients', () => {
       }),
     );
   });
+
+  it('nao deriva username de email Google nao verificado', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        access_token: 'google-access-token',
+        expires_in: 3600,
+        scope: 'openid email profile',
+        token_type: 'Bearer',
+      },
+    } as never);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        sub: 'google-sub-123',
+        email: 'private.localpart@example.com',
+        email_verified: false,
+      },
+    } as never);
+
+    const identity = await googleSocialOAuthClient.exchangeCodeForIdentity('oauth-code');
+
+    expect(identity.externalId).toBe('google-sub-123');
+    expect(identity.emailVerified).toBe(false);
+    expect(identity.username).toBeNull();
+  });
 });

--- a/backend/tests/unit/repositories/user.repository.test.ts
+++ b/backend/tests/unit/repositories/user.repository.test.ts
@@ -127,7 +127,7 @@ describe('userRepository', () => {
           username:      'clutchplayer',
           email:         'player@clutch.gg',
           password_hash: 'password123',
-          profile:  { create: { displayName: 'clutchplayer' } },
+          profile:  { create: { displayName: 'clutchplayer', avatarUrl: null } },
           stats:    { create: { level: 1, xp: 0 } },
           presence: { create: { status: 'OFFLINE' } },
         }),

--- a/backend/tests/unit/services/social-auth.service.test.ts
+++ b/backend/tests/unit/services/social-auth.service.test.ts
@@ -6,6 +6,7 @@ import {
   type SocialAuthProviderClient,
 } from '@/core/services/social-auth.service';
 import { ConnectedAccountConflictError } from '@/core/services/connected-account.service';
+import { IntegrationError } from '@/infra/integrations/integration.errors';
 
 const baseUser = {
   id: 'user-id-1',
@@ -118,6 +119,36 @@ describe('social auth service', () => {
     });
   });
 
+  it('rejeita callback cancelado pelo provider sem chamar troca de token', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      state,
+      providerError: 'access_denied',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Login social cancelado ou negado pelo provider.',
+    });
+
+    expect(dependencies.providerClients.GOOGLE.exchangeCodeForIdentity).not.toHaveBeenCalled();
+  });
+
+  it('rejeita callback sem code ou state material', async () => {
+    const service = createSocialAuthService(createDependencies());
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      state: 'state-only',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+    });
+  });
+
   it('emite login para o owner quando a identidade externa ja existe', async () => {
     const dependencies = createDependencies();
     const service = createSocialAuthService(dependencies);
@@ -140,6 +171,32 @@ describe('social auth service', () => {
     expect(result.user).toMatchObject({ id: 'user-id-1', username: 'clutchplayer' });
     expect(result.isNewUser).toBe(false);
     expect(dependencies.users.create).not.toHaveBeenCalled();
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('mapeia identidade externa existente sem owner para conflito de dominio', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD');
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue({
+      id: 'identity-id-1',
+      userId: 'missing-user-id',
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      status: 'CONNECTED',
+    });
+    dependencies.users.findById.mockResolvedValue(null);
+
+    await expect(service.completeCallback({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+      clientMessage: 'Identidade social vinculada a uma conta indisponível.',
+    });
+
     expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
   });
 
@@ -245,6 +302,44 @@ describe('social auth service', () => {
     expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
   });
 
+  it('bloqueia outro login social do mesmo provider ja vinculado ao usuario', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
+    dependencies.connectedAccounts.findByUserProvider.mockResolvedValue({
+      id: 'account-id-1',
+      userId: 'new-user-id',
+      provider: 'GOOGLE',
+      externalId: 'other-google-external-id',
+      connectionType: 'SOCIAL_LOGIN',
+      status: 'CONNECTED',
+      dataSource: 'OFFICIAL',
+      metadata: null,
+      createdAt: new Date('2026-04-28T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+      lastSyncAt: null,
+    });
+    dependencies.users.findByEmail.mockResolvedValue(null);
+    dependencies.users.findByUsername.mockResolvedValue(null);
+    dependencies.users.create.mockResolvedValue({
+      ...baseUser,
+      id: 'new-user-id',
+    });
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+      clientMessage: 'Este usuário já possui outro login social vinculado para este provider.',
+    });
+
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
   it('cria usuario social isolado quando email esta ausente', async () => {
     const dependencies = createDependencies();
     const service = createSocialAuthService(dependencies);
@@ -312,6 +407,78 @@ describe('social auth service', () => {
     })).rejects.toMatchObject({
       statusCode: 400,
       reason: 'invalid_state',
+    });
+  });
+
+  it('rejeita identidade retornada por provider diferente do callback', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+    dependencies.providerClients.GOOGLE.exchangeCodeForIdentity = vi.fn().mockResolvedValue({
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      email: null,
+      emailVerified: false,
+      displayName: 'Discord Player',
+      username: 'discordplayer',
+      avatarUrl: null,
+      accessToken: 'discord-access-token',
+      refreshToken: null,
+      metadata: {},
+    });
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Identidade social inválida.',
+    });
+  });
+
+  it('mapeia erro invalido do provider para erro de dominio sem vazar code', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+    dependencies.providerClients.GOOGLE.exchangeCodeForIdentity = vi.fn().mockRejectedValue(
+      new IntegrationError(
+        'google',
+        400,
+        'invalid_request',
+        'Autorização Google inválida ou expirada.',
+        'oauth-code=secret-code',
+      ),
+    );
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      code: 'secret-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Autorização Google inválida ou expirada.',
+    });
+  });
+
+  it('mapeia falha inesperada do provider para indisponibilidade social', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD');
+    dependencies.providerClients.DISCORD.exchangeCodeForIdentity = vi.fn().mockRejectedValue(
+      new Error('provider secret leaked internally'),
+    );
+
+    await expect(service.completeCallback({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 503,
+      reason: 'provider_unavailable',
+      clientMessage: 'Login Discord indisponível no momento.',
     });
   });
 

--- a/backend/tests/unit/services/social-auth.service.test.ts
+++ b/backend/tests/unit/services/social-auth.service.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   createSocialAuthService,
-  createSocialOAuthState,
   SocialAuthError,
+  type SocialAuthProvider,
   type SocialAuthProviderClient,
 } from '@/core/services/social-auth.service';
 import { ConnectedAccountConflictError } from '@/core/services/connected-account.service';
@@ -63,6 +63,22 @@ function createDependencies() {
   };
 }
 
+async function issueState(
+  service: ReturnType<typeof createSocialAuthService>,
+  dependencies: ReturnType<typeof createDependencies>,
+  provider: SocialAuthProvider,
+): Promise<string> {
+  await service.startLogin(provider.toLowerCase());
+  const createAuthorizationUrl = vi.mocked(dependencies.providerClients[provider].createAuthorizationUrl);
+  const lastCall = createAuthorizationUrl.mock.calls.at(-1);
+
+  if (!lastCall) {
+    throw new Error('Expected social auth state to be issued.');
+  }
+
+  return lastCall[0].state;
+}
+
 describe('social auth service', () => {
   it('inicia login social para provider suportado com state assinado', async () => {
     const dependencies = createDependencies();
@@ -104,7 +120,8 @@ describe('social auth service', () => {
 
   it('emite login para o owner quando a identidade externa ja existe', async () => {
     const dependencies = createDependencies();
-    const state = createSocialOAuthState('DISCORD').state;
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD');
     dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue({
       id: 'identity-id-1',
       userId: 'user-id-1',
@@ -113,7 +130,6 @@ describe('social auth service', () => {
       status: 'CONNECTED',
     });
     dependencies.users.findById.mockResolvedValue(baseUser);
-    const service = createSocialAuthService(dependencies);
 
     const result = await service.completeCallback({
       provider: 'discord',
@@ -129,7 +145,8 @@ describe('social auth service', () => {
 
   it('cria usuario novo com Google usando sub como externalId e email verificado', async () => {
     const dependencies = createDependencies();
-    const state = createSocialOAuthState('GOOGLE').state;
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
     dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
     dependencies.connectedAccounts.findByUserProvider.mockResolvedValue(null);
     dependencies.users.findByEmail.mockResolvedValue(null);
@@ -140,7 +157,6 @@ describe('social auth service', () => {
       username: 'clutchplayer',
       email: 'player@clutch.gg',
     });
-    const service = createSocialAuthService(dependencies);
 
     const result = await service.completeCallback({
       provider: 'google',
@@ -170,14 +186,15 @@ describe('social auth service', () => {
 
   it('nao usa email nao verificado para tomar conta existente', async () => {
     const dependencies = createDependencies();
-    const state = createSocialOAuthState('GOOGLE').state;
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
     dependencies.providerClients.GOOGLE.exchangeCodeForIdentity = vi.fn().mockResolvedValue({
       provider: 'GOOGLE',
       externalId: 'google-external-id',
       email: 'player@clutch.gg',
       emailVerified: false,
       displayName: 'Clutch Player',
-      username: 'clutchplayer',
+      username: null,
       avatarUrl: null,
       accessToken: 'google-access-token',
       refreshToken: null,
@@ -189,10 +206,9 @@ describe('social auth service', () => {
     dependencies.users.create.mockResolvedValue({
       ...baseUser,
       id: 'new-user-id',
-      username: 'clutchplayer',
+      username: 'clutch_player',
       email: 'social+google-google-external-id@users.clutch.local',
     });
-    const service = createSocialAuthService(dependencies);
 
     await service.completeCallback({
       provider: 'google',
@@ -203,14 +219,106 @@ describe('social auth service', () => {
     expect(dependencies.users.findByEmail).not.toHaveBeenCalled();
     expect(dependencies.users.create).toHaveBeenCalledWith(
       expect.objectContaining({
+        username: 'clutch_player',
         email: 'social+google-google-external-id@users.clutch.local',
       }),
     );
   });
 
+  it('rejeita email verificado existente sem ownership externo previo', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
+    dependencies.users.findByEmail.mockResolvedValue(baseUser);
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+    });
+
+    expect(dependencies.users.create).not.toHaveBeenCalled();
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('cria usuario social isolado quando email esta ausente', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD');
+    dependencies.providerClients.DISCORD.exchangeCodeForIdentity = vi.fn().mockResolvedValue({
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      email: null,
+      emailVerified: false,
+      displayName: null,
+      username: null,
+      avatarUrl: null,
+      accessToken: 'discord-access-token',
+      refreshToken: null,
+      metadata: {},
+    });
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
+    dependencies.connectedAccounts.findByUserProvider.mockResolvedValue(null);
+    dependencies.users.findByUsername.mockResolvedValue(null);
+    dependencies.users.create.mockResolvedValue({
+      ...baseUser,
+      id: 'new-user-id',
+      username: 'player',
+      email: 'social+discord-discord-external-id@users.clutch.local',
+    });
+
+    await service.completeCallback({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(dependencies.users.findByEmail).not.toHaveBeenCalled();
+    expect(dependencies.users.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'player',
+        email: 'social+discord-discord-external-id@users.clutch.local',
+      }),
+    );
+  });
+
+  it('rejeita reutilizacao de state social', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD');
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue({
+      id: 'identity-id-1',
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      status: 'CONNECTED',
+    });
+    dependencies.users.findById.mockResolvedValue(baseUser);
+
+    await service.completeCallback({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    });
+
+    await expect(service.completeCallback({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_state',
+    });
+  });
+
   it('mapeia conflito de ownership externo para erro de dominio', async () => {
     const dependencies = createDependencies();
-    const state = createSocialOAuthState('GOOGLE').state;
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
     dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
     dependencies.connectedAccounts.findByUserProvider.mockResolvedValue(null);
     dependencies.users.findByEmail.mockResolvedValue(null);
@@ -222,7 +330,6 @@ describe('social auth service', () => {
     dependencies.connectedAccountService.connectExternalIdentity.mockRejectedValue(
       new ConnectedAccountConflictError('GOOGLE', 'google-external-id', 'other-user-id'),
     );
-    const service = createSocialAuthService(dependencies);
 
     await expect(service.completeCallback({
       provider: 'google',

--- a/backend/tests/unit/services/social-auth.service.test.ts
+++ b/backend/tests/unit/services/social-auth.service.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSocialAuthService,
+  createSocialOAuthState,
+  SocialAuthError,
+  type SocialAuthProviderClient,
+} from '@/core/services/social-auth.service';
+import { ConnectedAccountConflictError } from '@/core/services/connected-account.service';
+
+const baseUser = {
+  id: 'user-id-1',
+  username: 'clutchplayer',
+  email: 'player@clutch.gg',
+  password_hash: 'hashed-password',
+  isActive: true,
+  createdAt: new Date('2026-04-28T00:00:00.000Z'),
+  updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+};
+
+function createProviderClient(
+  provider: 'GOOGLE' | 'DISCORD',
+  overrides: Partial<SocialAuthProviderClient> = {},
+): SocialAuthProviderClient {
+  return {
+    provider,
+    createAuthorizationUrl: vi.fn().mockReturnValue(`https://provider.test/${provider.toLowerCase()}/authorize`),
+    exchangeCodeForIdentity: vi.fn().mockResolvedValue({
+      provider,
+      externalId: `${provider.toLowerCase()}-external-id`,
+      email: provider === 'GOOGLE' ? 'player@clutch.gg' : null,
+      emailVerified: provider === 'GOOGLE',
+      displayName: provider === 'GOOGLE' ? 'Clutch Player' : 'clutchdiscord',
+      username: provider === 'GOOGLE' ? 'clutchplayer' : 'clutchdiscord',
+      avatarUrl: null,
+      accessToken: `${provider.toLowerCase()}-access-token`,
+      refreshToken: null,
+      metadata: { provider },
+    }),
+    ...overrides,
+  };
+}
+
+function createDependencies() {
+  return {
+    providerClients: {
+      GOOGLE: createProviderClient('GOOGLE'),
+      DISCORD: createProviderClient('DISCORD'),
+    },
+    users: {
+      findById: vi.fn(),
+      findByEmail: vi.fn(),
+      findByUsername: vi.fn(),
+      create: vi.fn(),
+    },
+    connectedAccounts: {
+      findByProviderExternalId: vi.fn(),
+      findByUserProvider: vi.fn(),
+    },
+    connectedAccountService: {
+      connectExternalIdentity: vi.fn(),
+    },
+    hashPassword: vi.fn().mockResolvedValue('hashed-social-password'),
+  };
+}
+
+describe('social auth service', () => {
+  it('inicia login social para provider suportado com state assinado', async () => {
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+
+    const result = await service.startLogin('google');
+
+    expect(result.provider).toBe('GOOGLE');
+    expect(result.authorizationUrl).toBe('https://provider.test/google/authorize');
+    expect(dependencies.providerClients.GOOGLE.createAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.stringContaining('.'),
+        nonce: expect.any(String),
+      }),
+    );
+  });
+
+  it('rejeita provider sem social login', async () => {
+    const service = createSocialAuthService(createDependencies());
+
+    await expect(service.startLogin('steam')).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+    });
+  });
+
+  it('rejeita callback com state invalido', async () => {
+    const service = createSocialAuthService(createDependencies());
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state: 'invalid-state',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_state',
+    });
+  });
+
+  it('emite login para o owner quando a identidade externa ja existe', async () => {
+    const dependencies = createDependencies();
+    const state = createSocialOAuthState('DISCORD').state;
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue({
+      id: 'identity-id-1',
+      userId: 'user-id-1',
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      status: 'CONNECTED',
+    });
+    dependencies.users.findById.mockResolvedValue(baseUser);
+    const service = createSocialAuthService(dependencies);
+
+    const result = await service.completeCallback({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(result.user).toMatchObject({ id: 'user-id-1', username: 'clutchplayer' });
+    expect(result.isNewUser).toBe(false);
+    expect(dependencies.users.create).not.toHaveBeenCalled();
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('cria usuario novo com Google usando sub como externalId e email verificado', async () => {
+    const dependencies = createDependencies();
+    const state = createSocialOAuthState('GOOGLE').state;
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
+    dependencies.connectedAccounts.findByUserProvider.mockResolvedValue(null);
+    dependencies.users.findByEmail.mockResolvedValue(null);
+    dependencies.users.findByUsername.mockResolvedValue(null);
+    dependencies.users.create.mockResolvedValue({
+      ...baseUser,
+      id: 'new-user-id',
+      username: 'clutchplayer',
+      email: 'player@clutch.gg',
+    });
+    const service = createSocialAuthService(dependencies);
+
+    const result = await service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(dependencies.users.findByEmail).toHaveBeenCalledWith('player@clutch.gg');
+    expect(dependencies.users.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'clutchplayer',
+        email: 'player@clutch.gg',
+        displayName: 'Clutch Player',
+      }),
+    );
+    expect(dependencies.connectedAccountService.connectExternalIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'new-user-id',
+        provider: 'GOOGLE',
+        externalId: 'google-external-id',
+        connectionType: 'SOCIAL_LOGIN',
+        accessToken: 'google-access-token',
+      }),
+    );
+    expect(result.isNewUser).toBe(true);
+  });
+
+  it('nao usa email nao verificado para tomar conta existente', async () => {
+    const dependencies = createDependencies();
+    const state = createSocialOAuthState('GOOGLE').state;
+    dependencies.providerClients.GOOGLE.exchangeCodeForIdentity = vi.fn().mockResolvedValue({
+      provider: 'GOOGLE',
+      externalId: 'google-external-id',
+      email: 'player@clutch.gg',
+      emailVerified: false,
+      displayName: 'Clutch Player',
+      username: 'clutchplayer',
+      avatarUrl: null,
+      accessToken: 'google-access-token',
+      refreshToken: null,
+      metadata: {},
+    });
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
+    dependencies.connectedAccounts.findByUserProvider.mockResolvedValue(null);
+    dependencies.users.findByUsername.mockResolvedValue(null);
+    dependencies.users.create.mockResolvedValue({
+      ...baseUser,
+      id: 'new-user-id',
+      username: 'clutchplayer',
+      email: 'social+google-google-external-id@users.clutch.local',
+    });
+    const service = createSocialAuthService(dependencies);
+
+    await service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(dependencies.users.findByEmail).not.toHaveBeenCalled();
+    expect(dependencies.users.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'social+google-google-external-id@users.clutch.local',
+      }),
+    );
+  });
+
+  it('mapeia conflito de ownership externo para erro de dominio', async () => {
+    const dependencies = createDependencies();
+    const state = createSocialOAuthState('GOOGLE').state;
+    dependencies.connectedAccounts.findByProviderExternalId.mockResolvedValue(null);
+    dependencies.connectedAccounts.findByUserProvider.mockResolvedValue(null);
+    dependencies.users.findByEmail.mockResolvedValue(null);
+    dependencies.users.findByUsername.mockResolvedValue(null);
+    dependencies.users.create.mockResolvedValue({
+      ...baseUser,
+      id: 'new-user-id',
+    });
+    dependencies.connectedAccountService.connectExternalIdentity.mockRejectedValue(
+      new ConnectedAccountConflictError('GOOGLE', 'google-external-id', 'other-user-id'),
+    );
+    const service = createSocialAuthService(dependencies);
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    })).rejects.toBeInstanceOf(SocialAuthError);
+  });
+});

--- a/frontend/src/app/api/auth/social/[provider]/callback/route.ts
+++ b/frontend/src/app/api/auth/social/[provider]/callback/route.ts
@@ -10,7 +10,7 @@ import {
   logServerEvent,
 } from '@/lib/server/logger';
 import { loginBackendResponseSchema } from '@/schemas/auth';
-import { buildApiUrl } from '@/services/http/client';
+import { buildApiUrl, buildPublicAppUrl } from '@/services/http/client';
 
 type RouteContext = {
   params: Promise<{
@@ -48,8 +48,8 @@ function resolveMessage(payload: unknown, fallback: string): string {
   return fallback;
 }
 
-function redirectToLoginWithError(request: NextRequest, message: string): NextResponse {
-  const redirectUrl = new URL('/login', request.url);
+function redirectToLoginWithError(message: string): NextResponse {
+  const redirectUrl = new URL(buildPublicAppUrl('/login'));
   redirectUrl.searchParams.set('socialAuthError', message);
   return NextResponse.redirect(redirectUrl);
 }
@@ -79,31 +79,22 @@ export async function GET(request: NextRequest, context: RouteContext): Promise<
       ...serializeServerError(error),
     });
 
-    return redirectToLoginWithError(
-      request,
-      'Nao foi possivel concluir o login social agora.',
-    );
+    return redirectToLoginWithError('Nao foi possivel concluir o login social agora.');
   }
 
   const payload = await readJsonBody(backendResponse);
 
   if (!backendResponse.ok) {
-    return redirectToLoginWithError(
-      request,
-      resolveMessage(payload, 'Nao foi possivel concluir o login social agora.'),
-    );
+    return redirectToLoginWithError(resolveMessage(payload, 'Nao foi possivel concluir o login social agora.'));
   }
 
   const sessionResult = loginBackendResponseSchema.safeParse(payload);
 
   if (!sessionResult.success) {
-    return redirectToLoginWithError(
-      request,
-      'Resposta invalida do backend de login social.',
-    );
+    return redirectToLoginWithError('Resposta invalida do backend de login social.');
   }
 
-  const redirectUrl = new URL('/feed', request.url);
+  const redirectUrl = new URL(buildPublicAppUrl('/feed'));
   const response = NextResponse.redirect(redirectUrl);
 
   setAccessSessionCookie(response, sessionResult.data.token);

--- a/frontend/src/app/api/auth/social/[provider]/callback/route.ts
+++ b/frontend/src/app/api/auth/social/[provider]/callback/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import {
+  appendRefreshSetCookie,
+  setAccessSessionCookie,
+} from '@/lib/auth/backend-refresh';
+import {
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+  serializeServerError,
+  logServerEvent,
+} from '@/lib/server/logger';
+import { loginBackendResponseSchema } from '@/schemas/auth';
+import { buildApiUrl } from '@/services/http/client';
+
+type RouteContext = {
+  params: Promise<{
+    provider: string;
+  }>;
+};
+
+type ErrorResponse = {
+  message?: string;
+};
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+function redirectToLoginWithError(request: NextRequest, message: string): NextResponse {
+  const redirectUrl = new URL('/login', request.url);
+  redirectUrl.searchParams.set('socialAuthError', message);
+  return NextResponse.redirect(redirectUrl);
+}
+
+export async function GET(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const { provider } = await context.params;
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+  const callbackUrl = new URL(request.url);
+  const backendUrl = new URL(buildApiUrl(`/auth/social/${provider}/callback`));
+  backendUrl.search = callbackUrl.search;
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(backendUrl, {
+      method: 'GET',
+      headers: {
+        [REQUEST_ID_HEADER]: requestId,
+      },
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logServerEvent('error', 'frontend_auth_social_callback_unreachable', 'Frontend social auth callback could not reach backend', {
+      requestId,
+      provider,
+      status: 502,
+      ...serializeServerError(error),
+    });
+
+    return redirectToLoginWithError(
+      request,
+      'Nao foi possivel concluir o login social agora.',
+    );
+  }
+
+  const payload = await readJsonBody(backendResponse);
+
+  if (!backendResponse.ok) {
+    return redirectToLoginWithError(
+      request,
+      resolveMessage(payload, 'Nao foi possivel concluir o login social agora.'),
+    );
+  }
+
+  const sessionResult = loginBackendResponseSchema.safeParse(payload);
+
+  if (!sessionResult.success) {
+    return redirectToLoginWithError(
+      request,
+      'Resposta invalida do backend de login social.',
+    );
+  }
+
+  const redirectUrl = new URL('/feed', request.url);
+  const response = NextResponse.redirect(redirectUrl);
+
+  setAccessSessionCookie(response, sessionResult.data.token);
+  appendRefreshSetCookie(response, backendResponse.headers.get('set-cookie'));
+
+  return response;
+}

--- a/frontend/src/app/api/auth/social/[provider]/start/route.ts
+++ b/frontend/src/app/api/auth/social/[provider]/start/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import {
+  REQUEST_ID_HEADER,
+  resolveServerRequestId,
+  serializeServerError,
+  logServerEvent,
+} from '@/lib/server/logger';
+import { buildApiUrl } from '@/services/http/client';
+
+type RouteContext = {
+  params: Promise<{
+    provider: string;
+  }>;
+};
+
+type StartSocialLoginResponse = {
+  authorizationUrl?: string;
+  message?: string;
+};
+
+async function readJsonBody(response: Response): Promise<StartSocialLoginResponse | null> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as StartSocialLoginResponse;
+  } catch {
+    return null;
+  }
+}
+
+function redirectToLoginWithError(request: NextRequest, message: string): NextResponse {
+  const redirectUrl = new URL('/login', request.url);
+  redirectUrl.searchParams.set('socialAuthError', message);
+  return NextResponse.redirect(redirectUrl);
+}
+
+function parseAuthorizationUrl(value: string): URL | null {
+  try {
+    const parsedUrl = new URL(value);
+
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return null;
+    }
+
+    return parsedUrl;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const { provider } = await context.params;
+  const requestId = resolveServerRequestId(request.headers.get(REQUEST_ID_HEADER));
+
+  let backendResponse: Response;
+
+  try {
+    backendResponse = await fetch(buildApiUrl(`/auth/social/${provider}/start`), {
+      method: 'GET',
+      headers: {
+        [REQUEST_ID_HEADER]: requestId,
+      },
+      cache: 'no-store',
+    });
+  } catch (error) {
+    logServerEvent('error', 'frontend_auth_social_start_unreachable', 'Frontend social auth start could not reach backend', {
+      requestId,
+      provider,
+      status: 502,
+      ...serializeServerError(error),
+    });
+
+    return redirectToLoginWithError(
+      request,
+      'Nao foi possivel iniciar o login social agora.',
+    );
+  }
+
+  const payload = await readJsonBody(backendResponse);
+
+  if (!backendResponse.ok) {
+    return redirectToLoginWithError(
+      request,
+      payload?.message ?? 'Nao foi possivel iniciar o login social agora.',
+    );
+  }
+
+  if (!payload?.authorizationUrl) {
+    return redirectToLoginWithError(
+      request,
+      'Resposta invalida do backend de login social.',
+    );
+  }
+
+  const authorizationUrl = parseAuthorizationUrl(payload.authorizationUrl);
+
+  if (!authorizationUrl) {
+    return redirectToLoginWithError(
+      request,
+      'URL de autorizacao social invalida.',
+    );
+  }
+
+  return NextResponse.redirect(authorizationUrl);
+}

--- a/frontend/src/app/api/auth/social/[provider]/start/route.ts
+++ b/frontend/src/app/api/auth/social/[provider]/start/route.ts
@@ -5,7 +5,7 @@ import {
   serializeServerError,
   logServerEvent,
 } from '@/lib/server/logger';
-import { buildApiUrl } from '@/services/http/client';
+import { buildApiUrl, buildPublicAppUrl } from '@/services/http/client';
 
 type RouteContext = {
   params: Promise<{
@@ -32,8 +32,8 @@ async function readJsonBody(response: Response): Promise<StartSocialLoginRespons
   }
 }
 
-function redirectToLoginWithError(request: NextRequest, message: string): NextResponse {
-  const redirectUrl = new URL('/login', request.url);
+function redirectToLoginWithError(message: string): NextResponse {
+  const redirectUrl = new URL(buildPublicAppUrl('/login'));
   redirectUrl.searchParams.set('socialAuthError', message);
   return NextResponse.redirect(redirectUrl);
 }
@@ -74,35 +74,23 @@ export async function GET(request: NextRequest, context: RouteContext): Promise<
       ...serializeServerError(error),
     });
 
-    return redirectToLoginWithError(
-      request,
-      'Nao foi possivel iniciar o login social agora.',
-    );
+    return redirectToLoginWithError('Nao foi possivel iniciar o login social agora.');
   }
 
   const payload = await readJsonBody(backendResponse);
 
   if (!backendResponse.ok) {
-    return redirectToLoginWithError(
-      request,
-      payload?.message ?? 'Nao foi possivel iniciar o login social agora.',
-    );
+    return redirectToLoginWithError(payload?.message ?? 'Nao foi possivel iniciar o login social agora.');
   }
 
   if (!payload?.authorizationUrl) {
-    return redirectToLoginWithError(
-      request,
-      'Resposta invalida do backend de login social.',
-    );
+    return redirectToLoginWithError('Resposta invalida do backend de login social.');
   }
 
   const authorizationUrl = parseAuthorizationUrl(payload.authorizationUrl);
 
   if (!authorizationUrl) {
-    return redirectToLoginWithError(
-      request,
-      'URL de autorizacao social invalida.',
-    );
+    return redirectToLoginWithError('URL de autorizacao social invalida.');
   }
 
   return NextResponse.redirect(authorizationUrl);

--- a/frontend/src/components/auth/login-form.tsx
+++ b/frontend/src/components/auth/login-form.tsx
@@ -23,7 +23,13 @@ const fieldClassName = 'space-y-2';
 
 export function LoginForm() {
   const router = useRouter();
-  const [serverError, setServerError] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(() => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    return new URLSearchParams(window.location.search).get('socialAuthError');
+  });
   const setSession = useAuthStore((state) => state.setSession);
 
   const {
@@ -105,6 +111,29 @@ export function LoginForm() {
         ) : null}
 
         <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2" aria-label="Login social">
+            <Link
+              href="/api/auth/social/google/start"
+              prefetch={false}
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-control border border-border bg-[var(--button-background)] px-control-x text-sm font-medium text-primary transition hover:border-accent-cyan hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary"
+            >
+              Continuar com Google
+            </Link>
+            <Link
+              href="/api/auth/social/discord/start"
+              prefetch={false}
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-control border border-border bg-[var(--button-background)] px-control-x text-sm font-medium text-primary transition hover:border-accent-cyan hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary"
+            >
+              Continuar com Discord
+            </Link>
+          </div>
+
+          <div className="flex items-center gap-3 text-xs font-medium uppercase text-secondary">
+            <span className="h-px flex-1 bg-border" />
+            <span>Email</span>
+            <span className="h-px flex-1 bg-border" />
+          </div>
+
           <label className={fieldClassName}>
             <span className="text-sm font-medium text-primary">Email</span>
             <Input

--- a/frontend/tests/unit/components/login-page.test.tsx
+++ b/frontend/tests/unit/components/login-page.test.tsx
@@ -53,9 +53,25 @@ describe('LoginPage', () => {
         screen.getByRole('heading', { name: /entre com sua conta do clutch/i }),
       ).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /entrar/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /continuar com google/i }),
+      ).toHaveAttribute('href', '/api/auth/social/google/start');
+      expect(
+        screen.getByRole('link', { name: /continuar com discord/i }),
+      ).toHaveAttribute('href', '/api/auth/social/discord/start');
     },
     10000,
   );
+
+  it('shows social callback errors from the URL', () => {
+    window.history.pushState({}, '', '/login?socialAuthError=Callback%20social%20invalido');
+
+    render(<LoginPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Callback social invalido');
+
+    window.history.pushState({}, '', '/login');
+  });
 
   it('shows validation errors for empty fields', async () => {
     render(<LoginPage />);

--- a/frontend/tests/unit/routes/auth-social-route.test.ts
+++ b/frontend/tests/unit/routes/auth-social-route.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET as startSocialLogin } from '@/app/api/auth/social/[provider]/start/route';
+import { GET as completeSocialLogin } from '@/app/api/auth/social/[provider]/callback/route';
+import { AUTH_SESSION_COOKIE_NAME } from '@/lib/auth/session';
+
+const originalInternalApiUrl = process.env.INTERNAL_API_URL;
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+describe('auth social frontend routes', () => {
+  beforeEach(() => {
+    process.env.INTERNAL_API_URL = 'http://backend.test';
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost';
+    process.env.NEXT_PUBLIC_API_URL = '/api';
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects start requests to provider authorization URL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({
+        provider: 'GOOGLE',
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=signed-state',
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )) as typeof fetch);
+
+    const response = await startSocialLogin(
+      new NextRequest('http://localhost/api/auth/social/google/start', {
+        headers: { 'x-request-id': 'req-social-start-1' },
+      }),
+      { params: Promise.resolve({ provider: 'google' }) },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://accounts.google.com/o/oauth2/v2/auth?state=signed-state',
+    );
+  });
+
+  it('stores CLUTCH session cookies after callback succeeds', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'http://backend.test/auth/social/discord/callback?code=oauth-code&state=signed-state',
+      );
+
+      return new Response(
+        JSON.stringify({
+          id: 'user-id-1',
+          username: 'clutchplayer',
+          token: 'access-token',
+          message: 'Acesso autorizado.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'clutch_refresh=refresh-token; Path=/; HttpOnly; SameSite=Lax',
+          },
+        },
+      );
+    }) as typeof fetch);
+
+    const response = await completeSocialLogin(
+      new NextRequest('http://localhost/api/auth/social/discord/callback?code=oauth-code&state=signed-state'),
+      { params: Promise.resolve({ provider: 'discord' }) },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost/feed');
+    const setCookieHeader = response.headers.get('set-cookie');
+    expect(setCookieHeader).toContain(AUTH_SESSION_COOKIE_NAME);
+    expect(setCookieHeader).toContain('access-token');
+    expect(setCookieHeader).toContain('clutch_refresh=refresh-token');
+  });
+
+  it('redirects callback errors back to login with honest message', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ message: 'Callback social inválido.' }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )) as typeof fetch);
+
+    const response = await completeSocialLogin(
+      new NextRequest('http://localhost/api/auth/social/google/callback?code=oauth-code&state=bad-state'),
+      { params: Promise.resolve({ provider: 'google' }) },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost/login?socialAuthError=Callback+social+inv%C3%A1lido.',
+    );
+  });
+});
+
+afterEach(() => {
+  if (typeof originalInternalApiUrl === 'undefined') {
+    delete process.env.INTERNAL_API_URL;
+  } else {
+    process.env.INTERNAL_API_URL = originalInternalApiUrl;
+  }
+
+  if (typeof originalAppUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  } else {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  }
+
+  if (typeof originalApiUrl === 'undefined') {
+    delete process.env.NEXT_PUBLIC_API_URL;
+  } else {
+    process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+  }
+});


### PR DESCRIPTION
﻿## Resumo
Implementa o primeiro slice funcional de login social com Google e Discord usando a fundação de providers/identities da #271. O fluxo emite sessão CLUTCH pelo mecanismo atual de access token, refresh cookie e proxy frontend, sem duplicar o Discord connect existente.

Closes #272

## O que foi alterado
- Backend: adiciona `SocialAuthService`, state OAuth assinado, start/callback social em `/auth/social/:provider/start` e `/auth/social/:provider/callback`, emissão de sessão pela mesma rotina do login email/senha e mapeamento de erros de domínio.
- Providers: adiciona clientes OAuth sociais para Google e Discord; Google usa `sub` como `externalId`; Discord reaproveita o serviço OAuth existente com redirect social separado.
- Identities: cria ou reaproveita ownership por `(platform, externalId)` via `ConnectedAccountService`, com `connectionType = SOCIAL_LOGIN`, `status = CONNECTED` e `dataSource = OFFICIAL` para novas identidades sociais.
- Frontend: adiciona rotas proxy de start/callback social, grava o cookie `clutch_session`, preserva o refresh cookie do backend e inclui botões mínimos de login social na tela de login.
- Configuração: documenta variáveis de ambiente para Google social login, Discord social redirect e segredo de state OAuth.
- Testes: cobre serviço social, providers, rotas backend, rotas frontend e tela de login.

## Motivação
A #271 criou a base segura de providers e connected accounts, mas ainda não havia fluxo real de social login. Esta PR usa essa fundação para permitir autenticação/cadastro por Google e Discord, mantendo a sessão própria do CLUTCH e protegendo ownership externo sem transformar o Discord connect antigo em um fluxo duplicado.

## Como validar
- Backend: `npm run test -- tests/unit/providers/provider-registry.test.ts tests/unit/providers/social-oauth-clients.test.ts tests/unit/services/social-auth.service.test.ts tests/integration/routes/auth.routes.test.ts`
- Backend: `npm run test -- tests/unit/services/connected-account.service.test.ts tests/integration/routes/integrations.routes.test.ts`
- Backend: `npm run typecheck`
- Backend: `npm run lint`
- Backend: `npm run build`
- Frontend: `npm run test -- tests/unit/components/login-page.test.tsx tests/unit/routes/auth-social-route.test.ts`
- Frontend: `npm run typecheck`
- Frontend: `npm run lint`
- Frontend: `npm run build`

## Riscos e impactos
- O smoke OAuth real depende de secrets e redirect URIs válidos para Google e Discord; a validação local foi feita por testes/mocks de service, provider e rotas.
- Google usa email apenas quando `email_verified` é verdadeiro; email não verificado ou ausente gera cadastro social isolado com email placeholder interno, evitando takeover por email não confiável.
- Discord social login usa `identify` e não email; contas Discord já conectadas por `(DISCORD, externalId)` autenticam o owner existente sem recriar o fluxo de connect.
- Novas identidades sociais persistem tokens via `ConnectedAccountService`, preservando a criptografia de tokens externos da fundação da #271.
- O lint backend passou com warnings já existentes em `backend/src/config/rate-limit.ts` sobre return type explícito; não foram introduzidos erros de lint.
- #273, #275 e #276 permanecem fora do escopo: unlink/reauth, Connection Center e privacidade/visibilidade de contas conectadas não foram implementados aqui.

## Evidências
- Backend: 44 testes afetados de auth/social passaram.
- Backend: 28 testes de compatibilidade de connected accounts/integrations passaram.
- Frontend: 8 testes afetados de login social passaram.
- Typecheck, lint e build passaram em backend e frontend.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

## Hardening pré-merge
- `state` OAuth continua assinado por HMAC e com TTL de 10 minutos, mas agora também é armazenado e consumido uma única vez no runtime para bloquear replay do callback.
- O fluxo Google usa `userinfo` em vez de validar `id_token`; por isso `nonce` é enviado no authorize, mas a identidade confiável vem do `sub` retornado pelo endpoint autenticado de userinfo. Tokens do provider não são enviados ao frontend.
- Email verificado não faz login nem vínculo automático em conta CLUTCH existente quando ainda não existe ownership por `(platform, externalId)`; esse caso retorna conflito e fica para account linking explícito da #273.
- Email não verificado ou ausente não busca conta existente por email e cria usuário social isolado com email placeholder interno.
- Redirect final do frontend usa `PUBLIC_APP_URL`/`NEXT_PUBLIC_APP_URL` via `buildPublicAppUrl`, evitando refletir host arbitrário da requisição em `/feed` ou `/login`.
- `/auth/social/discord/*` segue separado de `/integrations/discord/*`; os testes de compatibilidade de integrations continuam passando.
