### PR TITLE
test(auth): consolida testes de providers e Connection Center

### DIFF
--- a/backend/tests/integration/routes/profile.routes.test.ts
+++ b/backend/tests/integration/routes/profile.routes.test.ts
@@ -143,7 +143,11 @@ describe('Profile Routes', () => {
       });
       expect(JSON.stringify(response.json())).not.toContain('externalId');
       expect(JSON.stringify(response.json())).not.toContain('accessToken');
+      expect(JSON.stringify(response.json())).not.toContain('refreshToken');
       expect(JSON.stringify(response.json())).not.toContain('metadata');
+      expect(JSON.stringify(response.json())).not.toContain('rawProfile');
+      expect(JSON.stringify(response.json())).not.toContain('state');
+      expect(JSON.stringify(response.json())).not.toContain('secret');
       await app.close();
     });
 

--- a/backend/tests/unit/providers/provider-registry.test.ts
+++ b/backend/tests/unit/providers/provider-registry.test.ts
@@ -50,4 +50,10 @@ describe('provider registry', () => {
     expect(epic.capabilities).not.toContain('SOCIAL_LOGIN');
     expect(epic.capabilities).not.toContain('OAUTH_CONNECT');
   });
+
+  it('falha explicitamente para provider nao registrado', () => {
+    expect(() => getProviderDefinition('TWITCH' as never)).toThrowError(
+      'Provider TWITCH não está registrado.',
+    );
+  });
 });

