### PR TITLE
feat(auth): adiciona visibilidade de contas conectadas

### DIFF
--- a/backend/prisma/migrations/20260429162000_add_connected_account_visibility/migration.sql
+++ b/backend/prisma/migrations/20260429162000_add_connected_account_visibility/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "platform_integrations"
+ADD COLUMN "publicProfileVisible" BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN "platform_integrations"."publicProfileVisible"
+IS 'Controls whether a connected account can appear on the public profile. Default is private for existing and new accounts.';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -211,6 +211,7 @@ model PlatformIntegration {
   refreshToken   String?
   metadata       Json?
   isActive       Boolean                           @default(true)
+  publicProfileVisible Boolean                     @default(false)
   lastSyncAt     DateTime?
   createdAt      DateTime                          @default(now())
   updatedAt      DateTime                          @updatedAt

--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -52,6 +52,10 @@ const accountConnectionProviderParamsSchema = z.object({
   provider: z.string().min(1),
 });
 
+const accountVisibilityUpdateSchema = z.object({
+  publicProfileVisible: z.boolean(),
+});
+
 const socialCallbackSchema = z.object({
   code: z.string().min(1).optional(),
   state: z.string().min(1).optional(),
@@ -461,6 +465,52 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
           status: 200,
           userId: request.userId,
         }, 'Account unlinked');
+
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const accountError = replyWithAccountConnectionError(error);
+        return reply.status(accountError.statusCode).send(accountError.payload);
+      }
+    },
+  );
+
+  // ── PATCH /auth/connected-accounts/:provider/visibility ──
+  app.patch<{
+    Params: { provider: string };
+    Body: { publicProfileVisible?: unknown };
+  }>(
+    '/connected-accounts/:provider/visibility',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const paramsResult = accountConnectionProviderParamsSchema.safeParse(request.params);
+
+      if (!paramsResult.success) {
+        return reply.status(400).send({ message: 'Provider de conta inválido.' });
+      }
+
+      const bodyResult = accountVisibilityUpdateSchema.safeParse(request.body);
+
+      if (!bodyResult.success) {
+        return reply.status(400).send({ message: 'Preferência de visibilidade inválida.' });
+      }
+
+      try {
+        const resultPayload = await app.accountConnectionService.updateVisibility({
+          userId: request.userId,
+          provider: paramsResult.data.provider,
+          publicProfileVisible: bodyResult.data.publicProfileVisible,
+        });
+
+        request.log.info({
+          event: 'auth_connected_account_visibility_updated',
+          requestId: request.id,
+          method: request.method,
+          path: `/auth/connected-accounts/${resultPayload.provider.toLowerCase()}/visibility`,
+          provider: resultPayload.provider,
+          publicProfileVisible: resultPayload.publicProfileVisible,
+          status: 200,
+          userId: request.userId,
+        }, 'Connected account visibility updated');
 
         return reply.status(200).send(resultPayload);
       } catch (error) {

--- a/backend/src/core/repositories/connected-account.repository.ts
+++ b/backend/src/core/repositories/connected-account.repository.ts
@@ -17,6 +17,7 @@ export type ConnectedAccountRecord = {
   status: PlatformIntegrationStatus;
   dataSource: PlatformIntegrationDataSource;
   metadata: Prisma.JsonValue | null;
+  publicProfileVisible: boolean;
   createdAt: Date;
   updatedAt: Date;
   lastSyncAt: Date | null;
@@ -50,6 +51,12 @@ export type UpsertConnectedAccountInput = {
   lastSyncAt?: Date | null;
 };
 
+export type UpdateConnectedAccountVisibilityInput = {
+  userId: string;
+  provider: Platform;
+  publicProfileVisible: boolean;
+};
+
 function toConnectedAccountRecord(account: {
   id: string;
   userId: string;
@@ -59,6 +66,7 @@ function toConnectedAccountRecord(account: {
   status: PlatformIntegrationStatus;
   dataSource: PlatformIntegrationDataSource;
   metadata: Prisma.JsonValue | null;
+  publicProfileVisible: boolean;
   createdAt: Date;
   updatedAt: Date;
   lastSyncAt: Date | null;
@@ -72,6 +80,7 @@ function toConnectedAccountRecord(account: {
     status: account.status,
     dataSource: account.dataSource,
     metadata: account.metadata,
+    publicProfileVisible: account.publicProfileVisible,
     createdAt: account.createdAt,
     updatedAt: account.updatedAt,
     lastSyncAt: account.lastSyncAt,
@@ -87,6 +96,7 @@ export type ConnectedAccountRepository = {
   findByUserProvider(userId: string, provider: Platform): Promise<ConnectedAccountRecord | null>;
   upsertConnectedAccount(input: UpsertConnectedAccountInput): Promise<ConnectedAccountRecord>;
   deleteByUserProvider(userId: string, provider: Platform): Promise<ConnectedAccountRecord | null>;
+  updateVisibility(input: UpdateConnectedAccountVisibilityInput): Promise<ConnectedAccountRecord | null>;
 };
 
 export function createConnectedAccountRepository(): ConnectedAccountRepository {
@@ -222,6 +232,35 @@ export function createConnectedAccountRepository(): ConnectedAccountRepository {
       });
 
       return toConnectedAccountRecord(deletedAccount);
+    },
+
+    async updateVisibility(input: UpdateConnectedAccountVisibilityInput): Promise<ConnectedAccountRecord | null> {
+      const existingAccount = await prisma.platformIntegration.findUnique({
+        where: {
+          userId_platform: {
+            userId: input.userId,
+            platform: input.provider,
+          },
+        },
+      });
+
+      if (!existingAccount) {
+        return null;
+      }
+
+      const updatedAccount = await prisma.platformIntegration.update({
+        where: {
+          userId_platform: {
+            userId: input.userId,
+            platform: input.provider,
+          },
+        },
+        data: {
+          publicProfileVisible: input.publicProfileVisible,
+        },
+      });
+
+      return toConnectedAccountRecord(updatedAccount);
     },
   };
 }

--- a/backend/src/core/repositories/profile.repository.ts
+++ b/backend/src/core/repositories/profile.repository.ts
@@ -1,5 +1,6 @@
-import { Profile } from '@prisma/client';
+import { Profile, type Platform, type PlatformIntegrationConnectionType } from '@prisma/client';
 import { prisma } from '../../infra/database/client';
+import { getProviderDefinition } from '../providers/provider-registry';
 
 // ─────────────────────────────────────────────────────────────
 // Profile Repository
@@ -40,8 +41,9 @@ export interface FullProfileRecord {
     updatedAt: Date;
   };
   platformIntegrations: Array<{
-    platform: string;
-    metadata: Record<string, unknown> | null;
+    platform: Platform;
+    displayName: string;
+    connectionType: PlatformIntegrationConnectionType;
   }>;
   gameLibrary: Array<{
     gameName: string;
@@ -74,7 +76,7 @@ export const profileRepository = {
   },
 
   async findFullProfileByUsername(username: string): Promise<FullProfileRecord | null> {
-    return prisma.user.findUnique({
+    const user = await prisma.user.findUnique({
       where: { username },
       select: {
         id: true,
@@ -109,8 +111,16 @@ export const profileRepository = {
           },
         },
         platformIntegrations: {
-          where: { isActive: true },
-          select: { platform: true, metadata: true },
+          where: {
+            isActive: true,
+            publicProfileVisible: true,
+            status: 'CONNECTED',
+            dataSource: 'OFFICIAL',
+          },
+          select: {
+            platform: true,
+            connectionType: true,
+          },
         },
         gameLibrary: {
           orderBy: { lastPlayedAt: 'desc' },
@@ -123,7 +133,20 @@ export const profileRepository = {
           },
         },
       },
-    }) as Promise<FullProfileRecord | null>;
+    });
+
+    if (!user) {
+      return null;
+    }
+
+    return {
+      ...user,
+      platformIntegrations: user.platformIntegrations.map((integration) => ({
+        platform: integration.platform,
+        displayName: getProviderDefinition(integration.platform).displayName,
+        connectionType: integration.connectionType,
+      })),
+    } as FullProfileRecord;
   },
 
   async updateByUserId(userId: string, input: UpdateProfileInput): Promise<Profile> {

--- a/backend/src/core/services/account-connection.service.ts
+++ b/backend/src/core/services/account-connection.service.ts
@@ -49,6 +49,7 @@ export type PublicConnectedAccount = {
   connectionType: PlatformIntegrationConnectionType;
   status: PlatformIntegrationStatus;
   dataSource: ConnectedAccountRecord['dataSource'];
+  publicProfileVisible: boolean;
   connected: boolean;
   needsReauth: boolean;
   experimental: boolean;
@@ -87,7 +88,8 @@ export type AccountConnectionErrorReason =
   | 'provider_unavailable'
   | 'identity_conflict'
   | 'not_connected'
-  | 'unsafe_unlink';
+  | 'unsafe_unlink'
+  | 'visibility_not_allowed';
 
 export class AccountConnectionError extends Error {
   readonly statusCode: number;
@@ -123,6 +125,11 @@ export type AccountConnectionService = {
     providerError?: string;
   }): Promise<AccountConnectionCallbackResult>;
   unlink(input: { userId: string; provider: string }): Promise<{ message: string; provider: Platform }>;
+  updateVisibility(input: {
+    userId: string;
+    provider: string;
+    publicProfileVisible: boolean;
+  }): Promise<PublicConnectedAccount>;
   startReauth(input: { userId: string; provider: string }): Promise<AccountConnectionStartResult>;
   completeReauth(input: {
     provider: string;
@@ -141,7 +148,11 @@ type AccountConnectionDependencies = {
   users?: AccountConnectionUserGateway;
   repository?: Pick<
     ConnectedAccountRepository,
-    'listByUser' | 'findByProviderExternalId' | 'findByUserProvider' | 'deleteByUserProvider'
+    | 'listByUser'
+    | 'findByProviderExternalId'
+    | 'findByUserProvider'
+    | 'deleteByUserProvider'
+    | 'updateVisibility'
   >;
   connectedAccountService?: Pick<ConnectedAccountService, 'connectExternalIdentity'>;
   stateStore?: SocialOAuthStateStore;
@@ -415,6 +426,7 @@ function toPublicAccount(account: ConnectedAccountRecord, canUnlink: boolean): P
     connectionType: account.connectionType,
     status: account.status,
     dataSource: account.dataSource,
+    publicProfileVisible: account.publicProfileVisible,
     connected: account.status === 'CONNECTED',
     needsReauth: account.status === 'NEEDS_REAUTH',
     experimental: account.status === 'UNAVAILABLE' || account.dataSource === 'EXPERIMENTAL',
@@ -466,6 +478,10 @@ function canUnlinkAccount(input: {
       candidate.provider !== input.account.provider &&
       candidate.status === 'CONNECTED',
   );
+}
+
+function canPublishAccount(account: ConnectedAccountRecord): boolean {
+  return account.status === 'CONNECTED' && account.dataSource === 'OFFICIAL';
 }
 
 function mapProviderFailure(error: unknown, provider: SocialAuthProvider): never {
@@ -761,6 +777,53 @@ export function createAccountConnectionService(
         provider,
         message: `${getProviderDefinition(provider).displayName} desconectado com sucesso.`,
       };
+    },
+
+    async updateVisibility(input): Promise<PublicConnectedAccount> {
+      const provider = normalizePlatform(input.provider);
+      const account = await repository.findByUserProvider(input.userId, provider);
+
+      if (!account) {
+        throw createAccountConnectionError({
+          statusCode: 404,
+          reason: 'not_connected',
+          clientMessage: 'Conta externa não encontrada.',
+          provider,
+        });
+      }
+
+      if (input.publicProfileVisible && !canPublishAccount(account)) {
+        throw createAccountConnectionError({
+          statusCode: 409,
+          reason: 'visibility_not_allowed',
+          clientMessage: 'Apenas contas ativas e oficiais podem aparecer publicamente.',
+          provider,
+        });
+      }
+
+      const updatedAccount = await repository.updateVisibility({
+        userId: input.userId,
+        provider,
+        publicProfileVisible: input.publicProfileVisible,
+      });
+
+      if (!updatedAccount) {
+        throw createAccountConnectionError({
+          statusCode: 404,
+          reason: 'not_connected',
+          clientMessage: 'Conta externa não encontrada.',
+          provider,
+        });
+      }
+
+      const accounts = await repository.listByUser(input.userId);
+      const user = await users.findById(input.userId);
+
+      return toPublicAccount(updatedAccount, canUnlinkAccount({
+        account: updatedAccount,
+        accounts,
+        user,
+      }));
     },
 
     async startReauth(input): Promise<AccountConnectionStartResult> {

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -942,6 +942,23 @@ describe('Auth Routes', () => {
           provider: 'GOOGLE',
           message: 'Google desconectado com sucesso.',
         }),
+        updateVisibility: vi.fn().mockResolvedValue({
+          provider: 'GOOGLE',
+          displayName: 'Google',
+          externalId: 'google-external-id',
+          connectionType: 'SOCIAL_LOGIN',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+          publicProfileVisible: true,
+          connected: true,
+          needsReauth: false,
+          experimental: false,
+          canUnlink: true,
+          capabilities: ['SOCIAL_LOGIN', 'OAUTH_CONNECT'],
+          lastSyncAt: null,
+          createdAt: '2026-04-28T00:00:00.000Z',
+          updatedAt: '2026-04-28T00:00:00.000Z',
+        }),
         startReauth: vi.fn().mockResolvedValue({
           provider: 'DISCORD',
           authorizationUrl: 'https://discord.com/oauth2/authorize?state=signed-state',
@@ -967,6 +984,7 @@ describe('Auth Routes', () => {
             connectionType: 'CONNECTED_ACCOUNT',
             status: 'CONNECTED',
             dataSource: 'OFFICIAL',
+            publicProfileVisible: false,
             connected: true,
             needsReauth: false,
             experimental: false,
@@ -1169,6 +1187,71 @@ describe('Auth Routes', () => {
       expect(response.statusCode).toBe(409);
       expect(response.json()).toMatchObject({
         message: 'Não é possível remover o último método de login da conta.',
+      });
+      await app.close();
+    });
+
+    it('atualiza visibilidade de conta conectada autenticada', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/connected-accounts/google/visibility',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { publicProfileVisible: true },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'GOOGLE',
+        publicProfileVisible: true,
+      });
+      expect(accountConnectionService.updateVisibility).toHaveBeenCalledWith({
+        userId: 'user-id-1',
+        provider: 'google',
+        publicProfileVisible: true,
+      });
+      await app.close();
+    });
+
+    it('bloqueia update de visibilidade sem autenticacao', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/connected-accounts/google/visibility',
+        payload: { publicProfileVisible: true },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(accountConnectionService.updateVisibility).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna erro coerente quando visibilidade publica e bloqueada', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.updateVisibility.mockRejectedValue({
+        name: 'AccountConnectionError',
+        statusCode: 409,
+        reason: 'visibility_not_allowed',
+        clientMessage: 'Apenas contas ativas e oficiais podem aparecer publicamente.',
+      });
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/auth/connected-accounts/epic/visibility',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { publicProfileVisible: true },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json()).toMatchObject({
+        message: 'Apenas contas ativas e oficiais podem aparecer publicamente.',
       });
       await app.close();
     });

--- a/backend/tests/integration/routes/profile.routes.test.ts
+++ b/backend/tests/integration/routes/profile.routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildApp, generateTestToken } from '../../helpers/build-app';
+import type { FullProfileRecord } from '@/core/repositories/profile.repository';
 
 vi.mock('@/core/repositories/profile.repository', () => ({
   profileRepository: {
@@ -37,12 +38,18 @@ const mockUser = {
   password_hash: 'hash', isActive: true, createdAt: new Date(), updatedAt: new Date(),
 };
 
-const mockFullProfile = {
+const mockFullProfile: FullProfileRecord = {
   id: 'user-id-1', username: 'clutchplayer', createdAt: new Date(),
   profile: { displayName: 'Clutch Player', bio: null, avatarUrl: null, bannerUrl: null, accentColor: '#FF5500', badges: [] },
   stats: { level: 5, xp: 1200, reputation: 80, friendCount: 12, postCount: 34 },
   presence: { status: 'ONLINE', currentGame: null, gameDetails: null, platform: null, updatedAt: new Date() },
-  platformIntegrations: [], gameLibrary: [],
+  platformIntegrations: [
+    {
+      platform: 'STEAM',
+      displayName: 'Steam',
+      connectionType: 'CONNECTED_ACCOUNT',
+    },
+  ], gameLibrary: [],
 };
 
 const mockSocialContinuity = {
@@ -101,6 +108,13 @@ describe('Profile Routes', () => {
       expect(response.statusCode).toBe(200);
       expect(response.json()).toMatchObject({
         username: 'clutchplayer',
+        platformIntegrations: [
+          {
+            platform: 'STEAM',
+            displayName: 'Steam',
+            connectionType: 'CONNECTED_ACCOUNT',
+          },
+        ],
         socialContinuity: {
           currentStreakDays: 3,
           activeFriendOffensiveCount: 1,
@@ -127,6 +141,9 @@ describe('Profile Routes', () => {
           completedCount: 1,
         },
       });
+      expect(JSON.stringify(response.json())).not.toContain('externalId');
+      expect(JSON.stringify(response.json())).not.toContain('accessToken');
+      expect(JSON.stringify(response.json())).not.toContain('metadata');
       await app.close();
     });
 

--- a/backend/tests/unit/repositories/profile.repository.test.ts
+++ b/backend/tests/unit/repositories/profile.repository.test.ts
@@ -44,7 +44,12 @@ const mockFullProfile = {
     platform:    null,
     updatedAt:   new Date(),
   },
-  platformIntegrations: [],
+  platformIntegrations: [
+    {
+      platform: 'STEAM',
+      connectionType: 'CONNECTED_ACCOUNT',
+    },
+  ],
   gameLibrary:          [],
 };
 
@@ -74,7 +79,16 @@ describe('profileRepository', () => {
 
       const result = await profileRepository.findFullProfileByUsername('clutchplayer');
 
-      expect(result).toEqual(mockFullProfile);
+      expect(result).toEqual({
+        ...mockFullProfile,
+        platformIntegrations: [
+          {
+            platform: 'STEAM',
+            displayName: 'Steam',
+            connectionType: 'CONNECTED_ACCOUNT',
+          },
+        ],
+      });
       expect(prisma.user.findUnique).toHaveBeenCalledWith(
         expect.objectContaining({ where: { username: 'clutchplayer' } }),
       );
@@ -105,6 +119,39 @@ describe('profileRepository', () => {
 
       const profileQuery = vi.mocked(prisma.user.findUnique).mock.calls[0]?.[0];
       expect(profileQuery?.select?.gameLibrary).not.toHaveProperty('take');
+    });
+
+    it('filtra plataformas publicas sem selecionar metadata ou externalId', async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(mockFullProfile as never);
+
+      await profileRepository.findFullProfileByUsername('clutchplayer');
+
+      const profileQuery = vi.mocked(prisma.user.findUnique).mock.calls[0]?.[0];
+      const platformIntegrationsQuery = profileQuery?.select?.platformIntegrations;
+
+      expect(platformIntegrationsQuery).toMatchObject({
+        where: {
+          isActive: true,
+          publicProfileVisible: true,
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+        },
+        select: {
+          platform: true,
+          connectionType: true,
+        },
+      });
+
+      if (
+        typeof platformIntegrationsQuery !== 'object' ||
+        platformIntegrationsQuery === null ||
+        !('select' in platformIntegrationsQuery)
+      ) {
+        throw new Error('Expected platformIntegrations query to select public fields.');
+      }
+
+      expect(platformIntegrationsQuery.select).not.toHaveProperty('metadata');
+      expect(platformIntegrationsQuery.select).not.toHaveProperty('externalId');
     });
   });
 

--- a/backend/tests/unit/services/account-connection.service.test.ts
+++ b/backend/tests/unit/services/account-connection.service.test.ts
@@ -54,6 +54,7 @@ function createAccount(overrides: Partial<ConnectedAccountRecord> = {}): Connect
     status: 'CONNECTED',
     dataSource: 'OFFICIAL',
     metadata: null,
+    publicProfileVisible: false,
     createdAt: new Date('2026-04-28T00:00:00.000Z'),
     updatedAt: new Date('2026-04-28T00:00:00.000Z'),
     lastSyncAt: null,
@@ -75,6 +76,7 @@ function createDependencies() {
       findByProviderExternalId: vi.fn().mockResolvedValue(null),
       findByUserProvider: vi.fn().mockResolvedValue(null),
       deleteByUserProvider: vi.fn().mockResolvedValue(null),
+      updateVisibility: vi.fn().mockResolvedValue(null),
     },
     connectedAccountService: {
       connectExternalIdentity: vi.fn().mockResolvedValue(createAccount()),
@@ -129,6 +131,7 @@ describe('account connection service', () => {
       provider: 'DISCORD',
       externalId: 'discord-user-id',
       connectionType: 'CONNECTED_ACCOUNT',
+      publicProfileVisible: false,
       needsReauth: true,
       connected: false,
     });
@@ -383,6 +386,101 @@ describe('account connection service', () => {
       statusCode: 404,
       reason: 'not_connected',
     });
+  });
+
+  it('atualiza visibilidade publica da propria conta ativa oficial', async () => {
+    const dependencies = createDependencies();
+    const account = createAccount({
+      provider: 'STEAM',
+      connectionType: 'CONNECTED_ACCOUNT',
+      publicProfileVisible: false,
+    });
+    dependencies.repository.findByUserProvider.mockResolvedValue(account);
+    dependencies.repository.updateVisibility.mockResolvedValue({
+      ...account,
+      publicProfileVisible: true,
+    });
+    dependencies.repository.listByUser.mockResolvedValue([{
+      ...account,
+      publicProfileVisible: true,
+    }]);
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.updateVisibility({
+      userId: 'user-id-1',
+      provider: 'steam',
+      publicProfileVisible: true,
+    });
+
+    expect(result).toMatchObject({
+      provider: 'STEAM',
+      publicProfileVisible: true,
+      connected: true,
+    });
+    expect(dependencies.repository.updateVisibility).toHaveBeenCalledWith({
+      userId: 'user-id-1',
+      provider: 'STEAM',
+      publicProfileVisible: true,
+    });
+  });
+
+  it('bloqueia visibilidade publica para conta que precisa reconectar', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.findByUserProvider.mockResolvedValue(createAccount({
+      status: 'NEEDS_REAUTH',
+    }));
+    const service = createAccountConnectionService(dependencies);
+
+    await expect(service.updateVisibility({
+      userId: 'user-id-1',
+      provider: 'google',
+      publicProfileVisible: true,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'visibility_not_allowed',
+    });
+    expect(dependencies.repository.updateVisibility).not.toHaveBeenCalled();
+  });
+
+  it('bloqueia visibilidade publica para conta experimental ou nao oficial', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.findByUserProvider.mockResolvedValue(createAccount({
+      provider: 'EPIC',
+      dataSource: 'EXPERIMENTAL',
+    }));
+    const service = createAccountConnectionService(dependencies);
+
+    await expect(service.updateVisibility({
+      userId: 'user-id-1',
+      provider: 'epic',
+      publicProfileVisible: true,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'visibility_not_allowed',
+    });
+    expect(dependencies.repository.updateVisibility).not.toHaveBeenCalled();
+  });
+
+  it('permite tornar privada uma conta que nao esta ativa', async () => {
+    const dependencies = createDependencies();
+    const account = createAccount({
+      status: 'NEEDS_REAUTH',
+      publicProfileVisible: true,
+    });
+    dependencies.repository.findByUserProvider.mockResolvedValue(account);
+    dependencies.repository.updateVisibility.mockResolvedValue({
+      ...account,
+      publicProfileVisible: false,
+    });
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.updateVisibility({
+      userId: 'user-id-1',
+      provider: 'google',
+      publicProfileVisible: false,
+    });
+
+    expect(result.publicProfileVisible).toBe(false);
   });
 
   it('inicia reauth apenas para conta em NEEDS_REAUTH', async () => {

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -105,6 +105,7 @@ Esse catch-all encaminha chamadas para o backend real e, quando existe `clutch_s
 - `GET /integrations/discord/auth`
 - `GET /integrations/discord/callback`
 - `GET /auth/connected-accounts`
+- `PATCH /auth/connected-accounts/:provider/visibility`
 - `GET /auth/accounts/:provider/link/start`
 - `GET /auth/accounts/:provider/link/callback`
 - `DELETE /auth/accounts/:provider`

--- a/frontend/src/components/profile/platform-badges.tsx
+++ b/frontend/src/components/profile/platform-badges.tsx
@@ -9,6 +9,7 @@ const platformLabelByCode: Record<
   ProfileResponse['platformIntegrations'][number]['platform'],
   string
 > = {
+  GOOGLE: 'Google',
   STEAM: 'Steam',
   EPIC: 'Epic Games',
   DISCORD: 'Discord',
@@ -41,7 +42,8 @@ export function PlatformBadges({ integrations }: PlatformBadgesProps) {
         <div className="flex flex-wrap items-center gap-2">
           {platformCodes.map((platformCode) => (
             <Badge key={platformCode} tone="accent">
-              {platformLabelByCode[platformCode]}
+              {integrations.find((integration) => integration.platform === platformCode)?.displayName ??
+                platformLabelByCode[platformCode]}
             </Badge>
           ))}
         </div>

--- a/frontend/src/components/settings/connection-center.tsx
+++ b/frontend/src/components/settings/connection-center.tsx
@@ -16,6 +16,7 @@ import {
   startAccountLink,
   startAccountReauth,
   unlinkConnectedAccount,
+  updateConnectedAccountVisibility,
 } from '@/services/integrations';
 
 type ProviderDefinition = {
@@ -152,6 +153,7 @@ type ConnectionProviderRowProps = {
   onConnect(provider: ConnectedAccountProvider): void;
   onReauth(provider: ConnectedAccountProvider): void;
   onUnlink(provider: ConnectedAccountProvider): void;
+  onVisibilityChange(provider: ConnectedAccountProvider, publicProfileVisible: boolean): void;
 };
 
 function ConnectionProviderRow({
@@ -161,6 +163,7 @@ function ConnectionProviderRow({
   onConnect,
   onReauth,
   onUnlink,
+  onVisibilityChange,
 }: ConnectionProviderRowProps) {
   const isBusy = busyProvider === definition.provider;
   const canOAuthConnect = definition.capabilities.includes('OAUTH_CONNECT') && definition.status === 'CONNECTED';
@@ -168,6 +171,10 @@ function ConnectionProviderRow({
     (definition.capabilities.includes('LIBRARY_IMPORT') && !definition.capabilities.includes('OAUTH_CONNECT'));
   const canReauth = Boolean(account?.needsReauth) && canOAuthConnect;
   const canUnlink = Boolean(account?.canUnlink);
+  const canPublish = Boolean(account?.connected) &&
+    account?.status === 'CONNECTED' &&
+    !account.experimental &&
+    account.dataSource === 'OFFICIAL';
 
   return (
     <Card className="space-y-5" data-testid={`connection-provider-${definition.provider.toLowerCase()}`}>
@@ -207,6 +214,39 @@ function ConnectionProviderRow({
         <p className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
           Esta conta precisa ser reconectada antes de voltar ao estado ativo.
         </p>
+      ) : null}
+
+      {account ? (
+        <div className="rounded-control border border-border bg-background-tertiary/40 px-4 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-xs uppercase tracking-[0.24em] text-secondary">
+                Visibilidade no perfil
+              </p>
+              <p className="text-sm text-secondary">
+                {account.publicProfileVisible
+                  ? 'Publica no perfil sem tokens, payload bruto ou identificador externo.'
+                  : 'Privada. Esta conta nao aparece no perfil publico.'}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={isBusy || (!account.publicProfileVisible && !canPublish)}
+              onClick={() => {
+                onVisibilityChange(definition.provider, !account.publicProfileVisible);
+              }}
+            >
+              {account.publicProfileVisible ? 'Tornar privada' : 'Tornar publica'}
+            </Button>
+          </div>
+
+          {!canPublish ? (
+            <p className="mt-2 text-xs leading-5 text-secondary">
+              Apenas contas ativas e oficiais podem ser promovidas no perfil publico.
+            </p>
+          ) : null}
+        </div>
       ) : null}
 
       {!account && canLegacyConnect ? (
@@ -361,6 +401,32 @@ export function ConnectionCenter({ onRedirect }: ConnectionCenterProps = {}) {
     },
   });
 
+  const visibilityMutation = useMutation({
+    mutationFn: (input: {
+      provider: ConnectedAccountProvider;
+      publicProfileVisible: boolean;
+    }) => updateConnectedAccountVisibility(input.provider, {
+      publicProfileVisible: input.publicProfileVisible,
+    }),
+    onMutate: ({ provider }) => {
+      setBusyProvider(provider);
+      setErrorMessage(null);
+      setFeedbackMessage(null);
+    },
+    onSuccess: async (account) => {
+      setFeedbackMessage(account.publicProfileVisible
+        ? `${account.displayName} agora aparece no perfil publico.`
+        : `${account.displayName} foi removido do perfil publico.`);
+      await queryClient.invalidateQueries({ queryKey: ['connected-accounts'] });
+    },
+    onError: (error) => {
+      setErrorMessage(resolveErrorMessage(error, 'Nao foi possivel atualizar a visibilidade agora.'));
+    },
+    onSettled: () => {
+      setBusyProvider(null);
+    },
+  });
+
   if (accountsQuery.isPending) {
     return (
       <Card className="space-y-4" data-testid="connection-center-loading">
@@ -434,6 +500,9 @@ export function ConnectionCenter({ onRedirect }: ConnectionCenterProps = {}) {
             }}
             onUnlink={(provider) => {
               unlinkMutation.mutate(provider);
+            }}
+            onVisibilityChange={(provider, publicProfileVisible) => {
+              visibilityMutation.mutate({ provider, publicProfileVisible });
             }}
           />
         ))}

--- a/frontend/src/components/settings/integrations-page-content.tsx
+++ b/frontend/src/components/settings/integrations-page-content.tsx
@@ -13,23 +13,6 @@ import { SectionHeading } from '@/components/ui/section-heading';
 import { useAuth } from '@/hooks/use-auth';
 import { fetchProfileByUsername, ProfileRequestError } from '@/services/profile';
 
-function resolveDiscordLinkedAccountLabel(metadata: Record<string, unknown> | null): string | null {
-  if (!metadata) {
-    return null;
-  }
-
-  const globalName =
-    typeof metadata.globalName === 'string' && metadata.globalName.length > 0
-      ? metadata.globalName
-      : null;
-  const username =
-    typeof metadata.username === 'string' && metadata.username.length > 0
-      ? metadata.username
-      : null;
-
-  return globalName ?? username;
-}
-
 function IntegrationsLoadingState() {
   return (
     <div className="space-y-4" data-testid="settings-integrations-loading">
@@ -89,12 +72,6 @@ export function IntegrationsPageContent() {
   const connectedPlatforms = new Set(
     profileQuery.data.platformIntegrations.map((integration) => integration.platform),
   );
-  const discordIntegration =
-    profileQuery.data.platformIntegrations.find((integration) => integration.platform === 'DISCORD') ??
-    null;
-  const discordLinkedAccountLabel = resolveDiscordLinkedAccountLabel(
-    discordIntegration?.metadata ?? null,
-  );
 
   return (
     <div className="space-y-section" data-testid="settings-integrations-success">
@@ -140,7 +117,7 @@ export function IntegrationsPageContent() {
 
         <DiscordIntegrationCard
           isConnected={connectedPlatforms.has('DISCORD')}
-          linkedAccountLabel={discordLinkedAccountLabel}
+          linkedAccountLabel={null}
         />
       </div>
 

--- a/frontend/src/schemas/integrations.ts
+++ b/frontend/src/schemas/integrations.ts
@@ -90,6 +90,7 @@ export const connectedAccountSchema = z.object({
   connectionType: connectedAccountConnectionTypeSchema,
   status: connectedAccountStatusSchema,
   dataSource: connectedAccountDataSourceSchema,
+  publicProfileVisible: z.boolean(),
   connected: z.boolean(),
   needsReauth: z.boolean(),
   experimental: z.boolean(),
@@ -131,6 +132,10 @@ export const accountUnlinkResponseSchema = z.object({
   message: z.string().min(1),
 });
 
+export const connectedAccountVisibilityUpdateRequestSchema = z.object({
+  publicProfileVisible: z.boolean(),
+});
+
 export type SteamConnectValues = z.infer<typeof steamConnectRequestSchema>;
 export type SteamConnectResponse = z.infer<typeof steamConnectResponseSchema>;
 export type SteamSyncResponse = z.infer<typeof steamSyncResponseSchema>;
@@ -148,3 +153,4 @@ export type ConnectedAccountsResponse = z.infer<typeof connectedAccountsResponse
 export type AccountConnectionStartResponse = z.infer<typeof accountConnectionStartResponseSchema>;
 export type AccountConnectionCallbackResponse = z.infer<typeof accountConnectionCallbackResponseSchema>;
 export type AccountUnlinkResponse = z.infer<typeof accountUnlinkResponseSchema>;
+export type ConnectedAccountVisibilityUpdateValues = z.infer<typeof connectedAccountVisibilityUpdateRequestSchema>;

--- a/frontend/src/schemas/profile.ts
+++ b/frontend/src/schemas/profile.ts
@@ -8,6 +8,7 @@ export const profilePresenceStatusSchema = z.enum([
 ]);
 
 export const profileIntegrationPlatformSchema = z.enum([
+  'GOOGLE',
   'STEAM',
   'EPIC',
   'DISCORD',
@@ -76,7 +77,8 @@ export const profileResponseSchema = z.object({
   platformIntegrations: z.array(
     z.object({
       platform: profileIntegrationPlatformSchema,
-      metadata: z.record(z.unknown()).nullable(),
+      displayName: z.string().min(1),
+      connectionType: z.enum(['SOCIAL_LOGIN', 'CONNECTED_ACCOUNT']),
     }),
   ),
   gameLibrary: z.array(

--- a/frontend/src/services/integrations.ts
+++ b/frontend/src/services/integrations.ts
@@ -9,10 +9,14 @@ import {
   accountConnectionStartResponseSchema,
   accountUnlinkResponseSchema,
   connectedAccountsResponseSchema,
+  connectedAccountSchema,
+  connectedAccountVisibilityUpdateRequestSchema,
   type AccountConnectionStartResponse,
   type AccountUnlinkResponse,
   type ConnectedAccountsResponse,
+  type ConnectedAccount,
   type ConnectedAccountProvider,
+  type ConnectedAccountVisibilityUpdateValues,
   steamConnectRequestSchema,
   steamConnectResponseSchema,
   steamSyncResponseSchema,
@@ -269,4 +273,25 @@ export async function unlinkConnectedAccount(
   }
 
   return accountUnlinkResponseSchema.parse(responsePayload);
+}
+
+export async function updateConnectedAccountVisibility(
+  provider: ConnectedAccountProvider,
+  input: ConnectedAccountVisibilityUpdateValues,
+): Promise<ConnectedAccount> {
+  const payload = connectedAccountVisibilityUpdateRequestSchema.parse(input);
+  const response = await apiRequest(`/auth/connected-accounts/${provider.toLowerCase()}/visibility`, {
+    method: 'PATCH',
+    body: payload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel atualizar a visibilidade agora.'),
+    );
+  }
+
+  return connectedAccountSchema.parse(responsePayload);
 }

--- a/frontend/tests/unit/components/connection-center.test.tsx
+++ b/frontend/tests/unit/components/connection-center.test.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionCenter } from '@/components/settings/connection-center';
 import type { ConnectedAccount, ConnectedAccountProviderDefinition } from '@/schemas/integrations';
@@ -9,6 +9,7 @@ import {
   startAccountLink,
   startAccountReauth,
   unlinkConnectedAccount,
+  updateConnectedAccountVisibility,
 } from '@/services/integrations';
 
 vi.mock('@/services/integrations', () => ({
@@ -16,6 +17,7 @@ vi.mock('@/services/integrations', () => ({
   startAccountLink: vi.fn(),
   startAccountReauth: vi.fn(),
   unlinkConnectedAccount: vi.fn(),
+  updateConnectedAccountVisibility: vi.fn(),
   IntegrationsRequestError: class IntegrationsRequestError extends Error {
     public readonly status: number;
 
@@ -31,6 +33,7 @@ const mockedFetchConnectedAccounts = vi.mocked(fetchConnectedAccounts);
 const mockedStartAccountLink = vi.mocked(startAccountLink);
 const mockedStartAccountReauth = vi.mocked(startAccountReauth);
 const mockedUnlinkConnectedAccount = vi.mocked(unlinkConnectedAccount);
+const mockedUpdateConnectedAccountVisibility = vi.mocked(updateConnectedAccountVisibility);
 
 function renderWithQuery(ui: ReactElement) {
   const queryClient = new QueryClient({
@@ -53,6 +56,7 @@ function createAccount(overrides: Partial<ConnectedAccount> = {}): ConnectedAcco
     connectionType: 'SOCIAL_LOGIN',
     status: 'CONNECTED',
     dataSource: 'OFFICIAL',
+    publicProfileVisible: false,
     connected: true,
     needsReauth: false,
     experimental: false,
@@ -102,6 +106,7 @@ describe('ConnectionCenter', () => {
     mockedStartAccountLink.mockReset();
     mockedStartAccountReauth.mockReset();
     mockedUnlinkConnectedAccount.mockReset();
+    mockedUpdateConnectedAccountVisibility.mockReset();
   });
 
   it('renderiza contas conectadas sem expor tokens', async () => {
@@ -232,6 +237,69 @@ describe('ConnectionCenter', () => {
       expect(mockedUnlinkConnectedAccount.mock.calls[0]?.[0]).toBe('GOOGLE');
     });
     expect(await screen.findByText(/google desconectado com sucesso/i)).toBeInTheDocument();
+  });
+
+  it('alterna visibilidade publica da conta conectada', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [createAccount()],
+    });
+    mockedUpdateConnectedAccountVisibility.mockResolvedValue(createAccount({
+      publicProfileVisible: true,
+    }));
+
+    renderWithQuery(<ConnectionCenter />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /tornar publica/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateConnectedAccountVisibility).toHaveBeenCalledWith('GOOGLE', {
+        publicProfileVisible: true,
+      });
+    });
+    expect(await screen.findByText(/agora aparece no perfil publico/i)).toBeInTheDocument();
+  });
+
+  it('mostra erro quando visibilidade publica e bloqueada pelo backend', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [createAccount()],
+    });
+    mockedUpdateConnectedAccountVisibility.mockRejectedValue(new Error('Apenas contas ativas e oficiais podem aparecer publicamente.'));
+
+    renderWithQuery(<ConnectionCenter />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /tornar publica/i }));
+
+    expect(await screen.findByText(/nao foi possivel atualizar a visibilidade agora/i)).toBeInTheDocument();
+  });
+
+  it('nao sugere publicacao para Epic experimental', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [
+        createAccount({
+          provider: 'EPIC',
+          displayName: 'Epic Games',
+          externalId: 'legacy:epic:user-id-1',
+          dataSource: 'EXPERIMENTAL',
+          status: 'NEEDS_REAUTH',
+          connected: false,
+          needsReauth: true,
+          experimental: true,
+          capabilities: ['CONNECTED_ACCOUNT', 'TOKEN_CONNECT', 'LIBRARY_IMPORT'],
+        }),
+      ],
+    });
+
+    renderWithQuery(<ConnectionCenter />);
+
+    const epicCard = await screen.findByTestId('connection-provider-epic');
+    const publishButton = within(epicCard).getByRole('button', { name: /tornar publica/i });
+
+    expect(publishButton).toBeDisabled();
+    expect(epicCard).toHaveTextContent(/apenas contas ativas e oficiais/i);
+    expect(mockedUpdateConnectedAccountVisibility).not.toHaveBeenCalled();
   });
 
   it('desabilita unlink quando backend indica que removeria ultimo metodo de login', async () => {

--- a/frontend/tests/unit/components/gamer-card.test.tsx
+++ b/frontend/tests/unit/components/gamer-card.test.tsx
@@ -136,8 +136,8 @@ describe('GamerCard', () => {
         profile={{
           ...profileFixture,
           platformIntegrations: [
-            { platform: 'STEAM', metadata: null },
-            { platform: 'DISCORD', metadata: null },
+            { platform: 'STEAM', displayName: 'Steam', connectionType: 'CONNECTED_ACCOUNT' },
+            { platform: 'DISCORD', displayName: 'Discord', connectionType: 'CONNECTED_ACCOUNT' },
           ],
         }}
       />,

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -91,14 +91,20 @@ describe('IntegrationsPageContent', () => {
         updatedAt: '2026-03-29T22:15:00.000Z',
       },
       platformIntegrations: [
-        { platform: 'STEAM', metadata: null },
-        { platform: 'EPIC', metadata: null },
+        {
+          platform: 'STEAM',
+          displayName: 'Steam',
+          connectionType: 'CONNECTED_ACCOUNT',
+        },
+        {
+          platform: 'EPIC',
+          displayName: 'Epic Games',
+          connectionType: 'CONNECTED_ACCOUNT',
+        },
         {
           platform: 'DISCORD',
-          metadata: {
-            username: 'clutchplayer',
-            globalName: 'CLUTCH Guild',
-          },
+          displayName: 'Discord',
+          connectionType: 'CONNECTED_ACCOUNT',
         },
       ],
       gameLibrary: [
@@ -131,7 +137,8 @@ describe('IntegrationsPageContent', () => {
       screen.getByRole('heading', { name: /vinculo discord e presence bridge/i }),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /reconectar discord/i })).toBeInTheDocument();
-    expect(screen.getByText(/conta vinculada: clutch guild/i)).toBeInTheDocument();
+    expect(screen.queryByText(/conta vinculada: clutch guild/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/clutchplayer/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/ainda fora do contrato frontend atual/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/library-page-content.test.tsx
+++ b/frontend/tests/unit/components/library-page-content.test.tsx
@@ -52,8 +52,8 @@ const profileFixture: ProfileResponse = {
     updatedAt: '2026-03-29T22:15:00.000Z',
   },
   platformIntegrations: [
-    { platform: 'STEAM', metadata: null },
-    { platform: 'EPIC', metadata: null },
+    { platform: 'STEAM', displayName: 'Steam', connectionType: 'CONNECTED_ACCOUNT' },
+    { platform: 'EPIC', displayName: 'Epic Games', connectionType: 'CONNECTED_ACCOUNT' },
   ],
   gameLibrary: [
     {

--- a/frontend/tests/unit/components/profile-page-content.test.tsx
+++ b/frontend/tests/unit/components/profile-page-content.test.tsx
@@ -66,7 +66,8 @@ const profileFixture: ProfileResponse = {
   platformIntegrations: [
     {
       platform: 'STEAM',
-      metadata: null,
+      displayName: 'Steam',
+      connectionType: 'CONNECTED_ACCOUNT',
     },
   ],
   gameLibrary: [

--- a/frontend/tests/unit/lib/public-library-share.test.ts
+++ b/frontend/tests/unit/lib/public-library-share.test.ts
@@ -36,7 +36,8 @@ const profileFixture: ProfileResponse = {
   platformIntegrations: [
     {
       platform: 'STEAM',
-      metadata: null,
+      displayName: 'Steam',
+      connectionType: 'CONNECTED_ACCOUNT',
     },
   ],
   gameLibrary: [

--- a/frontend/tests/unit/lib/public-profile-share.test.ts
+++ b/frontend/tests/unit/lib/public-profile-share.test.ts
@@ -36,7 +36,8 @@ const profileFixture: ProfileResponse = {
   platformIntegrations: [
     {
       platform: 'STEAM',
-      metadata: null,
+      displayName: 'Steam',
+      connectionType: 'CONNECTED_ACCOUNT',
     },
   ],
   gameLibrary: [

--- a/frontend/tests/unit/services/integrations.test.ts
+++ b/frontend/tests/unit/services/integrations.test.ts
@@ -8,6 +8,7 @@ import {
   startAccountLink,
   startAccountReauth,
   unlinkConnectedAccount,
+  updateConnectedAccountVisibility,
   IntegrationsRequestError,
   searchIgdbGame,
   startDiscordOAuth,
@@ -27,6 +28,7 @@ const connectedAccountPayload = {
   connectionType: 'SOCIAL_LOGIN',
   status: 'CONNECTED',
   dataSource: 'OFFICIAL',
+  publicProfileVisible: false,
   connected: true,
   needsReauth: false,
   experimental: false,
@@ -263,6 +265,29 @@ describe('integrations service', () => {
     expect(result.message).toBe('Google desconectado com sucesso.');
     expect(mockedApiRequest).toHaveBeenCalledWith('/auth/accounts/google', {
       method: 'DELETE',
+    });
+  });
+
+  it('atualiza visibilidade publica de conta conectada', async () => {
+    mockedApiRequest.mockResolvedValue(new Response(
+      JSON.stringify({
+        ...connectedAccountPayload,
+        publicProfileVisible: true,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ));
+
+    const result = await updateConnectedAccountVisibility('GOOGLE', {
+      publicProfileVisible: true,
+    });
+
+    expect(result.publicProfileVisible).toBe(true);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/auth/connected-accounts/google/visibility', {
+      method: 'PATCH',
+      body: { publicProfileVisible: true },
     });
   });
 


### PR DESCRIPTION
﻿## Resumo
Implementa a camada mínima de privacidade para contas conectadas, permitindo que o usuário controle quais contas aparecem no perfil público. A mudança adiciona default conservador privado, endpoint autenticado de visibilidade e remove dados brutos de provider do contrato público de perfil.

## O que foi alterado
- Backend:
  - adiciona `publicProfileVisible` em `PlatformIntegration` com default `false`.
  - cria migration com comentário documentando o default privado.
  - expõe `publicProfileVisible` em `GET /auth/connected-accounts`.
  - adiciona `PATCH /auth/connected-accounts/:provider/visibility` autenticado.
  - bloqueia publicação de contas que não estão `CONNECTED` ou não usam `dataSource=OFFICIAL`.
  - filtra `GET /profiles/:username` para retornar somente contas públicas, ativas, conectadas e oficiais.
  - remove `metadata`, `externalId`, tokens e payload bruto do contrato público de plataformas do perfil.
- Frontend:
  - adiciona ação de visibilidade no `ConnectionCenter`.
  - mostra microcopy de conta pública/privada no perfil e estado não publicável.
  - consome o novo endpoint de visibilidade.
  - ajusta badges públicos de plataformas para o contrato mínimo seguro.
- Testes:
  - cobre listagem com visibilidade, update autenticado e bloqueios de domínio.
  - cobre profile público filtrado e sem dados sensíveis.
  - cobre toggle de visibilidade, erro no Connection Center e provider experimental não publicável.

## Motivação
A #276 precisa garantir que o frontend não seja a única barreira de privacidade. O perfil público já exibia integrações, mas ainda não existia preferência por conta e o contrato podia carregar metadata bruto. Esta PR move a decisão para backend e mantém o frontend como superfície de controle.

## Como validar
- `cd backend && npx prisma generate`
- `cd backend && npm run test -- tests/unit/services/account-connection.service.test.ts tests/unit/repositories/profile.repository.test.ts tests/integration/routes/auth.routes.test.ts tests/integration/routes/profile.routes.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd frontend && npm run test -- tests/unit/services/integrations.test.ts tests/unit/components/connection-center.test.tsx tests/unit/components/profile-page-content.test.tsx tests/unit/components/gamer-card.test.tsx tests/unit/services/profile.test.ts tests/unit/lib/public-profile-share.test.ts tests/unit/lib/public-library-share.test.ts tests/unit/components/library-page-content.test.tsx tests/unit/components/integrations-page-content.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Riscos e impactos
- Existing accounts ficam privadas após a migration por default. Isso é intencional e conservador.
- O contrato público de `platformIntegrations` deixa de retornar `metadata` e `externalId`; consumidores que dependiam desses dados devem migrar para contratos autenticados.
- Contas `NEEDS_REAUTH`, experimentais, desconectadas ou não oficiais não podem ser promovidas ao perfil público neste slice.
- Preferências por tipo de dado continuam fora do escopo e ficam para evolução futura.

## Evidências
- Backend affected tests: 83 testes passaram.
- Frontend affected tests: 53 testes passaram.
- Backend typecheck, lint e build passaram; lint manteve 3 warnings preexistentes em `src/config/rate-limit.ts`.
- Frontend typecheck, lint e build passaram.
- Testes de integração backend emitiram warnings preexistentes do Redis local indisponível, mas finalizaram com sucesso.

Closes #276

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados
