### PR TITLE
feat(auth): adiciona account linking e reauth

### DIFF
--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -14,6 +14,7 @@ import {
   RefreshTokenRevokedError,
   RefreshTokenReuseError,
 } from '../../core/services/refresh-token.service';
+import { AccountConnectionError } from '../../core/services/account-connection.service';
 import { SocialAuthError } from '../../core/services/social-auth.service';
 import { AUTH_RATE_LIMIT_POLICIES } from '../../config/rate-limit';
 
@@ -47,6 +48,10 @@ const socialProviderParamsSchema = z.object({
   provider: z.string().min(1),
 });
 
+const accountConnectionProviderParamsSchema = z.object({
+  provider: z.string().min(1),
+});
+
 const socialCallbackSchema = z.object({
   code: z.string().min(1).optional(),
   state: z.string().min(1).optional(),
@@ -73,6 +78,37 @@ function replyWithSocialAuthError(error: unknown): { statusCode: number; payload
     error !== null &&
     'name' in error &&
     (error as { name?: unknown }).name === 'SocialAuthError' &&
+    'statusCode' in error &&
+    typeof (error as { statusCode?: unknown }).statusCode === 'number' &&
+    'clientMessage' in error &&
+    typeof (error as { clientMessage?: unknown }).clientMessage === 'string'
+  ) {
+    return {
+      statusCode: (error as { statusCode: number }).statusCode,
+      payload: {
+        message: (error as { clientMessage: string }).clientMessage,
+      },
+    };
+  }
+
+  throw error;
+}
+
+function replyWithAccountConnectionError(error: unknown): { statusCode: number; payload: { message: string } } {
+  if (error instanceof AccountConnectionError) {
+    return {
+      statusCode: error.statusCode,
+      payload: {
+        message: error.clientMessage,
+      },
+    };
+  }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'AccountConnectionError' &&
     'statusCode' in error &&
     typeof (error as { statusCode?: unknown }).statusCode === 'number' &&
     'clientMessage' in error &&
@@ -294,6 +330,232 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       } catch (error) {
         const socialError = replyWithSocialAuthError(error);
         return reply.status(socialError.statusCode).send(socialError.payload);
+      }
+    },
+  );
+
+  // ── GET /auth/connected-accounts ─────────────────────────
+  app.get(
+    '/connected-accounts',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const resultPayload = await app.accountConnectionService.listConnectedAccounts(request.userId);
+
+      return reply.status(200).send(resultPayload);
+    },
+  );
+
+  // ── GET /auth/accounts/:provider/link/start ──────────────
+  app.get<{ Params: { provider: string } }>(
+    '/accounts/:provider/link/start',
+    {
+      preHandler: [app.authenticate],
+      config: {
+        rateLimit: AUTH_RATE_LIMIT_POLICIES.login,
+      },
+    },
+    async (request, reply) => {
+      const paramsResult = accountConnectionProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider de conta inválido.' });
+      }
+
+      try {
+        const resultPayload = await app.accountConnectionService.startLink({
+          userId: request.userId,
+          provider: paramsResult.data.provider,
+        });
+
+        request.log.info({
+          event: 'auth_account_link_started',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          provider: resultPayload.provider,
+          status: 200,
+          userId: request.userId,
+        }, 'Account link started');
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const accountError = replyWithAccountConnectionError(error);
+        return reply.status(accountError.statusCode).send(accountError.payload);
+      }
+    },
+  );
+
+  // ── GET /auth/accounts/:provider/link/callback ───────────
+  app.get<{
+    Params: { provider: string };
+    Querystring: { code?: string; state?: string; error?: string };
+  }>(
+    '/accounts/:provider/link/callback',
+    {
+      config: {
+        rateLimit: AUTH_RATE_LIMIT_POLICIES.login,
+      },
+    },
+    async (request, reply) => {
+      const paramsResult = accountConnectionProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider de conta inválido.' });
+      }
+
+      const queryResult = socialCallbackSchema.safeParse(request.query);
+
+      if (!queryResult.success) {
+        return reply.status(400).send({ message: 'Callback de conexão inválido.' });
+      }
+
+      try {
+        const resultPayload = await app.accountConnectionService.completeLink({
+          provider: paramsResult.data.provider,
+          code: queryResult.data.code,
+          state: queryResult.data.state,
+          providerError: queryResult.data.error,
+        });
+
+        request.log.info({
+          event: 'auth_account_link_succeeded',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          provider: resultPayload.provider,
+          status: 200,
+          connectionType: resultPayload.connectionType,
+        }, 'Account link succeeded');
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const accountError = replyWithAccountConnectionError(error);
+        return reply.status(accountError.statusCode).send(accountError.payload);
+      }
+    },
+  );
+
+  // ── DELETE /auth/accounts/:provider ──────────────────────
+  app.delete<{ Params: { provider: string } }>(
+    '/accounts/:provider',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const paramsResult = accountConnectionProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider de conta inválido.' });
+      }
+
+      try {
+        const resultPayload = await app.accountConnectionService.unlink({
+          userId: request.userId,
+          provider: paramsResult.data.provider,
+        });
+
+        request.log.info({
+          event: 'auth_account_unlinked',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          provider: resultPayload.provider,
+          status: 200,
+          userId: request.userId,
+        }, 'Account unlinked');
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const accountError = replyWithAccountConnectionError(error);
+        return reply.status(accountError.statusCode).send(accountError.payload);
+      }
+    },
+  );
+
+  // ── GET /auth/accounts/:provider/reauth/start ────────────
+  app.get<{ Params: { provider: string } }>(
+    '/accounts/:provider/reauth/start',
+    {
+      preHandler: [app.authenticate],
+      config: {
+        rateLimit: AUTH_RATE_LIMIT_POLICIES.login,
+      },
+    },
+    async (request, reply) => {
+      const paramsResult = accountConnectionProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider de conta inválido.' });
+      }
+
+      try {
+        const resultPayload = await app.accountConnectionService.startReauth({
+          userId: request.userId,
+          provider: paramsResult.data.provider,
+        });
+
+        request.log.info({
+          event: 'auth_account_reauth_started',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          provider: resultPayload.provider,
+          status: 200,
+          userId: request.userId,
+        }, 'Account reauth started');
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const accountError = replyWithAccountConnectionError(error);
+        return reply.status(accountError.statusCode).send(accountError.payload);
+      }
+    },
+  );
+
+  // ── GET /auth/accounts/:provider/reauth/callback ─────────
+  app.get<{
+    Params: { provider: string };
+    Querystring: { code?: string; state?: string; error?: string };
+  }>(
+    '/accounts/:provider/reauth/callback',
+    {
+      config: {
+        rateLimit: AUTH_RATE_LIMIT_POLICIES.login,
+      },
+    },
+    async (request, reply) => {
+      const paramsResult = accountConnectionProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider de conta inválido.' });
+      }
+
+      const queryResult = socialCallbackSchema.safeParse(request.query);
+
+      if (!queryResult.success) {
+        return reply.status(400).send({ message: 'Callback de reconexão inválido.' });
+      }
+
+      try {
+        const resultPayload = await app.accountConnectionService.completeReauth({
+          provider: paramsResult.data.provider,
+          code: queryResult.data.code,
+          state: queryResult.data.state,
+          providerError: queryResult.data.error,
+        });
+
+        request.log.info({
+          event: 'auth_account_reauth_succeeded',
+          requestId: request.id,
+          method: request.method,
+          path: request.url,
+          provider: resultPayload.provider,
+          status: 200,
+          connectionType: resultPayload.connectionType,
+        }, 'Account reauth succeeded');
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const accountError = replyWithAccountConnectionError(error);
+        return reply.status(accountError.statusCode).send(accountError.payload);
       }
     },
   );

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -47,6 +47,10 @@ import {
   createSocialAuthService,
   type SocialAuthService,
 } from './core/services/social-auth.service';
+import {
+  createAccountConnectionService,
+  type AccountConnectionService,
+} from './core/services/account-connection.service';
 import { ensureMediaUploadsDirectory } from './config/media-upload';
 import type Redis from 'ioredis';
 
@@ -61,6 +65,7 @@ export type BuildAppOptions = {
   discordOAuthService?: DiscordOAuthService;
   discordPresenceService?: DiscordPresenceService;
   socialAuthService?: SocialAuthService;
+  accountConnectionService?: AccountConnectionService;
 };
 
 export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
@@ -87,6 +92,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   const discordOAuthService = options.discordOAuthService ?? createDiscordOAuthService();
   const discordPresenceService = options.discordPresenceService ?? createDiscordPresenceService();
   const socialAuthService = options.socialAuthService ?? createSocialAuthService();
+  const accountConnectionService = options.accountConnectionService ?? createAccountConnectionService();
   const resolvedRateLimitRedis =
     options.rateLimitRedis !== undefined
       ? options.rateLimitRedis
@@ -102,6 +108,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   app.decorate('discordOAuthService', discordOAuthService);
   app.decorate('discordPresenceService', discordPresenceService);
   app.decorate('socialAuthService', socialAuthService);
+  app.decorate('accountConnectionService', accountConnectionService);
 
   await app.register(
     fastifyRateLimit,

--- a/backend/src/core/repositories/connected-account.repository.ts
+++ b/backend/src/core/repositories/connected-account.repository.ts
@@ -79,12 +79,14 @@ function toConnectedAccountRecord(account: {
 }
 
 export type ConnectedAccountRepository = {
+  listByUser(userId: string): Promise<ConnectedAccountRecord[]>;
   findByProviderExternalId(
     provider: Platform,
     externalId: string,
   ): Promise<ConnectedAccountOwnershipRecord | null>;
   findByUserProvider(userId: string, provider: Platform): Promise<ConnectedAccountRecord | null>;
   upsertConnectedAccount(input: UpsertConnectedAccountInput): Promise<ConnectedAccountRecord>;
+  deleteByUserProvider(userId: string, provider: Platform): Promise<ConnectedAccountRecord | null>;
 };
 
 export function createConnectedAccountRepository(): ConnectedAccountRepository {
@@ -122,6 +124,15 @@ export function createConnectedAccountRepository(): ConnectedAccountRepository {
   }
 
   return {
+    async listByUser(userId: string): Promise<ConnectedAccountRecord[]> {
+      const accounts = await prisma.platformIntegration.findMany({
+        where: { userId },
+        orderBy: [{ platform: 'asc' }],
+      });
+
+      return accounts.map(toConnectedAccountRecord);
+    },
+
     findByProviderExternalId,
 
     async findByUserProvider(
@@ -185,6 +196,32 @@ export function createConnectedAccountRepository(): ConnectedAccountRepository {
 
         throw error;
       }
+    },
+
+    async deleteByUserProvider(userId: string, provider: Platform): Promise<ConnectedAccountRecord | null> {
+      const existingAccount = await prisma.platformIntegration.findUnique({
+        where: {
+          userId_platform: {
+            userId,
+            platform: provider,
+          },
+        },
+      });
+
+      if (!existingAccount) {
+        return null;
+      }
+
+      const deletedAccount = await prisma.platformIntegration.delete({
+        where: {
+          userId_platform: {
+            userId,
+            platform: provider,
+          },
+        },
+      });
+
+      return toConnectedAccountRecord(deletedAccount);
     },
   };
 }

--- a/backend/src/core/services/account-connection.service.ts
+++ b/backend/src/core/services/account-connection.service.ts
@@ -1,0 +1,760 @@
+/* eslint-disable no-unused-vars */
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import type {
+  Platform,
+  PlatformIntegrationConnectionType,
+  PlatformIntegrationStatus,
+  Prisma,
+  User,
+} from '@prisma/client';
+import { getProviderDefinition, listProviderDefinitions } from '../providers/provider-registry';
+import {
+  createConnectedAccountRepository,
+  type ConnectedAccountRecord,
+  type ConnectedAccountRepository,
+} from '../repositories/connected-account.repository';
+import {
+  ConnectedAccountConflictError,
+  createConnectedAccountService,
+  type ConnectedAccountService,
+} from './connected-account.service';
+import {
+  createInMemorySocialOAuthStateStore,
+  type SocialAuthProvider,
+  type SocialAuthProviderClient,
+  type SocialAuthProviderIdentity,
+  type SocialOAuthStateStore,
+} from './social-auth.service';
+import {
+  discordSocialOAuthClient,
+  googleSocialOAuthClient,
+} from '../../infra/integrations/social/social-oauth.clients';
+import { userRepository } from '../repositories/user.repository';
+import { IntegrationError } from '../../infra/integrations/integration.errors';
+
+const ACCOUNT_CONNECTION_STATE_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_DEVELOPMENT_STATE_SECRET = 'clutch-account-connection-dev-secret';
+const SOCIAL_PLACEHOLDER_EMAIL_DOMAIN = 'users.clutch.local';
+
+export type AccountConnectionMode = 'link' | 'reauth';
+
+export type PublicConnectedAccount = {
+  provider: Platform;
+  displayName: string;
+  externalId: string;
+  connectionType: PlatformIntegrationConnectionType;
+  status: PlatformIntegrationStatus;
+  dataSource: ConnectedAccountRecord['dataSource'];
+  connected: boolean;
+  needsReauth: boolean;
+  experimental: boolean;
+  canUnlink: boolean;
+  capabilities: string[];
+  lastSyncAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AccountConnectionStartResult = {
+  provider: SocialAuthProvider;
+  authorizationUrl: string;
+};
+
+export type AccountConnectionCallbackResult = {
+  provider: SocialAuthProvider;
+  externalId: string;
+  status: PlatformIntegrationStatus;
+  connectionType: PlatformIntegrationConnectionType;
+  message: string;
+};
+
+export type AccountConnectionErrorReason =
+  | 'unsupported_provider'
+  | 'invalid_request'
+  | 'invalid_state'
+  | 'provider_unavailable'
+  | 'identity_conflict'
+  | 'not_connected'
+  | 'unsafe_unlink';
+
+export class AccountConnectionError extends Error {
+  readonly statusCode: number;
+  readonly reason: AccountConnectionErrorReason;
+  readonly clientMessage: string;
+  readonly provider: Platform | null;
+
+  constructor(input: {
+    statusCode: number;
+    reason: AccountConnectionErrorReason;
+    clientMessage: string;
+    provider?: Platform | null;
+  }) {
+    super(input.clientMessage);
+    this.name = 'AccountConnectionError';
+    this.statusCode = input.statusCode;
+    this.reason = input.reason;
+    this.clientMessage = input.clientMessage;
+    this.provider = input.provider ?? null;
+  }
+}
+
+export type AccountConnectionService = {
+  listConnectedAccounts(userId: string): Promise<{ accounts: PublicConnectedAccount[] }>;
+  startLink(input: { userId: string; provider: string }): Promise<AccountConnectionStartResult>;
+  completeLink(input: {
+    provider: string;
+    code?: string;
+    state?: string;
+    providerError?: string;
+  }): Promise<AccountConnectionCallbackResult>;
+  unlink(input: { userId: string; provider: string }): Promise<{ message: string; provider: Platform }>;
+  startReauth(input: { userId: string; provider: string }): Promise<AccountConnectionStartResult>;
+  completeReauth(input: {
+    provider: string;
+    code?: string;
+    state?: string;
+    providerError?: string;
+  }): Promise<AccountConnectionCallbackResult>;
+};
+
+type AccountConnectionUserGateway = {
+  findById(id: string): Promise<User | null>;
+};
+
+type AccountConnectionDependencies = {
+  providerClients?: Partial<Record<SocialAuthProvider, SocialAuthProviderClient>>;
+  users?: AccountConnectionUserGateway;
+  repository?: Pick<
+    ConnectedAccountRepository,
+    'listByUser' | 'findByProviderExternalId' | 'findByUserProvider' | 'deleteByUserProvider'
+  >;
+  connectedAccountService?: Pick<ConnectedAccountService, 'connectExternalIdentity'>;
+  stateStore?: SocialOAuthStateStore;
+};
+
+type AccountConnectionStatePayload = {
+  purpose: 'account_connection';
+  mode: AccountConnectionMode;
+  provider: SocialAuthProvider;
+  userId: string;
+  expectedExternalId?: string;
+  nonce: string;
+  issuedAt: number;
+};
+
+function createAccountConnectionError(input: {
+  statusCode: number;
+  reason: AccountConnectionErrorReason;
+  clientMessage: string;
+  provider?: Platform | null;
+}): AccountConnectionError {
+  return new AccountConnectionError(input);
+}
+
+function resolveStateSecret(): string {
+  const configuredSecret = process.env['ACCOUNT_CONNECTION_STATE_SECRET']?.trim()
+    ?? process.env['SOCIAL_OAUTH_STATE_SECRET']?.trim()
+    ?? process.env['JWT_SECRET']?.trim();
+
+  if (configuredSecret && configuredSecret.length > 0) {
+    return configuredSecret;
+  }
+
+  if (process.env['NODE_ENV'] === 'production') {
+    throw createAccountConnectionError({
+      statusCode: 503,
+      reason: 'provider_unavailable',
+      clientMessage: 'Conexões de conta indisponíveis no runtime atual.',
+    });
+  }
+
+  return DEFAULT_DEVELOPMENT_STATE_SECRET;
+}
+
+function signState(encodedPayload: string): string {
+  return createHmac('sha256', resolveStateSecret()).update(encodedPayload).digest('base64url');
+}
+
+function encodeStatePayload(payload: AccountConnectionStatePayload): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function isSocialOAuthProvider(value: unknown): value is SocialAuthProvider {
+  return value === 'GOOGLE' || value === 'DISCORD';
+}
+
+function decodeStatePayload(value: string): AccountConnectionStatePayload {
+  let parsedPayload: Partial<AccountConnectionStatePayload>;
+
+  try {
+    parsedPayload = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Partial<AccountConnectionStatePayload>;
+  } catch {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback de conexão inválido.',
+    });
+  }
+
+  if (
+    parsedPayload.purpose !== 'account_connection' ||
+    (parsedPayload.mode !== 'link' && parsedPayload.mode !== 'reauth') ||
+    !isSocialOAuthProvider(parsedPayload.provider) ||
+    typeof parsedPayload.userId !== 'string' ||
+    parsedPayload.userId.length === 0 ||
+    typeof parsedPayload.nonce !== 'string' ||
+    parsedPayload.nonce.length === 0 ||
+    typeof parsedPayload.issuedAt !== 'number' ||
+    !Number.isFinite(parsedPayload.issuedAt)
+  ) {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback de conexão inválido.',
+    });
+  }
+
+  return {
+    purpose: 'account_connection',
+    mode: parsedPayload.mode,
+    provider: parsedPayload.provider,
+    userId: parsedPayload.userId,
+    expectedExternalId: parsedPayload.expectedExternalId,
+    nonce: parsedPayload.nonce,
+    issuedAt: parsedPayload.issuedAt,
+  };
+}
+
+function createConnectionState(input: {
+  provider: SocialAuthProvider;
+  userId: string;
+  mode: AccountConnectionMode;
+  expectedExternalId?: string;
+}): { state: string; nonce: string } {
+  const nonce = randomUUID();
+  const encodedPayload = encodeStatePayload({
+    purpose: 'account_connection',
+    mode: input.mode,
+    provider: input.provider,
+    userId: input.userId,
+    expectedExternalId: input.expectedExternalId,
+    nonce,
+    issuedAt: Date.now(),
+  });
+
+  return {
+    nonce,
+    state: `${encodedPayload}.${signState(encodedPayload)}`,
+  };
+}
+
+function verifyStateValue(
+  state: string,
+  provider: SocialAuthProvider,
+  mode: AccountConnectionMode,
+): AccountConnectionStatePayload {
+  const segments = state.split('.');
+
+  if (segments.length !== 2 || !segments[0] || !segments[1]) {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback de conexão inválido.',
+      provider,
+    });
+  }
+
+  const [encodedPayload, receivedSignature] = segments;
+  const expectedSignature = signState(encodedPayload);
+  const receivedBuffer = Buffer.from(receivedSignature, 'utf8');
+  const expectedBuffer = Buffer.from(expectedSignature, 'utf8');
+
+  if (
+    receivedBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(receivedBuffer, expectedBuffer)
+  ) {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback de conexão inválido.',
+      provider,
+    });
+  }
+
+  const payload = decodeStatePayload(encodedPayload);
+
+  if (
+    payload.provider !== provider ||
+    payload.mode !== mode ||
+    Date.now() - payload.issuedAt > ACCOUNT_CONNECTION_STATE_TTL_MS
+  ) {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback de conexão inválido ou expirado.',
+      provider,
+    });
+  }
+
+  return payload;
+}
+
+function normalizePlatform(provider: string): Platform {
+  const normalizedProvider = provider.trim().toUpperCase();
+  const knownProvider = listProviderDefinitions().find(
+    (definition) => definition.provider === normalizedProvider,
+  );
+
+  if (!knownProvider) {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+      clientMessage: 'Provider de conta não suportado.',
+    });
+  }
+
+  return knownProvider.provider;
+}
+
+function normalizeOAuthProvider(provider: string): SocialAuthProvider {
+  const normalizedProvider = normalizePlatform(provider);
+  const definition = getProviderDefinition(normalizedProvider);
+
+  if (
+    !isSocialOAuthProvider(normalizedProvider) ||
+    definition.status === 'UNAVAILABLE' ||
+    !definition.capabilities.includes('OAUTH_CONNECT')
+  ) {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+      clientMessage: 'Provider não suporta conexão OAuth neste momento.',
+      provider: normalizedProvider,
+    });
+  }
+
+  return normalizedProvider;
+}
+
+function toPublicAccount(account: ConnectedAccountRecord, canUnlink: boolean): PublicConnectedAccount {
+  const definition = getProviderDefinition(account.provider);
+
+  return {
+    provider: account.provider,
+    displayName: definition.displayName,
+    externalId: account.externalId,
+    connectionType: account.connectionType,
+    status: account.status,
+    dataSource: account.dataSource,
+    connected: account.status === 'CONNECTED',
+    needsReauth: account.status === 'NEEDS_REAUTH',
+    experimental: account.status === 'UNAVAILABLE' || account.dataSource === 'EXPERIMENTAL',
+    canUnlink,
+    capabilities: definition.capabilities,
+    lastSyncAt: account.lastSyncAt?.toISOString() ?? null,
+    createdAt: account.createdAt.toISOString(),
+    updatedAt: account.updatedAt.toISOString(),
+  };
+}
+
+function hasViablePasswordLogin(user: User): boolean {
+  return !user.email.toLowerCase().endsWith(`@${SOCIAL_PLACEHOLDER_EMAIL_DOMAIN}`);
+}
+
+function canUnlinkAccount(input: {
+  account: ConnectedAccountRecord;
+  accounts: ConnectedAccountRecord[];
+  user: User | null;
+}): boolean {
+  if (input.account.status === 'UNAVAILABLE') {
+    return false;
+  }
+
+  if (input.account.connectionType !== 'SOCIAL_LOGIN') {
+    return true;
+  }
+
+  if (input.user && hasViablePasswordLogin(input.user)) {
+    return true;
+  }
+
+  return input.accounts.some(
+    (candidate) => candidate.connectionType === 'SOCIAL_LOGIN' &&
+      candidate.provider !== input.account.provider &&
+      candidate.status === 'CONNECTED',
+  );
+}
+
+function mapProviderFailure(error: unknown, provider: SocialAuthProvider): never {
+  if (error instanceof AccountConnectionError) {
+    throw error;
+  }
+
+  if (error instanceof IntegrationError) {
+    throw createAccountConnectionError({
+      statusCode: error.statusCode,
+      reason: error.reason === 'invalid_request' ? 'invalid_request' : 'provider_unavailable',
+      clientMessage: error.clientMessage,
+      provider,
+    });
+  }
+
+  throw createAccountConnectionError({
+    statusCode: 503,
+    reason: 'provider_unavailable',
+    clientMessage: 'Provider indisponível no momento.',
+    provider,
+  });
+}
+
+function buildIdentityMetadata(identity: SocialAuthProviderIdentity): Prisma.InputJsonObject {
+  return {
+    ...identity.metadata,
+    email: identity.email,
+    emailVerified: identity.emailVerified,
+    displayName: identity.displayName,
+    username: identity.username,
+    avatarUrl: identity.avatarUrl,
+    source: 'account_connection',
+  };
+}
+
+export function createAccountConnectionService(
+  dependencies: AccountConnectionDependencies = {},
+): AccountConnectionService {
+  const users = dependencies.users ?? userRepository;
+  const repository = dependencies.repository ?? createConnectedAccountRepository();
+  const connectedAccountService = dependencies.connectedAccountService ?? createConnectedAccountService();
+  const stateStore = dependencies.stateStore ?? createInMemorySocialOAuthStateStore();
+  const providerClients = {
+    GOOGLE: dependencies.providerClients?.GOOGLE ?? googleSocialOAuthClient,
+    DISCORD: dependencies.providerClients?.DISCORD ?? discordSocialOAuthClient,
+  };
+
+  async function exchangeIdentity(
+    provider: SocialAuthProvider,
+    code: string,
+  ): Promise<SocialAuthProviderIdentity> {
+    try {
+      const identity = await providerClients[provider].exchangeCodeForIdentity(code);
+
+      if (identity.provider !== provider) {
+        throw createAccountConnectionError({
+          statusCode: 400,
+          reason: 'invalid_request',
+          clientMessage: 'Identidade externa inválida.',
+          provider,
+        });
+      }
+
+      return identity;
+    } catch (error) {
+      mapProviderFailure(error, provider);
+    }
+  }
+
+  async function assertCanRemoveAccount(
+    userId: string,
+    account: ConnectedAccountRecord,
+  ): Promise<void> {
+    if (account.connectionType !== 'SOCIAL_LOGIN') {
+      return;
+    }
+
+    const user = await users.findById(userId);
+
+    if (!user) {
+      throw createAccountConnectionError({
+        statusCode: 404,
+        reason: 'not_connected',
+        clientMessage: 'Usuário não encontrado.',
+        provider: account.provider,
+      });
+    }
+
+    if (hasViablePasswordLogin(user)) {
+      return;
+    }
+
+    const accounts = await repository.listByUser(userId);
+    const remainingSocialLoginCount = accounts.filter(
+      (candidate) => candidate.connectionType === 'SOCIAL_LOGIN' &&
+        candidate.provider !== account.provider &&
+        candidate.status === 'CONNECTED',
+    ).length;
+
+    if (remainingSocialLoginCount === 0) {
+      throw createAccountConnectionError({
+        statusCode: 409,
+        reason: 'unsafe_unlink',
+        clientMessage: 'Não é possível remover o último método de login da conta.',
+        provider: account.provider,
+      });
+    }
+  }
+
+  async function startOAuthFlow(input: {
+    userId: string;
+    provider: string;
+    mode: AccountConnectionMode;
+    expectedExternalId?: string;
+  }): Promise<AccountConnectionStartResult> {
+    const provider = normalizeOAuthProvider(input.provider);
+    const { state, nonce } = createConnectionState({
+      userId: input.userId,
+      provider,
+      mode: input.mode,
+      expectedExternalId: input.expectedExternalId,
+    });
+    const authorizationUrl = providerClients[provider].createAuthorizationUrl({ state, nonce });
+
+    await stateStore.store(state, ACCOUNT_CONNECTION_STATE_TTL_MS);
+
+    return {
+      provider,
+      authorizationUrl,
+    };
+  }
+
+  async function completeOAuthCallback(input: {
+    provider: string;
+    code?: string;
+    state?: string;
+    providerError?: string;
+    mode: AccountConnectionMode;
+  }): Promise<{ provider: SocialAuthProvider; identity: SocialAuthProviderIdentity; statePayload: AccountConnectionStatePayload }> {
+    const provider = normalizeOAuthProvider(input.provider);
+
+    if (input.providerError) {
+      throw createAccountConnectionError({
+        statusCode: 400,
+        reason: 'invalid_request',
+        clientMessage: 'Conexão cancelada ou negada pelo provider.',
+        provider,
+      });
+    }
+
+    if (!input.code || !input.state) {
+      throw createAccountConnectionError({
+        statusCode: 400,
+        reason: 'invalid_request',
+        clientMessage: 'Callback de conexão inválido.',
+        provider,
+      });
+    }
+
+    const statePayload = verifyStateValue(input.state, provider, input.mode);
+
+    if (!await stateStore.consume(input.state)) {
+      throw createAccountConnectionError({
+        statusCode: 400,
+        reason: 'invalid_state',
+        clientMessage: 'Callback de conexão inválido ou expirado.',
+        provider,
+      });
+    }
+
+    return {
+      provider,
+      identity: await exchangeIdentity(provider, input.code),
+      statePayload,
+    };
+  }
+
+  return {
+    async listConnectedAccounts(userId): Promise<{ accounts: PublicConnectedAccount[] }> {
+      const accounts = await repository.listByUser(userId);
+      const user = await users.findById(userId);
+
+      return {
+        accounts: accounts.map((account) => toPublicAccount(account, canUnlinkAccount({
+          account,
+          accounts,
+          user,
+        }))),
+      };
+    },
+
+    async startLink(input): Promise<AccountConnectionStartResult> {
+      return startOAuthFlow({
+        userId: input.userId,
+        provider: input.provider,
+        mode: 'link',
+      });
+    },
+
+    async completeLink(input): Promise<AccountConnectionCallbackResult> {
+      const { provider, identity, statePayload } = await completeOAuthCallback({
+        ...input,
+        mode: 'link',
+      });
+      const existingIdentity = await repository.findByProviderExternalId(provider, identity.externalId);
+
+      if (existingIdentity && existingIdentity.userId !== statePayload.userId) {
+        throw createAccountConnectionError({
+          statusCode: 409,
+          reason: 'identity_conflict',
+          clientMessage: 'Esta identidade externa já está vinculada a outro usuário.',
+          provider,
+        });
+      }
+
+      const existingUserProvider = await repository.findByUserProvider(statePayload.userId, provider);
+
+      if (existingUserProvider && existingUserProvider.externalId !== identity.externalId) {
+        throw createAccountConnectionError({
+          statusCode: 409,
+          reason: 'identity_conflict',
+          clientMessage: 'Este usuário já possui outra identidade vinculada para este provider.',
+          provider,
+        });
+      }
+
+      try {
+        await connectedAccountService.connectExternalIdentity({
+          userId: statePayload.userId,
+          provider,
+          externalId: identity.externalId,
+          connectionType: 'SOCIAL_LOGIN',
+          status: 'CONNECTED',
+          dataSource: getProviderDefinition(provider).dataSource,
+          accessToken: identity.accessToken,
+          refreshToken: identity.refreshToken,
+          metadata: buildIdentityMetadata(identity),
+          lastSyncAt: new Date(),
+        });
+      } catch (error) {
+        if (error instanceof ConnectedAccountConflictError) {
+          throw createAccountConnectionError({
+            statusCode: 409,
+            reason: 'identity_conflict',
+            clientMessage: 'Esta identidade externa já está vinculada a outro usuário.',
+            provider,
+          });
+        }
+
+        throw error;
+      }
+
+      return {
+        provider,
+        externalId: identity.externalId,
+        status: 'CONNECTED',
+        connectionType: 'SOCIAL_LOGIN',
+        message: `${getProviderDefinition(provider).displayName} vinculado com sucesso.`,
+      };
+    },
+
+    async unlink(input): Promise<{ message: string; provider: Platform }> {
+      const provider = normalizePlatform(input.provider);
+      const account = await repository.findByUserProvider(input.userId, provider);
+
+      if (!account) {
+        throw createAccountConnectionError({
+          statusCode: 404,
+          reason: 'not_connected',
+          clientMessage: 'Conta externa não encontrada.',
+          provider,
+        });
+      }
+
+      await assertCanRemoveAccount(input.userId, account);
+      await repository.deleteByUserProvider(input.userId, provider);
+
+      return {
+        provider,
+        message: `${getProviderDefinition(provider).displayName} desconectado com sucesso.`,
+      };
+    },
+
+    async startReauth(input): Promise<AccountConnectionStartResult> {
+      const provider = normalizeOAuthProvider(input.provider);
+      const account = await repository.findByUserProvider(input.userId, provider);
+
+      if (!account) {
+        throw createAccountConnectionError({
+          statusCode: 404,
+          reason: 'not_connected',
+          clientMessage: 'Conta externa não encontrada.',
+          provider,
+        });
+      }
+
+      if (account.status !== 'NEEDS_REAUTH') {
+        throw createAccountConnectionError({
+          statusCode: 400,
+          reason: 'invalid_request',
+          clientMessage: 'Esta conta não precisa de reconexão.',
+          provider,
+        });
+      }
+
+      return startOAuthFlow({
+        userId: input.userId,
+        provider,
+        mode: 'reauth',
+        expectedExternalId: account.externalId,
+      });
+    },
+
+    async completeReauth(input): Promise<AccountConnectionCallbackResult> {
+      const { provider, identity, statePayload } = await completeOAuthCallback({
+        ...input,
+        mode: 'reauth',
+      });
+      const expectedExternalId = statePayload.expectedExternalId;
+
+      if (!expectedExternalId || identity.externalId !== expectedExternalId) {
+        throw createAccountConnectionError({
+          statusCode: 409,
+          reason: 'identity_conflict',
+          clientMessage: 'A identidade retornada pelo provider não corresponde à conta original.',
+          provider,
+        });
+      }
+
+      const account = await repository.findByUserProvider(statePayload.userId, provider);
+
+      if (!account || account.externalId !== expectedExternalId) {
+        throw createAccountConnectionError({
+          statusCode: account ? 409 : 404,
+          reason: account ? 'identity_conflict' : 'not_connected',
+          clientMessage: account
+            ? 'A conta original mudou desde o início da reconexão.'
+            : 'Conta externa não encontrada.',
+          provider,
+        });
+      }
+
+      if (account.status !== 'NEEDS_REAUTH') {
+        throw createAccountConnectionError({
+          statusCode: 400,
+          reason: 'invalid_request',
+          clientMessage: 'Esta conta não precisa de reconexão.',
+          provider,
+        });
+      }
+
+      await connectedAccountService.connectExternalIdentity({
+        userId: statePayload.userId,
+        provider,
+        externalId: identity.externalId,
+        connectionType: account.connectionType,
+        status: 'CONNECTED',
+        dataSource: account.dataSource,
+        accessToken: identity.accessToken,
+        refreshToken: identity.refreshToken,
+        metadata: buildIdentityMetadata(identity),
+        lastSyncAt: new Date(),
+      });
+
+      return {
+        provider,
+        externalId: identity.externalId,
+        status: 'CONNECTED',
+        connectionType: account.connectionType,
+        message: `${getProviderDefinition(provider).displayName} reconectado com sucesso.`,
+      };
+    },
+  };
+}

--- a/backend/src/types/fastify.d.ts
+++ b/backend/src/types/fastify.d.ts
@@ -5,6 +5,7 @@ import type { DiscordOAuthService } from '../core/services/discord-oauth.service
 import type { DiscordPresenceService } from '../core/services/discord-presence.service';
 import type { IntegrationsService } from '../core/services/integrations.service';
 import type { RefreshTokenService } from '../core/services/refresh-token.service';
+import type { AccountConnectionService } from '../core/services/account-connection.service';
 import type { SocialAuthService } from '../core/services/social-auth.service';
 
 // ─────────────────────────────────────────────────────────────
@@ -22,6 +23,7 @@ declare module 'fastify' {
     discordOAuthService: DiscordOAuthService;
     discordPresenceService: DiscordPresenceService;
     socialAuthService: SocialAuthService;
+    accountConnectionService: AccountConnectionService;
   }
 
   interface FastifyRequest {

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -923,4 +923,305 @@ describe('Auth Routes', () => {
     });
   });
 
+  describe('account connection routes', () => {
+    function createAccountConnectionService() {
+      return {
+        listConnectedAccounts: vi.fn().mockResolvedValue({ accounts: [] }),
+        startLink: vi.fn().mockResolvedValue({
+          provider: 'GOOGLE',
+          authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=signed-state',
+        }),
+        completeLink: vi.fn().mockResolvedValue({
+          provider: 'GOOGLE',
+          externalId: 'google-external-id',
+          status: 'CONNECTED',
+          connectionType: 'SOCIAL_LOGIN',
+          message: 'Google vinculado com sucesso.',
+        }),
+        unlink: vi.fn().mockResolvedValue({
+          provider: 'GOOGLE',
+          message: 'Google desconectado com sucesso.',
+        }),
+        startReauth: vi.fn().mockResolvedValue({
+          provider: 'DISCORD',
+          authorizationUrl: 'https://discord.com/oauth2/authorize?state=signed-state',
+        }),
+        completeReauth: vi.fn().mockResolvedValue({
+          provider: 'DISCORD',
+          externalId: 'discord-external-id',
+          status: 'CONNECTED',
+          connectionType: 'CONNECTED_ACCOUNT',
+          message: 'Discord reconectado com sucesso.',
+        }),
+      };
+    }
+
+    it('lista contas conectadas do usuario autenticado sem tokens', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.listConnectedAccounts.mockResolvedValue({
+        accounts: [
+          {
+            provider: 'DISCORD',
+            displayName: 'Discord',
+            externalId: 'discord-external-id',
+            connectionType: 'CONNECTED_ACCOUNT',
+            status: 'CONNECTED',
+            dataSource: 'OFFICIAL',
+            connected: true,
+            needsReauth: false,
+            experimental: false,
+            canUnlink: true,
+            capabilities: ['SOCIAL_LOGIN', 'CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+            lastSyncAt: null,
+            createdAt: '2026-04-28T00:00:00.000Z',
+            updatedAt: '2026-04-28T00:00:00.000Z',
+          },
+        ],
+      });
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/connected-accounts',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        accounts: [
+          {
+            provider: 'DISCORD',
+            externalId: 'discord-external-id',
+            connected: true,
+          },
+        ],
+      });
+      expect(JSON.stringify(response.json())).not.toContain('accessToken');
+      expect(accountConnectionService.listConnectedAccounts).toHaveBeenCalledWith('user-id-1');
+      await app.close();
+    });
+
+    it('exige autenticacao para listar contas conectadas', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/connected-accounts',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(accountConnectionService.listConnectedAccounts).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('inicia linking autenticado para provider suportado', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/google/link/start',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'GOOGLE',
+        authorizationUrl: expect.stringContaining('state=signed-state'),
+      });
+      expect(accountConnectionService.startLink).toHaveBeenCalledWith({
+        userId: 'user-id-1',
+        provider: 'google',
+      });
+      await app.close();
+    });
+
+    it('bloqueia start de linking sem autenticacao', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/google/link/start',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(accountConnectionService.startLink).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna conflito de dominio no start de linking', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.startLink.mockRejectedValue({
+        name: 'AccountConnectionError',
+        statusCode: 400,
+        reason: 'unsupported_provider',
+        clientMessage: 'Provider não suporta conexão OAuth neste momento.',
+      });
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/steam/link/start',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({
+        message: 'Provider não suporta conexão OAuth neste momento.',
+      });
+      await app.close();
+    });
+
+    it('conclui callback de linking sem emitir sessao nova', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/google/link/callback?code=oauth-code&state=signed-state',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'GOOGLE',
+        externalId: 'google-external-id',
+        status: 'CONNECTED',
+        connectionType: 'SOCIAL_LOGIN',
+      });
+      expect(response.json()).not.toHaveProperty('token');
+      expect(response.headers['set-cookie']).toBeUndefined();
+      expect(accountConnectionService.completeLink).toHaveBeenCalledWith({
+        provider: 'google',
+        code: 'oauth-code',
+        state: 'signed-state',
+        providerError: undefined,
+      });
+      await app.close();
+    });
+
+    it('retorna erro coerente no callback de linking com identity conflict', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.completeLink.mockRejectedValue({
+        name: 'AccountConnectionError',
+        statusCode: 409,
+        reason: 'identity_conflict',
+        clientMessage: 'Esta identidade externa já está vinculada a outro usuário.',
+      });
+      const app = await buildApp({ accountConnectionService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/discord/link/callback?code=oauth-code&state=signed-state',
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json()).toMatchObject({
+        message: 'Esta identidade externa já está vinculada a outro usuário.',
+      });
+      await app.close();
+    });
+
+    it('desconecta conta externa autenticada', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/auth/accounts/google',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'GOOGLE',
+        message: 'Google desconectado com sucesso.',
+      });
+      expect(accountConnectionService.unlink).toHaveBeenCalledWith({
+        userId: 'user-id-1',
+        provider: 'google',
+      });
+      await app.close();
+    });
+
+    it('bloqueia unlink inseguro com erro de dominio', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.unlink.mockRejectedValue({
+        name: 'AccountConnectionError',
+        statusCode: 409,
+        reason: 'unsafe_unlink',
+        clientMessage: 'Não é possível remover o último método de login da conta.',
+      });
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/auth/accounts/google',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json()).toMatchObject({
+        message: 'Não é possível remover o último método de login da conta.',
+      });
+      await app.close();
+    });
+
+    it('inicia reauth autenticado para conta que precisa reconectar', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/discord/reauth/start',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'DISCORD',
+        authorizationUrl: expect.stringContaining('state=signed-state'),
+      });
+      expect(accountConnectionService.startReauth).toHaveBeenCalledWith({
+        userId: 'user-id-1',
+        provider: 'discord',
+      });
+      await app.close();
+    });
+
+    it('conclui reauth sem trocar sessao CLUTCH', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/discord/reauth/callback?code=oauth-code&state=signed-state',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'DISCORD',
+        externalId: 'discord-external-id',
+        status: 'CONNECTED',
+        connectionType: 'CONNECTED_ACCOUNT',
+      });
+      expect(response.json()).not.toHaveProperty('token');
+      expect(response.headers['set-cookie']).toBeUndefined();
+      expect(accountConnectionService.completeReauth).toHaveBeenCalledWith({
+        provider: 'discord',
+        code: 'oauth-code',
+        state: 'signed-state',
+        providerError: undefined,
+      });
+      await app.close();
+    });
+  });
+
 });

--- a/backend/tests/unit/services/account-connection.service.test.ts
+++ b/backend/tests/unit/services/account-connection.service.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Platform, User } from '@prisma/client';
+import {
+  AccountConnectionError,
+  createAccountConnectionService,
+  type PublicConnectedAccount,
+} from '@/core/services/account-connection.service';
+import { ConnectedAccountConflictError } from '@/core/services/connected-account.service';
+import type { ConnectedAccountRecord } from '@/core/repositories/connected-account.repository';
+import type {
+  SocialAuthProvider,
+  SocialAuthProviderClient,
+} from '@/core/services/social-auth.service';
+
+const baseUser: User = {
+  id: 'user-id-1',
+  username: 'clutchplayer',
+  email: 'clutchplayer@users.clutch.local',
+  password_hash: 'hashed-password',
+  isActive: true,
+  createdAt: new Date('2026-04-28T00:00:00.000Z'),
+  updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+};
+
+function createProviderClient(
+  provider: SocialAuthProvider,
+  externalId = `${provider.toLowerCase()}-external-id`,
+): SocialAuthProviderClient {
+  return {
+    provider,
+    createAuthorizationUrl: vi.fn().mockReturnValue(`https://provider.test/${provider.toLowerCase()}/authorize`),
+    exchangeCodeForIdentity: vi.fn().mockResolvedValue({
+      provider,
+      externalId,
+      email: provider === 'GOOGLE' ? 'player@clutch.gg' : null,
+      emailVerified: provider === 'GOOGLE',
+      displayName: provider === 'GOOGLE' ? 'Clutch Player' : 'clutchdiscord',
+      username: provider === 'GOOGLE' ? 'clutchplayer' : 'clutchdiscord',
+      avatarUrl: null,
+      accessToken: `${provider.toLowerCase()}-access-token`,
+      refreshToken: `${provider.toLowerCase()}-refresh-token`,
+      metadata: { provider },
+    }),
+  };
+}
+
+function createAccount(overrides: Partial<ConnectedAccountRecord> = {}): ConnectedAccountRecord {
+  return {
+    id: 'account-id-1',
+    userId: 'user-id-1',
+    provider: 'GOOGLE',
+    externalId: 'google-external-id',
+    connectionType: 'SOCIAL_LOGIN',
+    status: 'CONNECTED',
+    dataSource: 'OFFICIAL',
+    metadata: null,
+    createdAt: new Date('2026-04-28T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+    lastSyncAt: null,
+    ...overrides,
+  };
+}
+
+function createDependencies() {
+  return {
+    providerClients: {
+      GOOGLE: createProviderClient('GOOGLE'),
+      DISCORD: createProviderClient('DISCORD'),
+    },
+    users: {
+      findById: vi.fn().mockResolvedValue(baseUser),
+    },
+    repository: {
+      listByUser: vi.fn().mockResolvedValue([]),
+      findByProviderExternalId: vi.fn().mockResolvedValue(null),
+      findByUserProvider: vi.fn().mockResolvedValue(null),
+      deleteByUserProvider: vi.fn().mockResolvedValue(null),
+    },
+    connectedAccountService: {
+      connectExternalIdentity: vi.fn().mockResolvedValue(createAccount()),
+    },
+  };
+}
+
+async function issueState(
+  service: ReturnType<typeof createAccountConnectionService>,
+  dependencies: ReturnType<typeof createDependencies>,
+  provider: SocialAuthProvider,
+  mode: 'link' | 'reauth' = 'link',
+): Promise<string> {
+  if (mode === 'reauth') {
+    dependencies.repository.findByUserProvider.mockResolvedValueOnce(createAccount({
+      provider,
+      externalId: `${provider.toLowerCase()}-external-id`,
+      status: 'NEEDS_REAUTH',
+    }));
+    await service.startReauth({ userId: 'user-id-1', provider: provider.toLowerCase() });
+  } else {
+    await service.startLink({ userId: 'user-id-1', provider: provider.toLowerCase() });
+  }
+
+  const createAuthorizationUrl = vi.mocked(dependencies.providerClients[provider].createAuthorizationUrl);
+  const lastCall = createAuthorizationUrl.mock.calls.at(-1);
+
+  if (!lastCall) {
+    throw new Error('Expected account connection state to be issued.');
+  }
+
+  return lastCall[0].state;
+}
+
+describe('account connection service', () => {
+  it('lista contas conectadas sem expor tokens', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.listByUser.mockResolvedValue([
+      createAccount({
+        provider: 'DISCORD',
+        externalId: 'discord-user-id',
+        connectionType: 'CONNECTED_ACCOUNT',
+        status: 'NEEDS_REAUTH',
+      }),
+    ]);
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.listConnectedAccounts('user-id-1');
+
+    expect(result.accounts).toHaveLength(1);
+    expect(result.accounts[0]).toMatchObject<Partial<PublicConnectedAccount>>({
+      provider: 'DISCORD',
+      externalId: 'discord-user-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+      needsReauth: true,
+      connected: false,
+    });
+    expect(result.accounts[0]).not.toHaveProperty('accessToken');
+    expect(result.accounts[0]).not.toHaveProperty('refreshToken');
+  });
+
+  it('marca ultimo login social como nao removivel quando usuario nao tem senha local viavel', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.listByUser.mockResolvedValue([createAccount()]);
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.listConnectedAccounts('user-id-1');
+
+    expect(result.accounts[0]).toMatchObject({
+      provider: 'GOOGLE',
+      connectionType: 'SOCIAL_LOGIN',
+      canUnlink: false,
+    });
+  });
+
+  it('inicia linking para provider OAuth suportado com state assinado', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.startLink({ userId: 'user-id-1', provider: 'google' });
+
+    expect(result).toMatchObject({
+      provider: 'GOOGLE',
+      authorizationUrl: 'https://provider.test/google/authorize',
+    });
+    expect(dependencies.providerClients.GOOGLE.createAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.stringContaining('.'),
+        nonce: expect.any(String),
+      }),
+    );
+  });
+
+  it('rejeita linking para provider sem capability OAuth connect', async () => {
+    const service = createAccountConnectionService(createDependencies());
+
+    await expect(service.startLink({
+      userId: 'user-id-1',
+      provider: 'steam',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+    });
+  });
+
+  it('conecta identidade externa ao usuario autenticado sem criar conta CLUTCH', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+
+    const result = await service.completeLink({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(result).toMatchObject({
+      provider: 'GOOGLE',
+      externalId: 'google-external-id',
+      status: 'CONNECTED',
+      connectionType: 'SOCIAL_LOGIN',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-id-1',
+        provider: 'GOOGLE',
+        externalId: 'google-external-id',
+        connectionType: 'SOCIAL_LOGIN',
+        accessToken: 'google-access-token',
+        refreshToken: 'google-refresh-token',
+      }),
+    );
+  });
+
+  it('bloqueia linking quando identidade externa pertence a outro usuario', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD');
+    dependencies.repository.findByProviderExternalId.mockResolvedValueOnce(createAccount({
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      userId: 'other-user-id',
+    }));
+
+    await expect(service.completeLink({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('mapeia corrida de ownership externo para erro de dominio', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD');
+    dependencies.connectedAccountService.connectExternalIdentity.mockRejectedValueOnce(
+      new ConnectedAccountConflictError('DISCORD', 'discord-external-id', 'other-user-id'),
+    );
+
+    await expect(service.completeLink({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+    });
+  });
+
+  it('desconecta conta externa quando nao remove ultimo metodo de login', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.findByUserProvider.mockResolvedValue(createAccount({
+      provider: 'STEAM',
+      connectionType: 'CONNECTED_ACCOUNT',
+    }));
+    dependencies.repository.deleteByUserProvider.mockResolvedValue(createAccount({
+      provider: 'STEAM',
+      connectionType: 'CONNECTED_ACCOUNT',
+    }));
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.unlink({ userId: 'user-id-1', provider: 'steam' });
+
+    expect(result).toMatchObject({
+      provider: 'STEAM',
+      message: 'Steam desconectado com sucesso.',
+    });
+    expect(dependencies.repository.deleteByUserProvider).toHaveBeenCalledWith('user-id-1', 'STEAM');
+  });
+
+  it('bloqueia unlink do ultimo login social quando usuario nao tem senha local viavel', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.findByUserProvider.mockResolvedValue(createAccount());
+    dependencies.repository.listByUser.mockResolvedValue([createAccount()]);
+    const service = createAccountConnectionService(dependencies);
+
+    await expect(service.unlink({
+      userId: 'user-id-1',
+      provider: 'google',
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'unsafe_unlink',
+    });
+    expect(dependencies.repository.deleteByUserProvider).not.toHaveBeenCalled();
+  });
+
+  it('permite unlink do login social quando usuario tem email local viavel', async () => {
+    const dependencies = createDependencies();
+    dependencies.users.findById.mockResolvedValue({
+      ...baseUser,
+      email: 'player@clutch.gg',
+    });
+    dependencies.repository.findByUserProvider.mockResolvedValue(createAccount());
+    dependencies.repository.deleteByUserProvider.mockResolvedValue(createAccount());
+    const service = createAccountConnectionService(dependencies);
+
+    await expect(service.unlink({
+      userId: 'user-id-1',
+      provider: 'google',
+    })).resolves.toMatchObject({ provider: 'GOOGLE' });
+  });
+
+  it('retorna erro coerente ao remover conta inexistente', async () => {
+    const service = createAccountConnectionService(createDependencies());
+
+    await expect(service.unlink({
+      userId: 'user-id-1',
+      provider: 'discord',
+    })).rejects.toMatchObject({
+      statusCode: 404,
+      reason: 'not_connected',
+    });
+  });
+
+  it('inicia reauth apenas para conta em NEEDS_REAUTH', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.findByUserProvider.mockResolvedValue(createAccount({
+      provider: 'DISCORD',
+      status: 'NEEDS_REAUTH',
+    }));
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.startReauth({ userId: 'user-id-1', provider: 'discord' });
+
+    expect(result.provider).toBe('DISCORD');
+    expect(result.authorizationUrl).toBe('https://provider.test/discord/authorize');
+  });
+
+  it('rejeita reauth para provider sem OAuth connect', async () => {
+    const service = createAccountConnectionService(createDependencies());
+
+    await expect(service.startReauth({
+      userId: 'user-id-1',
+      provider: 'epic',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+    });
+  });
+
+  it('reconecta mantendo o mesmo externalId e ownership', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD', 'reauth');
+    dependencies.repository.findByUserProvider.mockResolvedValueOnce(createAccount({
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+      status: 'NEEDS_REAUTH',
+    }));
+
+    const result = await service.completeReauth({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(result).toMatchObject({
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      status: 'CONNECTED',
+      connectionType: 'CONNECTED_ACCOUNT',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-id-1',
+        provider: 'DISCORD',
+        externalId: 'discord-external-id',
+        connectionType: 'CONNECTED_ACCOUNT',
+        status: 'CONNECTED',
+      }),
+    );
+  });
+
+  it('bloqueia reauth quando provider retorna externalId diferente', async () => {
+    const dependencies = createDependencies();
+    dependencies.providerClients.DISCORD = createProviderClient('DISCORD', 'discord-other-id');
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD', 'reauth');
+
+    await expect(service.completeReauth({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+    });
+  });
+
+  it('bloqueia reauth quando a conta original mudou depois do state emitido', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD', 'reauth');
+    dependencies.repository.findByUserProvider.mockResolvedValueOnce(createAccount({
+      provider: 'DISCORD',
+      externalId: 'discord-other-id',
+      status: 'NEEDS_REAUTH',
+    }));
+
+    await expect(service.completeReauth({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+      clientMessage: 'A conta original mudou desde o início da reconexão.',
+    });
+  });
+
+  it('bloqueia reauth quando a conta deixou de exigir reconexao depois do state emitido', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'DISCORD', 'reauth');
+    dependencies.repository.findByUserProvider.mockResolvedValueOnce(createAccount({
+      provider: 'DISCORD',
+      externalId: 'discord-external-id',
+      status: 'CONNECTED',
+    }));
+
+    await expect(service.completeReauth({
+      provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Esta conta não precisa de reconexão.',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('falha callback com state reutilizado', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+
+    await service.completeLink({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    });
+
+    await expect(service.completeLink({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    })).rejects.toBeInstanceOf(AccountConnectionError);
+  });
+});


### PR DESCRIPTION
﻿## Resumo
Implementa o primeiro slice backend de linking, unlink e reauth de contas conectadas para a issue #273. A mudan?a reaproveita a foundation de providers/identities da #271 e os clients OAuth usados pelo login social da #272, sem criar contas CLUTCH no fluxo de linking.

## O que foi alterado
- Backend/auth:
  - adicionadas rotas m?nimas para listar contas conectadas, iniciar/concluir linking, unlink e iniciar/concluir reauth.
  - callbacks de linking/reauth usam state assinado, TTL e consumo ?nico.
  - respostas p?blicas n?o exp?em tokens externos.
- Core:
  - adicionado `AccountConnectionService` para concentrar regras de provider, ownership, unlink seguro e reauth.
  - linking conecta identidade externa ao usu?rio autenticado e n?o cria nova conta.
  - unlink bloqueia remo??o do ?ltimo m?todo de login vi?vel.
  - reauth exige que o provider retorne o mesmo `externalId` esperado e revalida que a conta ainda est? em `NEEDS_REAUTH` antes de atualizar tokens.
- Repository:
  - adicionada listagem por usu?rio e remo??o por `userId + provider` para contas conectadas.
- Testes:
  - adicionada cobertura unit?ria do servi?o de account connection.
  - adicionada cobertura de integra??o das novas rotas em `/auth`.

## Motiva??o
A #273 precisa habilitar gest?o segura de identidades externas ap?s a funda??o de providers e o login social. O principal risco tratado ? evitar conflito de ownership externo e impedir que um usu?rio fique sem m?todo de autentica??o ao desconectar uma identidade social.

## Como validar
- `cd backend && npm run test -- tests/unit/services/account-connection.service.test.ts tests/integration/routes/auth.routes.test.ts tests/integration/routes/integrations.routes.test.ts tests/unit/services/social-auth.service.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd backend && npm run test:coverage`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Smoke OAuth real n?o foi executado porque depende de secrets e redirect URIs reais de Google/Discord. Os fluxos foram validados com mocks locais de provider/client e rotas.

## Riscos e impactos
- A PR adiciona contratos backend novos sob `/auth/accounts/*` e `/auth/connected-accounts`.
- Unlink remove localmente o registro de `PlatformIntegration`, liberando ownership externo e removendo tokens persistidos daquele v?nculo.
- Reauth OAuth est? limitado aos providers com capability `OAUTH_CONNECT` nesta PR: Google e Discord. Steam/Epic continuam pelos fluxos existentes e UI completa fica fora deste escopo.
- `npm run test:coverage` depende de Postgres local para duas su?tes de integra??o amplas; em ambiente sem banco em `localhost:5432`, essas su?tes falham antes do relat?rio final de cobertura.

## Evid?ncias
- Backend affected tests: 99 testes passaram.
- Backend typecheck, lint e build passaram; lint manteve 3 warnings preexistentes em `src/config/rate-limit.ts`.
- Frontend typecheck, lint e build passaram.
- `npm run test:coverage`: 346 testes passaram e 3 foram skipped, mas a execu??o local falhou em `tests/integration/prisma.seed.test.ts` e `tests/integration/server.connectivity.test.ts` por aus?ncia de Postgres local em `localhost:5432`.

Closes #273

## Checklist
- [x] Altera??o limitada ao objetivo da PR
- [x] Sem mudan?as desconexas
- [x] Impactos principais descritos
- [x] Valida??o documentada
- [x] Riscos identificados