--- a/backend/tests/unit/services/account-connection.service.test.ts
+++ b/backend/tests/unit/services/account-connection.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Platform, User } from '@prisma/client';
 import {
   AccountConnectionError,
@@ -112,6 +112,10 @@ async function issueState(
 }
 
 describe('account connection service', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('lista contas conectadas sem expor tokens', async () => {
     const dependencies = createDependencies();
     dependencies.repository.listByUser.mockResolvedValue([
@@ -305,6 +309,27 @@ describe('account connection service', () => {
     expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
   });
 
+  it('rejeita callback de linking com state expirado antes de trocar token', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T12:00:00.000Z'));
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+
+    vi.setSystemTime(new Date('2026-04-29T12:11:00.000Z'));
+
+    await expect(service.completeLink({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback de conexão inválido ou expirado.',
+    });
+    expect(dependencies.providerClients.GOOGLE.exchangeCodeForIdentity).not.toHaveBeenCalled();
+  });
+
   it('mapeia corrida de ownership externo para erro de dominio', async () => {
     const dependencies = createDependencies();
     const service = createAccountConnectionService(dependencies);
@@ -424,6 +449,26 @@ describe('account connection service', () => {
     });
   });
 
+  it('remove conta apenas pelo userId autenticado e provider solicitado', async () => {
+    const dependencies = createDependencies();
+    dependencies.repository.findByUserProvider.mockResolvedValue(createAccount({
+      provider: 'DISCORD',
+      userId: 'user-id-1',
+      connectionType: 'CONNECTED_ACCOUNT',
+    }));
+    dependencies.repository.deleteByUserProvider.mockResolvedValue(createAccount({
+      provider: 'DISCORD',
+      userId: 'user-id-1',
+      connectionType: 'CONNECTED_ACCOUNT',
+    }));
+    const service = createAccountConnectionService(dependencies);
+
+    await service.unlink({ userId: 'user-id-1', provider: 'discord' });
+
+    expect(dependencies.repository.findByUserProvider).toHaveBeenCalledWith('user-id-1', 'DISCORD');
+    expect(dependencies.repository.deleteByUserProvider).toHaveBeenCalledWith('user-id-1', 'DISCORD');
+  });
+
   it('bloqueia visibilidade publica para conta que precisa reconectar', async () => {
     const dependencies = createDependencies();
     dependencies.repository.findByUserProvider.mockResolvedValue(createAccount({
@@ -495,6 +540,18 @@ describe('account connection service', () => {
 
     expect(result.provider).toBe('DISCORD');
     expect(result.authorizationUrl).toBe('https://provider.test/discord/authorize');
+  });
+
+  it('bloqueia reauth para conta inexistente', async () => {
+    const service = createAccountConnectionService(createDependencies());
+
+    await expect(service.startReauth({
+      userId: 'user-id-1',
+      provider: 'discord',
+    })).rejects.toMatchObject({
+      statusCode: 404,
+      reason: 'not_connected',
+    });
   });
 
   it('rejeita reauth para provider sem OAuth connect', async () => {

--- a/backend/tests/unit/services/social-auth.service.test.ts
+++ b/backend/tests/unit/services/social-auth.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createSocialAuthService,
   SocialAuthError,
@@ -81,6 +81,10 @@ async function issueState(
 }
 
 describe('social auth service', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('inicia login social para provider suportado com state assinado', async () => {
     const dependencies = createDependencies();
     const service = createSocialAuthService(dependencies);
@@ -147,6 +151,27 @@ describe('social auth service', () => {
       statusCode: 400,
       reason: 'invalid_request',
     });
+  });
+
+  it('rejeita callback com state expirado antes de trocar token', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T12:00:00.000Z'));
+    const dependencies = createDependencies();
+    const service = createSocialAuthService(dependencies);
+    const state = await issueState(service, dependencies, 'GOOGLE');
+
+    vi.setSystemTime(new Date('2026-04-29T12:11:00.000Z'));
+
+    await expect(service.completeCallback({
+      provider: 'google',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_state',
+      clientMessage: 'Callback social inválido ou expirado.',
+    });
+    expect(dependencies.providerClients.GOOGLE.exchangeCodeForIdentity).not.toHaveBeenCalled();
   });
 
   it('emite login para o owner quando a identidade externa ja existe', async () => {

--- a/frontend/src/app/api/auth/accounts/[provider]/link/callback/route.ts
+++ b/frontend/src/app/api/auth/accounts/[provider]/link/callback/route.ts
@@ -18,6 +18,8 @@ type ErrorResponse = {
   message?: string;
 };
 
+const SENSITIVE_ERROR_MESSAGE_PATTERN = /\b(?:code|state|token|access[_-]?token|refresh[_-]?token|secret|cookie|authorization)\b|bearer\s+/iu;
+
 async function readJsonBody(response: Response): Promise<unknown> {
   const text = await response.text();
 
@@ -37,6 +39,10 @@ function resolveMessage(payload: unknown, fallback: string): string {
     const message = (payload as ErrorResponse).message;
 
     if (typeof message === 'string' && message.length > 0) {
+      if (SENSITIVE_ERROR_MESSAGE_PATTERN.test(message)) {
+        return fallback;
+      }
+
       return message;
     }
   }

--- a/frontend/src/app/api/auth/accounts/[provider]/reauth/callback/route.ts
+++ b/frontend/src/app/api/auth/accounts/[provider]/reauth/callback/route.ts
@@ -18,6 +18,8 @@ type ErrorResponse = {
   message?: string;
 };
 
+const SENSITIVE_ERROR_MESSAGE_PATTERN = /\b(?:code|state|token|access[_-]?token|refresh[_-]?token|secret|cookie|authorization)\b|bearer\s+/iu;
+
 async function readJsonBody(response: Response): Promise<unknown> {
   const text = await response.text();
 
@@ -37,6 +39,10 @@ function resolveMessage(payload: unknown, fallback: string): string {
     const message = (payload as ErrorResponse).message;
 
     if (typeof message === 'string' && message.length > 0) {
+      if (SENSITIVE_ERROR_MESSAGE_PATTERN.test(message)) {
+        return fallback;
+      }
+
       return message;
     }
   }

--- a/frontend/src/app/api/auth/social/[provider]/callback/route.ts
+++ b/frontend/src/app/api/auth/social/[provider]/callback/route.ts
@@ -22,6 +22,8 @@ type ErrorResponse = {
   message?: string;
 };
 
+const SENSITIVE_ERROR_MESSAGE_PATTERN = /\b(?:code|state|token|access[_-]?token|refresh[_-]?token|secret|cookie|authorization)\b|bearer\s+/iu;
+
 async function readJsonBody(response: Response): Promise<unknown> {
   const text = await response.text();
 
@@ -41,6 +43,10 @@ function resolveMessage(payload: unknown, fallback: string): string {
     const message = (payload as ErrorResponse).message;
 
     if (typeof message === 'string' && message.length > 0) {
+      if (SENSITIVE_ERROR_MESSAGE_PATTERN.test(message)) {
+        return fallback;
+      }
+
       return message;
     }
   }

--- a/frontend/tests/unit/routes/auth-account-route.test.ts
+++ b/frontend/tests/unit/routes/auth-account-route.test.ts
@@ -76,6 +76,31 @@ describe('auth account connection frontend routes', () => {
     expect(location).not.toContain('should-not-leak');
   });
 
+  it('redireciona erro de linking com fallback quando mensagem contem code ou state', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({
+        message: 'Falha OAuth code=oauth-code state=signed-state token=provider-token',
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )) as typeof fetch);
+
+    const response = await completeAccountLink(
+      new NextRequest('http://localhost/api/auth/accounts/google/link/callback?code=oauth-code&state=signed-state'),
+      { params: Promise.resolve({ provider: 'google' }) },
+    );
+    const location = response.headers.get('location') ?? '';
+
+    expect(response.status).toBe(307);
+    expect(location).toContain('connectionStatus=error');
+    expect(location).toContain('Nao+foi+possivel+concluir+a+conexao+agora.');
+    expect(location).not.toContain('oauth-code');
+    expect(location).not.toContain('signed-state');
+    expect(location).not.toContain('provider-token');
+  });
+
   it('bloqueia provider invalido no callback frontend sem chamar backend', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
@@ -116,6 +141,32 @@ describe('auth account connection frontend routes', () => {
 
     expect(response.status).toBe(307);
     expect(location).toContain('connectionStatus=error');
+    expect(location).not.toContain('oauth-code');
+    expect(location).not.toContain('signed-state');
+  });
+
+  it('redireciona erro de reauth com fallback quando mensagem contem segredo', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({
+        message: 'Provider retornou secret=client-secret refresh_token=refresh-token',
+      }),
+      {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )) as typeof fetch);
+
+    const response = await completeAccountReauth(
+      new NextRequest('http://localhost/api/auth/accounts/discord/reauth/callback?code=oauth-code&state=signed-state'),
+      { params: Promise.resolve({ provider: 'discord' }) },
+    );
+    const location = response.headers.get('location') ?? '';
+
+    expect(response.status).toBe(307);
+    expect(location).toContain('connectionStatus=error');
+    expect(location).toContain('Nao+foi+possivel+concluir+a+reconexao+agora.');
+    expect(location).not.toContain('client-secret');
+    expect(location).not.toContain('refresh-token');
     expect(location).not.toContain('oauth-code');
     expect(location).not.toContain('signed-state');
   });

--- a/frontend/tests/unit/routes/auth-social-route.test.ts
+++ b/frontend/tests/unit/routes/auth-social-route.test.ts
@@ -100,6 +100,30 @@ describe('auth social frontend routes', () => {
       'http://localhost/login?socialAuthError=Callback+social+inv%C3%A1lido.',
     );
   });
+
+  it('nao propaga code, state ou token no redirect final de erro social', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({
+        message: 'Falha OAuth code=oauth-code state=signed-state token=provider-token',
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )) as typeof fetch);
+
+    const response = await completeSocialLogin(
+      new NextRequest('http://localhost/api/auth/social/google/callback?code=oauth-code&state=signed-state'),
+      { params: Promise.resolve({ provider: 'google' }) },
+    );
+    const location = response.headers.get('location') ?? '';
+
+    expect(response.status).toBe(307);
+    expect(location).toContain('socialAuthError=Nao+foi+possivel+concluir+o+login+social+agora.');
+    expect(location).not.toContain('oauth-code');
+    expect(location).not.toContain('signed-state');
+    expect(location).not.toContain('provider-token');
+  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
﻿## Resumo
Consolida a matriz de testes de auth, providers e Connection Center antes da expansão de providers prevista na #274. A PR adiciona regressões para state OAuth expirado, ownership/linking, reauth, visibilidade pública e sanitização de callbacks frontend.

## O que foi alterado
- Backend:
  - adiciona teste de provider não registrado no provider registry.
  - adiciona testes de state expirado em login social e account linking.
  - reforça unlink para garantir remoção pelo `userId` autenticado e provider solicitado.
  - adiciona cobertura de reauth para conta inexistente.
  - reforça teste de profile público contra exposição de `refreshToken`, raw profile, `state` e `secret`.
- Frontend:
  - adiciona testes para callbacks de social login, link e reauth não propagarem `code`, `state`, token ou segredo no redirect final.
  - endurece callbacks frontend para substituir mensagens de erro sensíveis por fallback seguro.

## Motivação
O epic #270 já possui foundation, login social, linking/unlink/reauth, Connection Center e visibilidade pública. Antes de adicionar novos providers, a matriz crítica precisava cobrir melhor regressões de segurança em state OAuth, ownership externo, callbacks e payload público.

## Como validar
- `cd backend && npm run test -- tests/unit/providers/provider-registry.test.ts tests/unit/providers/social-oauth-clients.test.ts tests/unit/services/social-auth.service.test.ts tests/unit/services/account-connection.service.test.ts tests/unit/services/connected-account.service.test.ts tests/unit/repositories/profile.repository.test.ts tests/integration/routes/auth.routes.test.ts tests/integration/routes/profile.routes.test.ts`
- `cd frontend && npm run test -- tests/unit/components/connection-center.test.tsx tests/unit/routes/auth-account-route.test.ts tests/unit/routes/auth-social-route.test.ts tests/unit/services/integrations.test.ts tests/unit/components/profile-page-content.test.tsx tests/unit/services/profile.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Riscos e impactos
- A única alteração produtiva é defensiva: callbacks frontend deixam de refletir mensagens de erro que contenham indícios de `code`, `state`, token, segredo, cookie ou authorization.
- Não há provider novo, mudança de sessão, mudança de foundation ou expansão do Connection Center.
- `npm run test:coverage` completo local não finalizou de forma confiável neste ambiente: backend falhou por Postgres local indisponível em suites fora do escopo e timeouts em rotas não relacionadas; frontend falhou por timeout no teste de landing fora do escopo.
- O recorte de coverage de frontend para auth/providers/Connection Center passou. O recorte de coverage de backend executou os 126 testes focados, mas o comando sai 1 porque o threshold global é aplicado sobre suíte parcial.

## Evidências
- Backend affected tests: 126 testes passaram.
- Frontend affected tests: 42 testes passaram.
- Backend typecheck, lint e build passaram; lint manteve 3 warnings preexistentes em `src/config/rate-limit.ts`.
- Frontend typecheck, lint e build passaram.
- Testes de integração backend emitiram warnings preexistentes do Redis local indisponível, mas finalizaram com sucesso no recorte afetado.

Closes #277

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados
