### PR TITLE
feat(auth): consolida conexão Steam/MyAnimeList

### DIFF
--- a/backend/src/api/routes/integrations.routes.ts
+++ b/backend/src/api/routes/integrations.routes.ts
@@ -9,7 +9,7 @@ import { createIntegrationError } from '../../infra/integrations/integration.err
 import { isIntegrationError } from '../../core/services/integrations.service';
 
 const steamConnectSchema = z.object({
-  steamId: z.string().min(1, 'SteamID é obrigatório'),
+  steamId: z.string().trim().min(1, 'SteamID é obrigatório'),
 });
 
 const epicConnectSchema = z.object({

--- a/backend/src/core/providers/provider-registry.ts
+++ b/backend/src/core/providers/provider-registry.ts
@@ -18,6 +18,7 @@ export type ProviderDefinition = {
   dataSource: PlatformIntegrationDataSource;
   status: PlatformIntegrationStatus;
   capabilities: ProviderCapability[];
+  visibleInConnectionCenter?: boolean;
 };
 
 const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
@@ -27,6 +28,7 @@ const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
     dataSource: 'OFFICIAL',
     status: 'CONNECTED',
     capabilities: ['SOCIAL_LOGIN', 'OAUTH_CONNECT'],
+    visibleInConnectionCenter: true,
   },
   {
     provider: 'DISCORD',
@@ -34,6 +36,7 @@ const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
     dataSource: 'OFFICIAL',
     status: 'CONNECTED',
     capabilities: ['SOCIAL_LOGIN', 'CONNECTED_ACCOUNT', 'OAUTH_CONNECT', 'PRESENCE_INGESTION'],
+    visibleInConnectionCenter: true,
   },
   {
     provider: 'STEAM',
@@ -41,6 +44,7 @@ const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
     dataSource: 'OFFICIAL',
     status: 'CONNECTED',
     capabilities: ['CONNECTED_ACCOUNT', 'LIBRARY_IMPORT'],
+    visibleInConnectionCenter: true,
   },
   {
     provider: 'EPIC',
@@ -48,13 +52,15 @@ const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
     dataSource: 'EXPERIMENTAL',
     status: 'EXPERIMENTAL',
     capabilities: ['CONNECTED_ACCOUNT', 'TOKEN_CONNECT', 'LIBRARY_IMPORT'],
+    visibleInConnectionCenter: true,
   },
   {
     provider: 'MYANIMELIST',
     displayName: 'MyAnimeList',
     dataSource: 'OFFICIAL',
     status: 'UNAVAILABLE',
-    capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+    capabilities: ['CONNECTED_ACCOUNT'],
+    visibleInConnectionCenter: true,
   },
   {
     provider: 'ANILIST',

--- a/backend/src/core/services/account-connection.service.ts
+++ b/backend/src/core/services/account-connection.service.ts
@@ -442,7 +442,10 @@ function listPublicProviders(accounts: ConnectedAccountRecord[]): PublicConnecte
   const accountProviders = new Set(accounts.map((account) => account.provider));
 
   return listProviderDefinitions()
-    .filter((definition) => definition.status !== 'UNAVAILABLE' || accountProviders.has(definition.provider))
+    .filter((definition) =>
+      definition.visibleInConnectionCenter === true ||
+      definition.status !== 'UNAVAILABLE' ||
+      accountProviders.has(definition.provider))
     .map((definition) => ({
       provider: definition.provider,
       displayName: definition.displayName,

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -201,7 +201,8 @@ export function createIntegrationsService(dependencies?: {
 
   return {
     async connectSteam(userId: string, steamId: string): Promise<{ imported: number; message: string }> {
-      const isValidSteamId = await steamClient.validateSteamId(steamId);
+      const normalizedSteamId = steamId.trim();
+      const isValidSteamId = await steamClient.validateSteamId(normalizedSteamId);
 
       if (!isValidSteamId) {
         throw createIntegrationError(
@@ -212,9 +213,9 @@ export function createIntegrationsService(dependencies?: {
         );
       }
 
-      await persistence.upsertPlatformIntegration(userId, 'STEAM', { externalId: steamId });
+      await persistence.upsertPlatformIntegration(userId, 'STEAM', { externalId: normalizedSteamId });
 
-      const games = await steamClient.getOwnedGames(steamId);
+      const games = await steamClient.getOwnedGames(normalizedSteamId);
 
       for (const game of games) {
         const coverUrl = await resolveIgdbCover(game.name, igdbClient);

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -6,7 +6,7 @@ import type {
 import { buildExperimentalEpicExternalId } from '../providers/epic-identity';
 import {
   createIntegrationError,
-  type IntegrationError,
+  IntegrationError,
   translateUpstreamError,
 } from '../../infra/integrations/integration.errors';
 import { epicService, type EpicGame } from '../../infra/integrations/epic/epic.service';
@@ -215,7 +215,27 @@ export function createIntegrationsService(dependencies?: {
 
       await persistence.upsertPlatformIntegration(userId, 'STEAM', { externalId: normalizedSteamId });
 
-      const games = await steamClient.getOwnedGames(normalizedSteamId);
+      let games: SteamGame[] = [];
+      let libraryImportSkipped = false;
+
+      try {
+        games = await steamClient.getOwnedGames(normalizedSteamId);
+      } catch (error) {
+        if (!(error instanceof IntegrationError)) {
+          throw error;
+        }
+
+        libraryImportSkipped = true;
+        writeBackendRuntimeLog(
+          'warn',
+          'integration_steam_library_import_skipped',
+          'Steam connection was persisted, but the initial library import failed.',
+          {
+            provider: 'steam',
+            reason: error.reason,
+          },
+        );
+      }
 
       for (const game of games) {
         const coverUrl = await resolveIgdbCover(game.name, igdbClient);
@@ -224,7 +244,9 @@ export function createIntegrationsService(dependencies?: {
 
       return {
         imported: games.length,
-        message: `Steam conectado. ${games.length} jogos importados.`,
+        message: libraryImportSkipped
+          ? 'Steam conectado. Biblioteca indisponivel no momento; tente sincronizar novamente mais tarde.'
+          : `Steam conectado. ${games.length} jogos importados.`,
       };
     },
 

--- a/backend/src/infra/integrations/steam/steam.service.ts
+++ b/backend/src/infra/integrations/steam/steam.service.ts
@@ -48,7 +48,7 @@ export const steamService = {
   async getOwnedGames(steamId: string): Promise<SteamGame[]> {
     try {
       const response = await axios.get<{
-        response: {
+        response?: {
           game_count: number;
           games:      SteamGame[];
         };
@@ -65,7 +65,7 @@ export const steamService = {
         },
       );
 
-      return response.data.response.games ?? [];
+      return response.data.response?.games ?? [];
     } catch (error) {
       throw translateUpstreamError(
         'steam',

--- a/backend/tests/integration/routes/integrations.routes.test.ts
+++ b/backend/tests/integration/routes/integrations.routes.test.ts
@@ -45,7 +45,7 @@ describe('Integrations Routes', () => {
       const response = await app.inject({
         method: 'POST',
         url: '/integrations/steam/connect',
-        payload: { steamId: '76561198000000000' },
+        payload: { steamId: ' 76561198000000000 ' },
       });
 
       expect(response.statusCode).toBe(401);
@@ -84,7 +84,7 @@ describe('Integrations Routes', () => {
         method: 'POST',
         url: '/integrations/steam/connect',
         headers: { Authorization: `Bearer ${token}` },
-        payload: { steamId: '76561198000000000' },
+        payload: { steamId: ' 76561198000000000 ' },
       });
 
       expect(response.statusCode).toBe(200);

--- a/backend/tests/unit/providers/provider-registry.test.ts
+++ b/backend/tests/unit/providers/provider-registry.test.ts
@@ -31,13 +31,14 @@ describe('provider registry', () => {
     );
   });
 
-  it('mantem providers futuros indisponiveis sem remover capabilities declaradas', () => {
+  it('mantem MyAnimeList planejado sem declarar OAuth antes do client real', () => {
     const myAnimeList = getProviderDefinition('MYANIMELIST');
 
     expect(myAnimeList.status).toBe('UNAVAILABLE');
-    expect(myAnimeList.capabilities).toEqual(
-      expect.arrayContaining(['CONNECTED_ACCOUNT', 'OAUTH_CONNECT']),
-    );
+    expect(myAnimeList.visibleInConnectionCenter).toBe(true);
+    expect(myAnimeList.capabilities).toContain('CONNECTED_ACCOUNT');
+    expect(myAnimeList.capabilities).not.toContain('OAUTH_CONNECT');
+    expect(myAnimeList.capabilities).not.toContain('SOCIAL_LOGIN');
   });
 
   it('mantem Epic como provider experimental sem login social', () => {

--- a/backend/tests/unit/services/account-connection.service.test.ts
+++ b/backend/tests/unit/services/account-connection.service.test.ts
@@ -152,12 +152,17 @@ describe('account connection service', () => {
           provider: 'EPIC',
           status: 'EXPERIMENTAL',
         }),
+        expect.objectContaining({
+          provider: 'MYANIMELIST',
+          status: 'UNAVAILABLE',
+          capabilities: ['CONNECTED_ACCOUNT'],
+        }),
       ]),
     );
     expect(result.providers).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          provider: 'MYANIMELIST',
+          provider: 'ANILIST',
         }),
       ]),
     );
@@ -253,6 +258,14 @@ describe('account connection service', () => {
     await expect(service.startLink({
       userId: 'user-id-1',
       provider: 'steam',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+    });
+
+    await expect(service.startLink({
+      userId: 'user-id-1',
+      provider: 'myanimelist',
     })).rejects.toMatchObject({
       statusCode: 400,
       reason: 'unsupported_provider',

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -112,6 +112,58 @@ describe('integrations service layer', () => {
     );
   });
 
+  it('mantem conexao Steam quando importacao inicial da biblioteca falha', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const steamClient = {
+      validateSteamId: vi.fn().mockResolvedValue(true),
+      getOwnedGames: vi.fn().mockRejectedValue(
+        new IntegrationError(
+          'steam',
+          503,
+          'upstream_unavailable',
+          'Integração Steam indisponível no momento.',
+        ),
+      ),
+    };
+    const persistence = {
+      upsertPlatformIntegration: vi.fn().mockResolvedValue(undefined),
+      findPlatformIntegration: vi.fn(),
+      upsertSteamLibraryGame: vi.fn(),
+      upsertEpicLibraryGame: vi.fn(),
+    };
+
+    const service = createIntegrationsService({
+      steamClient,
+      igdbClient: {
+        searchGames: vi.fn(),
+        searchGame: vi.fn(),
+      },
+      epicClient: {
+        validateToken: vi.fn(),
+        getLibrary: vi.fn(),
+      },
+      persistence,
+    });
+
+    const result = await service.connectSteam('user-id-1', '76561198000000000');
+
+    expect(result).toMatchObject({
+      imported: 0,
+      message: 'Steam conectado. Biblioteca indisponivel no momento; tente sincronizar novamente mais tarde.',
+    });
+    expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
+      'user-id-1',
+      'STEAM',
+      { externalId: '76561198000000000' },
+    );
+    expect(persistence.upsertSteamLibraryGame).not.toHaveBeenCalled();
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"integration_steam_library_import_skipped"'),
+    );
+
+    stdoutWriteSpy.mockRestore();
+  });
+
   it('traduz Steam nao conectado na sincronizacao', async () => {
     const service = createIntegrationsService({
       steamClient: {

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -53,6 +53,10 @@ describe('integrations service layer', () => {
   });
 
   it('importa biblioteca Steam e tolera falha do IGDB como enriquecimento opcional', async () => {
+    const steamClient = {
+      validateSteamId: vi.fn().mockResolvedValue(true),
+      getOwnedGames: vi.fn().mockResolvedValue(mockSteamGames),
+    };
     const persistence = {
       upsertPlatformIntegration: vi.fn().mockResolvedValue(undefined),
       findPlatformIntegration: vi.fn(),
@@ -61,10 +65,7 @@ describe('integrations service layer', () => {
     };
 
     const service = createIntegrationsService({
-      steamClient: {
-        validateSteamId: vi.fn().mockResolvedValue(true),
-        getOwnedGames: vi.fn().mockResolvedValue(mockSteamGames),
-      },
+      steamClient,
       igdbClient: {
         searchGames: vi.fn(),
         searchGame: vi.fn()
@@ -84,12 +85,14 @@ describe('integrations service layer', () => {
       persistence,
     });
 
-    const result = await service.connectSteam('user-id-1', '76561198000000000');
+    const result = await service.connectSteam('user-id-1', ' 76561198000000000 ');
 
     expect(result).toMatchObject({
       imported: 2,
       message: 'Steam conectado. 2 jogos importados.',
     });
+    expect(steamClient.validateSteamId).toHaveBeenCalledWith('76561198000000000');
+    expect(steamClient.getOwnedGames).toHaveBeenCalledWith('76561198000000000');
     expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
       'user-id-1',
       'STEAM',
@@ -415,6 +418,44 @@ describe('createPrismaIntegrationsPersistence', () => {
 
     expect(prisma.platformIntegration.upsert).not.toHaveBeenCalled();
   });
+
+  it('persiste Steam via connected account foundation com dataSource oficial', async () => {
+    vi.mocked(prisma.platformIntegration.findUnique).mockResolvedValueOnce(null);
+    vi.mocked(prisma.platformIntegration.upsert).mockResolvedValue({
+      id: 'integration-id-1',
+      userId: 'user-id-1',
+      platform: 'STEAM',
+      externalId: '76561198000000000',
+      connectionType: 'CONNECTED_ACCOUNT',
+      status: 'CONNECTED',
+      dataSource: 'OFFICIAL',
+      metadata: null,
+      publicProfileVisible: false,
+      createdAt: new Date('2026-04-29T00:00:00.000Z'),
+      updatedAt: new Date('2026-04-29T00:00:00.000Z'),
+      lastSyncAt: new Date('2026-04-29T00:00:00.000Z'),
+    } as never);
+    const persistence = createPrismaIntegrationsPersistence();
+
+    await persistence.upsertPlatformIntegration(
+      'user-id-1',
+      'STEAM',
+      { externalId: '76561198000000000' },
+    );
+
+    expect(prisma.platformIntegration.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          userId: 'user-id-1',
+          platform: 'STEAM',
+          externalId: '76561198000000000',
+          connectionType: 'CONNECTED_ACCOUNT',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+        }),
+      }),
+    );
+  });
 });
 
 describe('steamService', () => {
@@ -443,6 +484,18 @@ describe('steamService', () => {
     const games = await steamService.getOwnedGames('76561198000000000');
 
     expect(games).toHaveLength(2);
+  });
+
+  it('trata biblioteca Steam privada ou indisponivel como lista vazia', async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        response: {},
+      },
+    } as never);
+
+    const games = await steamService.getOwnedGames('76561198000000000');
+
+    expect(games).toEqual([]);
   });
 
   it('traduz timeout da Steam para erro coerente', async () => {

--- a/docs/steam-myanimelist-connection-scope.md
+++ b/docs/steam-myanimelist-connection-scope.md
@@ -7,6 +7,7 @@
 - O CLUTCH ainda usa o fluxo legado de formulario com SteamID informado pelo usuario, mas persiste esse SteamID64 como `PlatformIntegration.externalId` via `ConnectedAccountService`.
 - A importacao de biblioteca usa `IPlayerService/GetOwnedGames` com `STEAM_API_KEY`, `include_appinfo=true` e `include_played_free_games=true`.
 - Quando a Steam nao retorna jogos por biblioteca privada ou detalhes nao visiveis, o CLUTCH trata como lista vazia e mantem a conexao, sem expor API key ou payload bruto ao frontend.
+- O contrato atual nao diferencia com confianca biblioteca realmente vazia, biblioteca privada e resposta sem jogos por regra de visibilidade da Steam. A UI deve comunicar esse fallback sem transformar a ausencia de jogos em erro fatal.
 
 ## MyAnimeList
 

--- a/docs/steam-myanimelist-connection-scope.md
+++ b/docs/steam-myanimelist-connection-scope.md
@@ -1,0 +1,24 @@
+# Conexao inicial Steam/MyAnimeList
+
+## Steam
+
+- Steam Web Sign-In usa OpenID 2.0, nao OAuth2 comum.
+- A identidade forte para ownership externo e o SteamID64 retornado pela Claimed ID no formato `https://steamcommunity.com/openid/id/<steamid>`.
+- O CLUTCH ainda usa o fluxo legado de formulario com SteamID informado pelo usuario, mas persiste esse SteamID64 como `PlatformIntegration.externalId` via `ConnectedAccountService`.
+- A importacao de biblioteca usa `IPlayerService/GetOwnedGames` com `STEAM_API_KEY`, `include_appinfo=true` e `include_played_free_games=true`.
+- Quando a Steam nao retorna jogos por biblioteca privada ou detalhes nao visiveis, o CLUTCH trata como lista vazia e mantem a conexao, sem expor API key ou payload bruto ao frontend.
+
+## MyAnimeList
+
+- MyAnimeList API v2 exige app registration e OAuth2 Authorization Code com PKCE.
+- O fluxo real precisa de, no minimo, `MYANIMELIST_CLIENT_ID`, `MYANIMELIST_CLIENT_SECRET` quando aplicavel, redirect URI registrada, state seguro, code verifier/challenge e callback backend.
+- Nao existe client OAuth, env de MyAnimeList ou callback seguro no CLUTCH nesta rodada.
+- Por isso, MyAnimeList fica registrado como provider planejado/indisponivel no Connection Center, sem `OAUTH_CONNECT` e sem criar conexao falsa.
+- Importacao de anime/manga lists e normalizacao de watchlist ficam fora da #274 ate haver contrato dedicado.
+
+## Fontes consultadas
+
+- Steamworks User Authentication and Ownership: https://partner.steamgames.com/doc/features/auth
+- Steamworks IPlayerService/GetOwnedGames: https://partner.steamgames.com/doc/webapi/iplayerservice
+- MyAnimeList authorization: https://myanimelist.net/apiconfig/references/authorization
+- MyAnimeList API v2: https://myanimelist.net/apiconfig/references/api/v2

--- a/docs/steam-myanimelist-connection-scope.md
+++ b/docs/steam-myanimelist-connection-scope.md
@@ -8,6 +8,7 @@
 - A importacao de biblioteca usa `IPlayerService/GetOwnedGames` com `STEAM_API_KEY`, `include_appinfo=true` e `include_played_free_games=true`.
 - Quando a Steam nao retorna jogos por biblioteca privada ou detalhes nao visiveis, o CLUTCH trata como lista vazia e mantem a conexao, sem expor API key ou payload bruto ao frontend.
 - O contrato atual nao diferencia com confianca biblioteca realmente vazia, biblioteca privada e resposta sem jogos por regra de visibilidade da Steam. A UI deve comunicar esse fallback sem transformar a ausencia de jogos em erro fatal.
+- Se a importacao inicial da biblioteca falhar depois que o SteamID64 ja foi validado e persistido, a conexao permanece ativa e a sincronizacao pode ser tentada novamente depois.
 
 ## MyAnimeList
 

--- a/frontend/src/components/settings/connection-center.tsx
+++ b/frontend/src/components/settings/connection-center.tsx
@@ -49,10 +49,25 @@ const PROVIDER_COPY: Partial<Record<ConnectedAccountProvider, {
     description: 'Biblioteca importada pelo fluxo experimental atual.',
     connectionTypeLabel: 'Conta conectada experimental',
   },
+  MYANIMELIST: {
+    description: 'Provider planejado para showcase otaku; OAuth/API ainda nao estao habilitados nesta versao.',
+    connectionTypeLabel: 'Conta conectada otaku',
+  },
 };
 
-function getStatusLabel(account: ConnectedAccount | null): string {
+function getStatusLabel(
+  account: ConnectedAccount | null,
+  providerStatus: ConnectedAccountProviderDefinition['status'],
+): string {
   if (!account) {
+    if (providerStatus === 'UNAVAILABLE') {
+      return 'Indisponivel';
+    }
+
+    if (providerStatus === 'EXPERIMENTAL') {
+      return 'Experimental';
+    }
+
     return 'Nao conectada';
   }
 
@@ -75,8 +90,15 @@ function getStatusLabel(account: ConnectedAccount | null): string {
   return 'Indisponivel';
 }
 
-function getStatusTone(account: ConnectedAccount | null): 'success' | 'warning' | 'neutral' {
+function getStatusTone(
+  account: ConnectedAccount | null,
+  providerStatus: ConnectedAccountProviderDefinition['status'],
+): 'success' | 'warning' | 'neutral' {
   if (!account) {
+    if (providerStatus === 'EXPERIMENTAL') {
+      return 'warning';
+    }
+
     return 'neutral';
   }
 
@@ -190,7 +212,9 @@ function ConnectionProviderRow({
             {definition.description}
           </p>
         </div>
-        <Badge tone={getStatusTone(account)}>{getStatusLabel(account)}</Badge>
+        <Badge tone={getStatusTone(account, definition.status)}>
+          {getStatusLabel(account, definition.status)}
+        </Badge>
       </div>
 
       <dl className="grid gap-3 text-sm text-secondary sm:grid-cols-2">
@@ -480,7 +504,8 @@ export function ConnectionCenter({ onRedirect }: ConnectionCenterProps = {}) {
             Nenhuma conta conectada
           </h3>
           <p className="text-sm leading-6 text-secondary">
-            Conecte Google ou Discord por OAuth, ou use os formularios de Steam e Epic nesta pagina.
+            Conecte Google ou Discord por OAuth, use os formularios de Steam e Epic
+            nesta pagina, e acompanhe providers planejados quando estiverem indisponiveis.
           </p>
         </Card>
       ) : null}

--- a/frontend/src/components/settings/integrations-page-content.tsx
+++ b/frontend/src/components/settings/integrations-page-content.tsx
@@ -11,6 +11,7 @@ import { SteamIntegrationCard } from '@/components/settings/steam-integration-ca
 import { Card } from '@/components/ui/card';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { useAuth } from '@/hooks/use-auth';
+import { fetchConnectedAccounts } from '@/services/integrations';
 import { fetchProfileByUsername, ProfileRequestError } from '@/services/profile';
 
 function IntegrationsLoadingState() {
@@ -53,12 +54,28 @@ export function IntegrationsPageContent() {
     queryFn: () => fetchProfileByUsername(username as string),
     enabled: status === 'authenticated' && typeof username === 'string',
   });
+  const connectedAccountsQuery = useQuery({
+    queryKey: ['connected-accounts'],
+    queryFn: fetchConnectedAccounts,
+    enabled: status === 'authenticated',
+  });
 
-  if (status === 'loading' || profileQuery.isPending) {
+  if (
+    status === 'loading' ||
+    profileQuery.isPending ||
+    (status === 'authenticated' && connectedAccountsQuery.isPending)
+  ) {
     return <IntegrationsLoadingState />;
   }
 
-  if (status !== 'authenticated' || !username || profileQuery.isError || !profileQuery.data) {
+  if (
+    status !== 'authenticated' ||
+    !username ||
+    profileQuery.isError ||
+    connectedAccountsQuery.isError ||
+    !profileQuery.data ||
+    !connectedAccountsQuery.data
+  ) {
     const errorMessage =
       profileQuery.error instanceof ProfileRequestError
         ? profileQuery.error.message
@@ -70,7 +87,9 @@ export function IntegrationsPageContent() {
   const steamGames = profileQuery.data.gameLibrary.filter((game) => game.platform === 'STEAM');
   const epicGames = profileQuery.data.gameLibrary.filter((game) => game.platform === 'EPIC');
   const connectedPlatforms = new Set(
-    profileQuery.data.platformIntegrations.map((integration) => integration.platform),
+    connectedAccountsQuery.data.accounts
+      .filter((account) => account.connected)
+      .map((account) => account.provider),
   );
 
   return (
@@ -103,7 +122,10 @@ export function IntegrationsPageContent() {
           isConnected={connectedPlatforms.has('STEAM')}
           importedPreviewCount={steamGames.length}
           onRefreshStatus={async () => {
-            await profileQuery.refetch();
+            await Promise.all([
+              profileQuery.refetch(),
+              connectedAccountsQuery.refetch(),
+            ]);
           }}
         />
 
@@ -111,7 +133,10 @@ export function IntegrationsPageContent() {
           isConnected={connectedPlatforms.has('EPIC')}
           importedPreviewCount={epicGames.length}
           onRefreshStatus={async () => {
-            await profileQuery.refetch();
+            await Promise.all([
+              profileQuery.refetch(),
+              connectedAccountsQuery.refetch(),
+            ]);
           }}
         />
 

--- a/frontend/src/components/settings/steam-integration-card.tsx
+++ b/frontend/src/components/settings/steam-integration-card.tsx
@@ -80,6 +80,11 @@ export function SteamIntegrationCard({
   const onSubmit = handleSubmit(async (values) => {
     await connectMutation.mutateAsync(values);
   });
+  const statusCopy = isConnected
+    ? importedPreviewCount > 0
+      ? `A profile API mostra ${importedPreviewCount} jogo(s) recentes dessa integracao.`
+      : 'Steam conectada, mas nenhum jogo apareceu na previa. Isso pode indicar biblioteca vazia, biblioteca privada ou sincronizacao ainda sem jogos importados.'
+    : 'Ainda nao ha integracao Steam ativa neste perfil.';
 
   return (
     <Card className="space-y-5">
@@ -99,9 +104,7 @@ export function SteamIntegrationCard({
       </div>
 
       <p className="text-sm text-secondary">
-        {isConnected
-          ? `A profile API mostra ${importedPreviewCount} jogo(s) recentes dessa integracao.`
-          : 'Ainda nao ha integracao Steam ativa neste perfil.'}
+        {statusCopy}
       </p>
 
       {feedback ? (

--- a/frontend/tests/unit/components/connection-center.test.tsx
+++ b/frontend/tests/unit/components/connection-center.test.tsx
@@ -98,6 +98,13 @@ const providerDefinitions: ConnectedAccountProviderDefinition[] = [
     dataSource: 'EXPERIMENTAL',
     capabilities: ['CONNECTED_ACCOUNT', 'TOKEN_CONNECT', 'LIBRARY_IMPORT'],
   },
+  {
+    provider: 'MYANIMELIST',
+    displayName: 'MyAnimeList',
+    status: 'UNAVAILABLE',
+    dataSource: 'OFFICIAL',
+    capabilities: ['CONNECTED_ACCOUNT'],
+  },
 ];
 
 describe('ConnectionCenter', () => {
@@ -143,6 +150,39 @@ describe('ConnectionCenter', () => {
 
     expect(screen.getByRole('button', { name: /conectar google/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /conectar discord/i })).toBeInTheDocument();
+  });
+
+  it('renderiza MyAnimeList como planejado sem acao de conexao falsa', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [],
+    });
+
+    renderWithQuery(<ConnectionCenter />);
+
+    const myAnimeListCard = await screen.findByTestId('connection-provider-myanimelist');
+
+    expect(myAnimeListCard).toHaveTextContent('MyAnimeList');
+    expect(myAnimeListCard).toHaveTextContent('Indisponivel');
+    expect(myAnimeListCard).toHaveTextContent(/OAuth\/API ainda nao estao habilitados/i);
+    expect(within(myAnimeListCard).queryByRole('button', { name: /conectar myanimelist/i })).not.toBeInTheDocument();
+    expect(mockedStartAccountLink).not.toHaveBeenCalled();
+  });
+
+  it('renderiza Steam pelo provider registry sem acao OAuth indevida', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [],
+    });
+
+    renderWithQuery(<ConnectionCenter />);
+
+    const steamCard = await screen.findByTestId('connection-provider-steam');
+
+    expect(steamCard).toHaveTextContent('Steam');
+    expect(steamCard).toHaveTextContent(/SteamID publica/i);
+    expect(steamCard).toHaveTextContent(/formulario especifico/i);
+    expect(within(steamCard).queryByRole('button', { name: /conectar steam/i })).not.toBeInTheDocument();
   });
 
   it('mostra erro de carregamento', async () => {

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { IntegrationsPageContent } from '@/components/settings/integrations-page-content';
 import { useAuth } from '@/hooks/use-auth';
+import { fetchConnectedAccounts } from '@/services/integrations';
 import { fetchProfileByUsername } from '@/services/profile';
 
 vi.mock('next/navigation', () => ({
@@ -28,12 +29,30 @@ vi.mock('@/services/profile', () => ({
   },
 }));
 
+vi.mock('@/services/integrations', () => ({
+  connectEpic: vi.fn(),
+  connectSteam: vi.fn(),
+  fetchConnectedAccounts: vi.fn(),
+  startDiscordOAuth: vi.fn(),
+  syncSteamLibrary: vi.fn(),
+  IntegrationsRequestError: class IntegrationsRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'IntegrationsRequestError';
+      this.status = status;
+    }
+  },
+}));
+
 vi.mock('@/components/settings/connection-center', () => ({
   ConnectionCenter: () => <div data-testid="connection-center" />,
 }));
 
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedFetchProfileByUsername = vi.mocked(fetchProfileByUsername);
+const mockedFetchConnectedAccounts = vi.mocked(fetchConnectedAccounts);
 
 function renderWithQuery(ui: ReactElement) {
   const queryClient = new QueryClient({
@@ -52,6 +71,7 @@ describe('IntegrationsPageContent', () => {
   beforeEach(() => {
     mockedUseAuth.mockReset();
     mockedFetchProfileByUsername.mockReset();
+    mockedFetchConnectedAccounts.mockReset();
   });
 
   it('renders integrations status including discord connection state', async () => {
@@ -90,23 +110,7 @@ describe('IntegrationsPageContent', () => {
         platform: 'PC',
         updatedAt: '2026-03-29T22:15:00.000Z',
       },
-      platformIntegrations: [
-        {
-          platform: 'STEAM',
-          displayName: 'Steam',
-          connectionType: 'CONNECTED_ACCOUNT',
-        },
-        {
-          platform: 'EPIC',
-          displayName: 'Epic Games',
-          connectionType: 'CONNECTED_ACCOUNT',
-        },
-        {
-          platform: 'DISCORD',
-          displayName: 'Discord',
-          connectionType: 'CONNECTED_ACCOUNT',
-        },
-      ],
+      platformIntegrations: [],
       gameLibrary: [
         {
           gameName: 'Counter-Strike 2',
@@ -122,6 +126,84 @@ describe('IntegrationsPageContent', () => {
         strongestFriendOffensive: null,
       },
       otakuShowcase: null,
+    });
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: [
+        {
+          provider: 'STEAM',
+          displayName: 'Steam',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+          capabilities: ['CONNECTED_ACCOUNT', 'LIBRARY_IMPORT'],
+        },
+        {
+          provider: 'EPIC',
+          displayName: 'Epic Games',
+          status: 'EXPERIMENTAL',
+          dataSource: 'EXPERIMENTAL',
+          capabilities: ['CONNECTED_ACCOUNT', 'TOKEN_CONNECT', 'LIBRARY_IMPORT'],
+        },
+        {
+          provider: 'DISCORD',
+          displayName: 'Discord',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+          capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+        },
+      ],
+      accounts: [
+        {
+          provider: 'STEAM',
+          displayName: 'Steam',
+          externalId: '76561198000000000',
+          connectionType: 'CONNECTED_ACCOUNT',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+          publicProfileVisible: false,
+          connected: true,
+          needsReauth: false,
+          experimental: false,
+          canUnlink: true,
+          capabilities: ['CONNECTED_ACCOUNT', 'LIBRARY_IMPORT'],
+          lastSyncAt: null,
+          createdAt: '2026-04-29T10:00:00.000Z',
+          updatedAt: '2026-04-29T10:00:00.000Z',
+        },
+        {
+          provider: 'EPIC',
+          displayName: 'Epic Games',
+          externalId: 'epic:hash',
+          connectionType: 'CONNECTED_ACCOUNT',
+          status: 'NEEDS_REAUTH',
+          dataSource: 'EXPERIMENTAL',
+          publicProfileVisible: false,
+          connected: false,
+          needsReauth: true,
+          experimental: true,
+          canUnlink: true,
+          capabilities: ['CONNECTED_ACCOUNT', 'TOKEN_CONNECT', 'LIBRARY_IMPORT'],
+          lastSyncAt: null,
+          createdAt: '2026-04-29T10:00:00.000Z',
+          updatedAt: '2026-04-29T10:00:00.000Z',
+        },
+        {
+          provider: 'DISCORD',
+          displayName: 'Discord',
+          externalId: 'discord-user-id',
+          connectionType: 'CONNECTED_ACCOUNT',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+          publicProfileVisible: false,
+          connected: true,
+          needsReauth: false,
+          experimental: false,
+          canUnlink: true,
+          capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+          lastSyncAt: null,
+          createdAt: '2026-04-29T10:00:00.000Z',
+          updatedAt: '2026-04-29T10:00:00.000Z',
+        },
+      ],
     });
 
     renderWithQuery(<IntegrationsPageContent />);

--- a/frontend/tests/unit/components/steam-integration-card.test.tsx
+++ b/frontend/tests/unit/components/steam-integration-card.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@/services/integrations', () => ({
 const mockedConnectSteam = vi.mocked(connectSteam);
 const mockedSyncSteamLibrary = vi.mocked(syncSteamLibrary);
 
-function renderSteamIntegrationCard() {
+function renderSteamIntegrationCard(options: { importedPreviewCount?: number } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -34,7 +34,7 @@ function renderSteamIntegrationCard() {
     <QueryClientProvider client={queryClient}>
       <SteamIntegrationCard
         isConnected
-        importedPreviewCount={3}
+        importedPreviewCount={options.importedPreviewCount ?? 3}
         onRefreshStatus={vi.fn().mockResolvedValue(undefined)}
       />
     </QueryClientProvider>,
@@ -82,5 +82,11 @@ describe('SteamIntegrationCard', () => {
     await waitFor(() => {
       expect(mockedSyncSteamLibrary).toHaveBeenCalled();
     });
+  });
+
+  it('mostra fallback honesto quando a conexao Steam nao tem jogos visiveis', () => {
+    renderSteamIntegrationCard({ importedPreviewCount: 0 });
+
+    expect(screen.getByText(/biblioteca vazia, biblioteca privada/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Resumo
Consolida a conexão inicial de Steam na foundation de contas conectadas e expõe MyAnimeList no Connection Center como provider planejado/indisponível. O recorte evita criar OAuth falso para MyAnimeList enquanto não há client, envs e callback seguros no projeto.

Closes #274

## O que foi alterado
- Backend: SteamID é normalizado antes de validar, persistir e importar biblioteca.
- Backend: `GetOwnedGames` passa a degradar para lista vazia quando a Steam não retorna jogos por privacidade/indisponibilidade de biblioteca.
- Backend: conexão Steam permanece ativa quando a importação inicial da biblioteca falha depois que o SteamID64 já foi validado e persistido.
- Backend: provider registry marca Steam/Epic/Google/Discord/MyAnimeList como visíveis no Connection Center e remove `OAUTH_CONNECT` de MyAnimeList até existir fluxo real.
- Backend: listagem pública de providers de contas conectadas passa a incluir providers planejados explicitamente visíveis.
- Frontend: Connection Center exibe MyAnimeList como indisponível/planejado sem CTA de conexão falsa.
- Frontend: `/settings/integrations` usa `/auth/connected-accounts` como fonte de status de conexão, evitando depender do perfil público após `publicProfileVisible=false`.
- Frontend: card legado de Steam comunica que ausência de jogos visíveis pode indicar biblioteca vazia, biblioteca privada ou sincronização sem itens importados.
- Docs: adicionada nota de escopo com referências Steam OpenID/Web API e MyAnimeList OAuth/API, incluindo a limitação de diferenciação entre biblioteca vazia e privada no contrato atual.
- Testes: adicionada cobertura para SteamID normalizado, persistência via foundation, biblioteca Steam privada/indisponível, capabilities de MyAnimeList e UI sem ação indevida.

## Motivação
A #274 precisa entregar um slice real e honesto de Steam/MyAnimeList após a foundation de providers. Steam já tinha fluxo legado funcional e agora fica consolidado com a boundary de connected accounts; MyAnimeList exige OAuth2 com PKCE e configuração própria, que ainda não existem no repo, então o provider não deve simular conexão.

## Como validar
- `cd backend && npm run test -- tests/unit/providers/provider-registry.test.ts tests/unit/services/account-connection.service.test.ts tests/unit/services/integrations.service.test.ts tests/integration/routes/integrations.routes.test.ts`
- `cd backend && npm run test -- tests/integration/routes/auth.routes.test.ts tests/unit/services/social-auth.service.test.ts tests/unit/providers/social-oauth-clients.test.ts tests/unit/services/discord-oauth.service.test.ts tests/integration/routes/integrations.routes.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd frontend && npm run test -- tests/unit/components/connection-center.test.tsx tests/unit/components/integrations-page-content.test.tsx tests/unit/components/steam-integration-card.test.tsx tests/unit/services/integrations.test.ts`
- `cd frontend && npm run test -- tests/unit/routes/auth-social-route.test.ts tests/unit/routes/auth-account-route.test.ts tests/unit/components/discord-integration-card.test.tsx tests/unit/components/connection-center.test.tsx`
- `cd frontend && npm run test:coverage`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Riscos e impactos
- Steam continua usando o formulário legado de SteamID público; esta PR não implementa Steam OpenID no navegador.
- MyAnimeList aparece no contrato como provider planejado/indisponível, mas não conecta usuário nem persiste identidade externa até existir OAuth2/PKCE real.
- O contrato atual da Steam não diferencia com confiança biblioteca realmente vazia, biblioteca privada e resposta sem jogos por regra de visibilidade; a UI comunica esse fallback sem tratar a conexão como falha fatal.
- Falha HTTP de importação inicial da biblioteca Steam depois da validação do SteamID64 não desfaz a conexão; a sincronização pode ser tentada novamente depois.
- `npm run test:coverage` do backend foi executado localmente em rodada anterior, mas não concluiu por ausência de PostgreSQL em `localhost:5432` nas suítes `prisma.seed` e `server.connectivity`; nesta rodada, a indisponibilidade local do Postgres foi confirmada e os testes focados da PR passaram.
- O lint backend mantém três warnings pré-existentes em `src/config/rate-limit.ts`, sem erro.

## Evidências
- Backend focado Steam/providers: 4 arquivos de teste, 74 testes passaram.
- Backend compatibilidade auth/social/Discord/integrations: 5 arquivos de teste, 104 testes passaram.
- Frontend focado Connection Center/integrações: 4 arquivos de teste, 29 testes passaram.
- Frontend compatibilidade auth/social/Discord/Connection Center: 4 arquivos de teste, 27 testes passaram.
- Frontend coverage completo: 70 arquivos de teste, 252 testes passaram, linhas globais em 82.28%.
- Backend typecheck, lint e build concluíram com sucesso.
- Frontend typecheck, lint e build concluíram com sucesso.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados