### PR TITLE
feat(integrations): valida ownership Steam via OpenID

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,13 @@ REDIS_URL="redis://redis:6379"
 # Obter em: https://steamcommunity.com/dev/apikey
 # Obrigatório para integração Steam
 STEAM_API_KEY=
+# URL pública registrada/retornada pelo Steam OpenID.
+# Se vazia em desenvolvimento, o backend usa fallback local.
+# Em produção, configure explicitamente para evitar callback inválido.
+# Exemplo local: http://localhost/api/auth/accounts/steam/link/callback
+STEAM_OPENID_RETURN_URL=
+# Opcional. Realm OpenID; se vazio, usa a origem da return URL.
+STEAM_OPENID_REALM=
 
 # ── Discord ──────────────────────────────────────────────────
 # Obter em: https://discord.com/developers/applications

--- a/backend/src/api/routes/auth.routes.ts
+++ b/backend/src/api/routes/auth.routes.ts
@@ -67,6 +67,31 @@ const socialCallbackSchema = z.object({
   },
 );
 
+const accountConnectionCallbackSchema = z.object({
+  code: z.string().min(1).optional(),
+  state: z.string().min(1).optional(),
+  error: z.string().min(1).optional(),
+}).passthrough().refine(
+  (input) => Boolean(input.error) ||
+    (Boolean(input.code) && Boolean(input.state)) ||
+    (Boolean(input.state) && typeof input['openid.mode'] === 'string'),
+  {
+    message: 'Callback de conexão inválido.',
+  },
+);
+
+function toStringQueryRecord(input: Record<string, unknown>): Record<string, string | undefined> {
+  const output: Record<string, string | undefined> = {};
+
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === 'string') {
+      output[key] = value;
+    }
+  }
+
+  return output;
+}
+
 function replyWithSocialAuthError(error: unknown): { statusCode: number; payload: { message: string } } {
   if (error instanceof SocialAuthError) {
     return {
@@ -282,7 +307,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   // ── GET /auth/social/:provider/callback ──────────────────
   app.get<{
     Params: { provider: string };
-    Querystring: { code?: string; state?: string; error?: string };
+    Querystring: Record<string, string | undefined>;
   }>(
     '/social/:provider/callback',
     {
@@ -407,18 +432,20 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
         return reply.status(400).send({ message: 'Provider de conta inválido.' });
       }
 
-      const queryResult = socialCallbackSchema.safeParse(request.query);
+      const queryResult = accountConnectionCallbackSchema.safeParse(request.query);
 
       if (!queryResult.success) {
         return reply.status(400).send({ message: 'Callback de conexão inválido.' });
       }
 
       try {
+        const queryValues = toStringQueryRecord(queryResult.data);
         const resultPayload = await app.accountConnectionService.completeLink({
           provider: paramsResult.data.provider,
-          code: queryResult.data.code,
-          state: queryResult.data.state,
-          providerError: queryResult.data.error,
+          code: queryValues['code'],
+          state: queryValues['state'],
+          providerError: queryValues['error'],
+          openIdParams: queryValues,
         });
 
         request.log.info({

--- a/backend/src/core/providers/provider-registry.ts
+++ b/backend/src/core/providers/provider-registry.ts
@@ -8,6 +8,7 @@ export type ProviderCapability =
   | 'SOCIAL_LOGIN'
   | 'CONNECTED_ACCOUNT'
   | 'OAUTH_CONNECT'
+  | 'OPENID_CONNECT'
   | 'TOKEN_CONNECT'
   | 'LIBRARY_IMPORT'
   | 'PRESENCE_INGESTION';
@@ -43,7 +44,7 @@ const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
     displayName: 'Steam',
     dataSource: 'OFFICIAL',
     status: 'CONNECTED',
-    capabilities: ['CONNECTED_ACCOUNT', 'LIBRARY_IMPORT'],
+    capabilities: ['CONNECTED_ACCOUNT', 'OPENID_CONNECT', 'LIBRARY_IMPORT'],
     visibleInConnectionCenter: true,
   },
   {

--- a/backend/src/core/services/account-connection.service.ts
+++ b/backend/src/core/services/account-connection.service.ts
@@ -29,6 +29,11 @@ import {
   discordSocialOAuthClient,
   googleSocialOAuthClient,
 } from '../../infra/integrations/social/social-oauth.clients';
+import {
+  steamOpenIdClient,
+  type SteamOpenIdCallbackParams,
+  type SteamOpenIdClient,
+} from '../../infra/integrations/steam/steam-openid.client';
 import { userRepository } from '../repositories/user.repository';
 import { IntegrationError } from '../../infra/integrations/integration.errors';
 
@@ -41,6 +46,7 @@ const ACCOUNT_CONNECTION_CALLBACK_PATHS: Record<AccountConnectionMode, string> =
 };
 
 export type AccountConnectionMode = 'link' | 'reauth';
+type BrowserAccountConnectionProvider = SocialAuthProvider | 'STEAM';
 
 export type PublicConnectedAccount = {
   provider: Platform;
@@ -69,12 +75,12 @@ export type PublicConnectedAccountProvider = {
 };
 
 export type AccountConnectionStartResult = {
-  provider: SocialAuthProvider;
+  provider: BrowserAccountConnectionProvider;
   authorizationUrl: string;
 };
 
 export type AccountConnectionCallbackResult = {
-  provider: SocialAuthProvider;
+  provider: BrowserAccountConnectionProvider;
   externalId: string;
   status: PlatformIntegrationStatus;
   connectionType: PlatformIntegrationConnectionType;
@@ -123,6 +129,7 @@ export type AccountConnectionService = {
     code?: string;
     state?: string;
     providerError?: string;
+    openIdParams?: SteamOpenIdCallbackParams;
   }): Promise<AccountConnectionCallbackResult>;
   unlink(input: { userId: string; provider: string }): Promise<{ message: string; provider: Platform }>;
   updateVisibility(input: {
@@ -145,6 +152,7 @@ type AccountConnectionUserGateway = {
 
 type AccountConnectionDependencies = {
   providerClients?: Partial<Record<SocialAuthProvider, SocialAuthProviderClient>>;
+  steamClient?: SteamOpenIdClient;
   users?: AccountConnectionUserGateway;
   repository?: Pick<
     ConnectedAccountRepository,
@@ -161,7 +169,7 @@ type AccountConnectionDependencies = {
 type AccountConnectionStatePayload = {
   purpose: 'account_connection';
   mode: AccountConnectionMode;
-  provider: SocialAuthProvider;
+  provider: BrowserAccountConnectionProvider;
   userId: string;
   expectedExternalId?: string;
   nonce: string;
@@ -209,6 +217,10 @@ function isSocialOAuthProvider(value: unknown): value is SocialAuthProvider {
   return value === 'GOOGLE' || value === 'DISCORD';
 }
 
+function isBrowserAccountConnectionProvider(value: unknown): value is BrowserAccountConnectionProvider {
+  return isSocialOAuthProvider(value) || value === 'STEAM';
+}
+
 function decodeStatePayload(value: string): AccountConnectionStatePayload {
   let parsedPayload: Partial<AccountConnectionStatePayload>;
 
@@ -225,7 +237,7 @@ function decodeStatePayload(value: string): AccountConnectionStatePayload {
   if (
     parsedPayload.purpose !== 'account_connection' ||
     (parsedPayload.mode !== 'link' && parsedPayload.mode !== 'reauth') ||
-    !isSocialOAuthProvider(parsedPayload.provider) ||
+    !isBrowserAccountConnectionProvider(parsedPayload.provider) ||
     typeof parsedPayload.userId !== 'string' ||
     parsedPayload.userId.length === 0 ||
     typeof parsedPayload.nonce !== 'string' ||
@@ -252,7 +264,7 @@ function decodeStatePayload(value: string): AccountConnectionStatePayload {
 }
 
 function createConnectionState(input: {
-  provider: SocialAuthProvider;
+  provider: BrowserAccountConnectionProvider;
   userId: string;
   mode: AccountConnectionMode;
   expectedExternalId?: string;
@@ -276,7 +288,7 @@ function createConnectionState(input: {
 
 function verifyStateValue(
   state: string,
-  provider: SocialAuthProvider,
+  provider: BrowserAccountConnectionProvider,
   mode: AccountConnectionMode,
 ): AccountConnectionStatePayload {
   const segments = state.split('.');
@@ -360,6 +372,97 @@ function normalizeOAuthProvider(provider: string): SocialAuthProvider {
   }
 
   return normalizedProvider;
+}
+
+function normalizeSteamOpenIdProvider(provider: string): 'STEAM' {
+  const normalizedProvider = normalizePlatform(provider);
+  const definition = getProviderDefinition(normalizedProvider);
+
+  if (
+    normalizedProvider !== 'STEAM' ||
+    definition.status === 'UNAVAILABLE' ||
+    !definition.capabilities.includes('OPENID_CONNECT')
+  ) {
+    throw createAccountConnectionError({
+      statusCode: 400,
+      reason: 'unsupported_provider',
+      clientMessage: 'Provider não suporta conexão OpenID neste momento.',
+      provider: normalizedProvider,
+    });
+  }
+
+  return 'STEAM';
+}
+
+function assertSafePublicUrl(value: string): URL {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(value);
+  } catch {
+    throw createAccountConnectionError({
+      statusCode: 503,
+      reason: 'provider_unavailable',
+      clientMessage: 'Conexão Steam indisponível no runtime atual.',
+      provider: 'STEAM',
+    });
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol) || parsedUrl.username || parsedUrl.password) {
+    throw createAccountConnectionError({
+      statusCode: 503,
+      reason: 'provider_unavailable',
+      clientMessage: 'Conexão Steam indisponível no runtime atual.',
+      provider: 'STEAM',
+    });
+  }
+
+  return parsedUrl;
+}
+
+function resolveSteamOpenIdBaseReturnUrl(): string {
+  const explicitReturnUrl = process.env['STEAM_OPENID_RETURN_URL']?.trim();
+
+  if (explicitReturnUrl) {
+    return assertSafePublicUrl(explicitReturnUrl).toString();
+  }
+
+  const publicAppUrl = process.env['PUBLIC_APP_URL']?.trim()
+    ?? process.env['APP_PUBLIC_URL']?.trim()
+    ?? process.env['FRONTEND_PUBLIC_URL']?.trim()
+    ?? process.env['NEXT_PUBLIC_APP_URL']?.trim();
+
+  if (publicAppUrl) {
+    return assertSafePublicUrl(new URL('/api/auth/accounts/steam/link/callback', publicAppUrl).toString()).toString();
+  }
+
+  if (process.env['NODE_ENV'] === 'production') {
+    throw createAccountConnectionError({
+      statusCode: 503,
+      reason: 'provider_unavailable',
+      clientMessage: 'Conexão Steam indisponível no runtime atual.',
+      provider: 'STEAM',
+    });
+  }
+
+  return 'http://localhost/api/auth/accounts/steam/link/callback';
+}
+
+function resolveSteamOpenIdReturnTo(state: string): string {
+  const returnUrl = assertSafePublicUrl(resolveSteamOpenIdBaseReturnUrl());
+  returnUrl.searchParams.set('state', state);
+
+  return returnUrl.toString();
+}
+
+function resolveSteamOpenIdRealm(returnTo: string): string {
+  const explicitRealm = process.env['STEAM_OPENID_REALM']?.trim();
+
+  if (explicitRealm) {
+    return assertSafePublicUrl(explicitRealm).origin;
+  }
+
+  return assertSafePublicUrl(returnTo).origin;
 }
 
 function getDefaultSocialRedirectUri(provider: SocialAuthProvider): string | undefined {
@@ -487,7 +590,7 @@ function canPublishAccount(account: ConnectedAccountRecord): boolean {
   return account.status === 'CONNECTED' && account.dataSource === 'OFFICIAL';
 }
 
-function mapProviderFailure(error: unknown, provider: SocialAuthProvider): never {
+function mapProviderFailure(error: unknown, provider: BrowserAccountConnectionProvider): never {
   if (error instanceof AccountConnectionError) {
     throw error;
   }
@@ -532,6 +635,7 @@ export function createAccountConnectionService(
     GOOGLE: dependencies.providerClients?.GOOGLE ?? googleSocialOAuthClient,
     DISCORD: dependencies.providerClients?.DISCORD ?? discordSocialOAuthClient,
   };
+  const steamClient = dependencies.steamClient ?? steamOpenIdClient;
 
   async function exchangeIdentity(
     provider: SocialAuthProvider,
@@ -623,6 +727,30 @@ export function createAccountConnectionService(
     };
   }
 
+  async function startSteamOpenIdFlow(input: {
+    userId: string;
+    provider: string;
+  }): Promise<AccountConnectionStartResult> {
+    const provider = normalizeSteamOpenIdProvider(input.provider);
+    const { state } = createConnectionState({
+      userId: input.userId,
+      provider,
+      mode: 'link',
+    });
+    const returnTo = resolveSteamOpenIdReturnTo(state);
+    const authorizationUrl = steamClient.createAuthorizationUrl({
+      returnTo,
+      realm: resolveSteamOpenIdRealm(returnTo),
+    });
+
+    await stateStore.store(state, ACCOUNT_CONNECTION_STATE_TTL_MS);
+
+    return {
+      provider,
+      authorizationUrl,
+    };
+  }
+
   async function completeOAuthCallback(input: {
     provider: string;
     code?: string;
@@ -672,6 +800,59 @@ export function createAccountConnectionService(
     };
   }
 
+  async function completeSteamOpenIdCallback(input: {
+    provider: string;
+    state?: string;
+    providerError?: string;
+    openIdParams?: SteamOpenIdCallbackParams;
+  }): Promise<{ provider: 'STEAM'; externalId: string; statePayload: AccountConnectionStatePayload }> {
+    const provider = normalizeSteamOpenIdProvider(input.provider);
+
+    if (input.providerError) {
+      throw createAccountConnectionError({
+        statusCode: 400,
+        reason: 'invalid_request',
+        clientMessage: 'Conexão Steam cancelada ou negada.',
+        provider,
+      });
+    }
+
+    if (!input.state) {
+      throw createAccountConnectionError({
+        statusCode: 400,
+        reason: 'invalid_request',
+        clientMessage: 'Callback Steam inválido.',
+        provider,
+      });
+    }
+
+    const statePayload = verifyStateValue(input.state, provider, 'link');
+
+    if (!await stateStore.consume(input.state)) {
+      throw createAccountConnectionError({
+        statusCode: 400,
+        reason: 'invalid_state',
+        clientMessage: 'Callback Steam inválido ou expirado.',
+        provider,
+      });
+    }
+
+    try {
+      const verification = await steamClient.verifyCallback(
+        input.openIdParams ?? {},
+        { expectedReturnTo: resolveSteamOpenIdReturnTo(input.state) },
+      );
+
+      return {
+        provider,
+        externalId: verification.steamId,
+        statePayload,
+      };
+    } catch (error) {
+      mapProviderFailure(error, provider);
+    }
+  }
+
   return {
     async listConnectedAccounts(userId): Promise<{
       accounts: PublicConnectedAccount[];
@@ -691,6 +872,10 @@ export function createAccountConnectionService(
     },
 
     async startLink(input): Promise<AccountConnectionStartResult> {
+      if (normalizePlatform(input.provider) === 'STEAM') {
+        return startSteamOpenIdFlow(input);
+      }
+
       return startOAuthFlow({
         userId: input.userId,
         provider: input.provider,
@@ -699,6 +884,66 @@ export function createAccountConnectionService(
     },
 
     async completeLink(input): Promise<AccountConnectionCallbackResult> {
+      if (normalizePlatform(input.provider) === 'STEAM') {
+        const { provider, externalId, statePayload } = await completeSteamOpenIdCallback(input);
+        const existingIdentity = await repository.findByProviderExternalId(provider, externalId);
+
+        if (existingIdentity && existingIdentity.userId !== statePayload.userId) {
+          throw createAccountConnectionError({
+            statusCode: 409,
+            reason: 'identity_conflict',
+            clientMessage: 'Esta identidade externa já está vinculada a outro usuário.',
+            provider,
+          });
+        }
+
+        const existingUserProvider = await repository.findByUserProvider(statePayload.userId, provider);
+
+        if (existingUserProvider && existingUserProvider.externalId !== externalId) {
+          throw createAccountConnectionError({
+            statusCode: 409,
+            reason: 'identity_conflict',
+            clientMessage: 'Este usuário já possui outra identidade Steam vinculada.',
+            provider,
+          });
+        }
+
+        try {
+          await connectedAccountService.connectExternalIdentity({
+            userId: statePayload.userId,
+            provider,
+            externalId,
+            connectionType: 'CONNECTED_ACCOUNT',
+            status: 'CONNECTED',
+            dataSource: getProviderDefinition(provider).dataSource,
+            metadata: {
+              source: 'steam_openid',
+              ownershipProof: 'openid',
+              ownershipVerifiedAt: new Date().toISOString(),
+            },
+          });
+        } catch (error) {
+          if (error instanceof ConnectedAccountConflictError) {
+            throw createAccountConnectionError({
+              statusCode: 409,
+              reason: 'identity_conflict',
+              clientMessage: 'Esta identidade externa já está vinculada a outro usuário.',
+              provider,
+            });
+          }
+
+          throw error;
+        }
+
+        return {
+          provider,
+          externalId,
+          status: 'CONNECTED',
+          connectionType: 'CONNECTED_ACCOUNT',
+          message: 'Steam verificada e conectada com sucesso.',
+        };
+      }
+
       const { provider, identity, statePayload } = await completeOAuthCallback({
         ...input,
         mode: 'link',

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -22,6 +22,7 @@ type PlatformIntegrationPlatform = 'STEAM' | 'EPIC';
 
 type PersistedIntegration = {
   externalId: string;
+  dataSource: PlatformIntegrationDataSource;
   accessToken?: string | null;
 };
 
@@ -102,6 +103,7 @@ export function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
 
       return {
         externalId: integration.externalId,
+        dataSource: integration.dataSource,
         accessToken: integration.accessToken,
       };
     },
@@ -213,7 +215,22 @@ export function createIntegrationsService(dependencies?: {
         );
       }
 
-      await persistence.upsertPlatformIntegration(userId, 'STEAM', { externalId: normalizedSteamId });
+      const existingSteamIntegration = await persistence.findPlatformIntegration(userId, 'STEAM');
+      const hasOfficialOwnershipProof = existingSteamIntegration?.dataSource === 'OFFICIAL';
+
+      if (hasOfficialOwnershipProof && existingSteamIntegration.externalId !== normalizedSteamId) {
+        throw createIntegrationError(
+          'steam',
+          409,
+          'conflict',
+          'A conta Steam verificada já usa outro SteamID. Use o fluxo verificado pela Steam para trocar a conta.',
+        );
+      }
+
+      await persistence.upsertPlatformIntegration(userId, 'STEAM', {
+        externalId: normalizedSteamId,
+        dataSource: hasOfficialOwnershipProof ? 'OFFICIAL' : 'MANUAL',
+      });
 
       let games: SteamGame[] = [];
       let libraryImportSkipped = false;

--- a/backend/src/infra/integrations/steam/steam-openid.client.ts
+++ b/backend/src/infra/integrations/steam/steam-openid.client.ts
@@ -1,0 +1,254 @@
+import axios from 'axios';
+import {
+  createIntegrationError,
+  IntegrationError,
+  translateUpstreamError,
+} from '../integration.errors';
+
+const STEAM_OPENID_ENDPOINT = 'https://steamcommunity.com/openid/login';
+const STEAM_OPENID_NS = 'http://specs.openid.net/auth/2.0';
+const STEAM_OPENID_IDENTIFIER_SELECT = 'http://specs.openid.net/auth/2.0/identifier_select';
+const STEAM_OPENID_TIMEOUT_MS = 10_000;
+const STEAM_OPENID_CLAIMED_ID_PATTERN = /^\/openid\/id\/(\d{17,20})$/u;
+
+export type SteamOpenIdCallbackParams = Record<string, string | undefined>;
+
+export type SteamOpenIdVerificationResult = {
+  steamId: string;
+};
+
+export type SteamOpenIdClient = {
+  createAuthorizationUrl: typeof createSteamOpenIdAuthorizationUrl;
+  verifyCallback: typeof verifySteamOpenIdCallback;
+};
+
+function getRequiredParam(
+  params: SteamOpenIdCallbackParams,
+  key: string,
+): string {
+  const value = params[key]?.trim();
+
+  if (!value) {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Callback Steam inválido.',
+    );
+  }
+
+  return value;
+}
+
+function assertSteamOpenIdEndpoint(value: string): void {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(value);
+  } catch {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Callback Steam inválido.',
+    );
+  }
+
+  if (
+    parsedUrl.protocol !== 'https:' ||
+    parsedUrl.hostname !== 'steamcommunity.com' ||
+    parsedUrl.pathname !== '/openid/login' ||
+    parsedUrl.username ||
+    parsedUrl.password
+  ) {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Callback Steam inválido.',
+    );
+  }
+}
+
+export function extractSteamIdFromClaimedId(claimedId: string): string {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(claimedId);
+  } catch {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Identidade Steam inválida.',
+    );
+  }
+
+  const match = STEAM_OPENID_CLAIMED_ID_PATTERN.exec(parsedUrl.pathname);
+
+  if (
+    !match?.[1] ||
+    !['http:', 'https:'].includes(parsedUrl.protocol) ||
+    parsedUrl.hostname !== 'steamcommunity.com' ||
+    parsedUrl.username ||
+    parsedUrl.password
+  ) {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Identidade Steam inválida.',
+    );
+  }
+
+  return match[1];
+}
+
+function assertExpectedReturnTo(receivedReturnTo: string, expectedReturnTo: string): void {
+  if (receivedReturnTo !== expectedReturnTo) {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Callback Steam inválido.',
+    );
+  }
+}
+
+function buildVerificationBody(params: SteamOpenIdCallbackParams): string {
+  const body = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (!key.startsWith('openid.') || typeof value !== 'string') {
+      continue;
+    }
+
+    body.set(key, value);
+  }
+
+  body.set('openid.mode', 'check_authentication');
+
+  return body.toString();
+}
+
+function isValidSteamOpenIdVerificationResponse(payload: unknown): boolean {
+  if (typeof payload !== 'string') {
+    return false;
+  }
+
+  return payload
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .includes('is_valid:true');
+}
+
+function validateCallbackShape(
+  params: SteamOpenIdCallbackParams,
+  expectedReturnTo: string,
+): string {
+  const mode = getRequiredParam(params, 'openid.mode');
+
+  if (mode === 'cancel') {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Conexão Steam cancelada.',
+    );
+  }
+
+  if (mode !== 'id_res') {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Callback Steam inválido.',
+    );
+  }
+
+  const namespace = getRequiredParam(params, 'openid.ns');
+  const endpoint = getRequiredParam(params, 'openid.op_endpoint');
+  const claimedId = getRequiredParam(params, 'openid.claimed_id');
+  const identity = getRequiredParam(params, 'openid.identity');
+  const returnTo = getRequiredParam(params, 'openid.return_to');
+  getRequiredParam(params, 'openid.signed');
+  getRequiredParam(params, 'openid.sig');
+
+  if (namespace !== STEAM_OPENID_NS || claimedId !== identity) {
+    throw createIntegrationError(
+      'steam',
+      400,
+      'invalid_request',
+      'Callback Steam inválido.',
+    );
+  }
+
+  assertSteamOpenIdEndpoint(endpoint);
+  assertExpectedReturnTo(returnTo, expectedReturnTo);
+
+  return extractSteamIdFromClaimedId(claimedId);
+}
+
+function createSteamOpenIdAuthorizationUrl(input: {
+  returnTo: string;
+  realm: string;
+}): string {
+  const authorizationUrl = new URL(STEAM_OPENID_ENDPOINT);
+
+  authorizationUrl.searchParams.set('openid.ns', STEAM_OPENID_NS);
+  authorizationUrl.searchParams.set('openid.mode', 'checkid_setup');
+  authorizationUrl.searchParams.set('openid.return_to', input.returnTo);
+  authorizationUrl.searchParams.set('openid.realm', input.realm);
+  authorizationUrl.searchParams.set('openid.identity', STEAM_OPENID_IDENTIFIER_SELECT);
+  authorizationUrl.searchParams.set('openid.claimed_id', STEAM_OPENID_IDENTIFIER_SELECT);
+
+  return authorizationUrl.toString();
+}
+
+async function verifySteamOpenIdCallback(
+  params: SteamOpenIdCallbackParams,
+  options: { expectedReturnTo: string },
+): Promise<SteamOpenIdVerificationResult> {
+  const steamId = validateCallbackShape(params, options.expectedReturnTo);
+
+  try {
+    const response = await axios.post<string>(
+      STEAM_OPENID_ENDPOINT,
+      buildVerificationBody(params),
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        timeout: STEAM_OPENID_TIMEOUT_MS,
+        responseType: 'text',
+      },
+    );
+
+    if (!isValidSteamOpenIdVerificationResponse(response.data)) {
+      throw createIntegrationError(
+        'steam',
+        400,
+        'invalid_request',
+        'Callback Steam inválido.',
+      );
+    }
+
+    return { steamId };
+  } catch (error) {
+    if (error instanceof IntegrationError) {
+      throw error;
+    }
+
+    throw translateUpstreamError(
+      'steam',
+      error,
+      'Steam OpenID indisponível no momento.',
+      { targetUrl: STEAM_OPENID_ENDPOINT },
+    );
+  }
+}
+
+export const steamOpenIdClient: SteamOpenIdClient = {
+  createAuthorizationUrl: createSteamOpenIdAuthorizationUrl,
+  verifyCallback: verifySteamOpenIdCallback,
+};

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -1077,7 +1077,7 @@ describe('Auth Routes', () => {
         name: 'AccountConnectionError',
         statusCode: 400,
         reason: 'unsupported_provider',
-        clientMessage: 'Provider não suporta conexão OAuth neste momento.',
+        clientMessage: 'Provider nao suporta conexao OpenID neste momento.',
       });
       const app = await buildApp({ accountConnectionService });
       const token = generateTestToken(app);
@@ -1090,7 +1090,7 @@ describe('Auth Routes', () => {
 
       expect(response.statusCode).toBe(400);
       expect(response.json()).toMatchObject({
-        message: 'Provider não suporta conexão OAuth neste momento.',
+        message: 'Provider nao suporta conexao OpenID neste momento.',
       });
       await app.close();
     });
@@ -1118,6 +1118,48 @@ describe('Auth Routes', () => {
         code: 'oauth-code',
         state: 'signed-state',
         providerError: undefined,
+        openIdParams: expect.objectContaining({
+          code: 'oauth-code',
+          state: 'signed-state',
+        }),
+      });
+      await app.close();
+    });
+
+    it('conclui callback Steam OpenID repassando parametros sem emitir sessao nova', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.completeLink.mockResolvedValueOnce({
+        provider: 'STEAM',
+        externalId: '76561198000000000',
+        status: 'CONNECTED',
+        connectionType: 'CONNECTED_ACCOUNT',
+        message: 'Steam verificada e conectada com sucesso.',
+      });
+      const app = await buildApp({ accountConnectionService });
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/steam/link/callback?state=signed-state&openid.mode=id_res&openid.claimed_id=https%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F76561198000000000',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'STEAM',
+        externalId: '76561198000000000',
+        status: 'CONNECTED',
+        connectionType: 'CONNECTED_ACCOUNT',
+      });
+      expect(response.json()).not.toHaveProperty('token');
+      expect(response.headers['set-cookie']).toBeUndefined();
+      expect(accountConnectionService.completeLink).toHaveBeenCalledWith({
+        provider: 'steam',
+        code: undefined,
+        state: 'signed-state',
+        providerError: undefined,
+        openIdParams: expect.objectContaining({
+          'openid.mode': 'id_res',
+          'openid.claimed_id': 'https://steamcommunity.com/openid/id/76561198000000000',
+        }),
       });
       await app.close();
     });
@@ -1212,6 +1254,33 @@ describe('Auth Routes', () => {
         userId: 'user-id-1',
         provider: 'google',
         publicProfileVisible: true,
+      });
+      await app.close();
+    });
+
+    it('inicia linking Steam OpenID autenticado', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.startLink.mockResolvedValueOnce({
+        provider: 'STEAM',
+        authorizationUrl: 'https://steamcommunity.com/openid/login?openid.mode=checkid_setup',
+      });
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/steam/link/start',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'STEAM',
+        authorizationUrl: expect.stringContaining('steamcommunity.com/openid/login'),
+      });
+      expect(accountConnectionService.startLink).toHaveBeenCalledWith({
+        userId: 'user-id-1',
+        provider: 'steam',
       });
       await app.close();
     });

--- a/backend/tests/unit/providers/provider-registry.test.ts
+++ b/backend/tests/unit/providers/provider-registry.test.ts
@@ -24,7 +24,9 @@ describe('provider registry', () => {
     const google = providers.find((provider) => provider.provider === 'GOOGLE');
 
     expect(steam?.capabilities).toContain('CONNECTED_ACCOUNT');
+    expect(steam?.capabilities).toContain('OPENID_CONNECT');
     expect(steam?.capabilities).not.toContain('SOCIAL_LOGIN');
+    expect(steam?.capabilities).not.toContain('OAUTH_CONNECT');
     expect(google?.status).toBe('CONNECTED');
     expect(google?.capabilities).toEqual(
       expect.arrayContaining(['SOCIAL_LOGIN', 'OAUTH_CONNECT']),

--- a/backend/tests/unit/providers/steam-openid.client.test.ts
+++ b/backend/tests/unit/providers/steam-openid.client.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios');
+
+import axios from 'axios';
+import {
+  extractSteamIdFromClaimedId,
+  steamOpenIdClient,
+  type SteamOpenIdCallbackParams,
+} from '@/infra/integrations/steam/steam-openid.client';
+
+const expectedReturnTo = 'http://localhost/api/auth/accounts/steam/link/callback?state=signed-state';
+
+function createValidCallback(overrides: SteamOpenIdCallbackParams = {}): SteamOpenIdCallbackParams {
+  return {
+    'openid.ns': 'http://specs.openid.net/auth/2.0',
+    'openid.mode': 'id_res',
+    'openid.op_endpoint': 'https://steamcommunity.com/openid/login',
+    'openid.claimed_id': 'https://steamcommunity.com/openid/id/76561198000000000',
+    'openid.identity': 'https://steamcommunity.com/openid/id/76561198000000000',
+    'openid.return_to': expectedReturnTo,
+    'openid.response_nonce': '2026-04-30T00:00:00Znonce',
+    'openid.assoc_handle': 'assoc-handle',
+    'openid.signed': 'signed,op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle',
+    'openid.sig': 'signature',
+    ...overrides,
+  };
+}
+
+describe('steamOpenIdClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('cria authorization URL OpenID para a Steam', () => {
+    const authorizationUrl = new URL(steamOpenIdClient.createAuthorizationUrl({
+      returnTo: expectedReturnTo,
+      realm: 'http://localhost',
+    }));
+
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe('https://steamcommunity.com/openid/login');
+    expect(authorizationUrl.searchParams.get('openid.ns')).toBe('http://specs.openid.net/auth/2.0');
+    expect(authorizationUrl.searchParams.get('openid.mode')).toBe('checkid_setup');
+    expect(authorizationUrl.searchParams.get('openid.return_to')).toBe(expectedReturnTo);
+    expect(authorizationUrl.searchParams.get('openid.realm')).toBe('http://localhost');
+    expect(authorizationUrl.searchParams.get('openid.identity')).toBe('http://specs.openid.net/auth/2.0/identifier_select');
+    expect(authorizationUrl.searchParams.get('openid.claimed_id')).toBe('http://specs.openid.net/auth/2.0/identifier_select');
+  });
+
+  it('extrai SteamID64 de claimed id oficial', () => {
+    expect(extractSteamIdFromClaimedId('http://steamcommunity.com/openid/id/76561198000000000'))
+      .toBe('76561198000000000');
+    expect(extractSteamIdFromClaimedId('https://steamcommunity.com/openid/id/76561198000000000'))
+      .toBe('76561198000000000');
+  });
+
+  it('rejeita claimed id de dominio invalido', () => {
+    expect(() => extractSteamIdFromClaimedId('https://steamcommunity.example/openid/id/76561198000000000'))
+      .toThrowError('Identidade Steam inválida.');
+  });
+
+  it('valida callback com a Steam antes de aceitar SteamID64', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: 'ns:http://specs.openid.net/auth/2.0\nis_valid:true\n',
+    } as never);
+
+    const result = await steamOpenIdClient.verifyCallback(
+      createValidCallback(),
+      { expectedReturnTo },
+    );
+
+    expect(result).toEqual({ steamId: '76561198000000000' });
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://steamcommunity.com/openid/login',
+      expect.stringContaining('openid.mode=check_authentication'),
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      }),
+    );
+  });
+
+  it('rejeita callback quando a Steam nao confirma assinatura', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: 'is_valid:false\n',
+    } as never);
+
+    await expect(steamOpenIdClient.verifyCallback(
+      createValidCallback(),
+      { expectedReturnTo },
+    )).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+    });
+  });
+
+  it('rejeita return_to divergente', async () => {
+    await expect(steamOpenIdClient.verifyCallback(
+      createValidCallback({
+        'openid.return_to': 'https://evil.example/callback?state=signed-state',
+      }),
+      { expectedReturnTo },
+    )).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+    });
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unit/services/account-connection.service.test.ts
+++ b/backend/tests/unit/services/account-connection.service.test.ts
@@ -68,6 +68,10 @@ function createDependencies() {
       GOOGLE: createProviderClient('GOOGLE'),
       DISCORD: createProviderClient('DISCORD'),
     },
+    steamClient: {
+      createAuthorizationUrl: vi.fn().mockReturnValue('https://steamcommunity.com/openid/login?openid.mode=checkid_setup'),
+      verifyCallback: vi.fn().mockResolvedValue({ steamId: '76561198000000000' }),
+    },
     users: {
       findById: vi.fn().mockResolvedValue(baseUser),
     },
@@ -109,6 +113,29 @@ async function issueState(
   }
 
   return lastCall[0].state;
+}
+
+async function issueSteamState(
+  service: ReturnType<typeof createAccountConnectionService>,
+  dependencies: ReturnType<typeof createDependencies>,
+): Promise<string> {
+  await service.startLink({ userId: 'user-id-1', provider: 'steam' });
+
+  const createAuthorizationUrl = vi.mocked(dependencies.steamClient.createAuthorizationUrl);
+  const lastCall = createAuthorizationUrl.mock.calls.at(-1);
+
+  if (!lastCall) {
+    throw new Error('Expected Steam account connection state to be issued.');
+  }
+
+  const returnTo = new URL(lastCall[0].returnTo);
+  const state = returnTo.searchParams.get('state');
+
+  if (!state) {
+    throw new Error('Expected Steam returnTo to include state.');
+  }
+
+  return state;
 }
 
 describe('account connection service', () => {
@@ -252,16 +279,31 @@ describe('account connection service', () => {
     }
   });
 
-  it('rejeita linking para provider sem capability OAuth connect', async () => {
-    const service = createAccountConnectionService(createDependencies());
+  it('inicia linking Steam por OpenID sem tratar como login social', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
 
-    await expect(service.startLink({
+    const result = await service.startLink({
       userId: 'user-id-1',
       provider: 'steam',
-    })).rejects.toMatchObject({
-      statusCode: 400,
-      reason: 'unsupported_provider',
     });
+
+    expect(result).toMatchObject({
+      provider: 'STEAM',
+      authorizationUrl: 'https://steamcommunity.com/openid/login?openid.mode=checkid_setup',
+    });
+    expect(dependencies.steamClient.createAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        returnTo: expect.stringContaining('/api/auth/accounts/steam/link/callback?state='),
+        realm: 'http://localhost',
+      }),
+    );
+    expect(dependencies.providerClients.GOOGLE.createAuthorizationUrl).not.toHaveBeenCalled();
+    expect(dependencies.providerClients.DISCORD.createAuthorizationUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejeita linking para provider sem capability de browser connect', async () => {
+    const service = createAccountConnectionService(createDependencies());
 
     await expect(service.startLink({
       userId: 'user-id-1',
@@ -301,6 +343,47 @@ describe('account connection service', () => {
     );
   });
 
+  it('conecta Steam via OpenID como conta conectada oficial', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueSteamState(service, dependencies);
+
+    const result = await service.completeLink({
+      provider: 'steam',
+      state,
+      openIdParams: {
+        'openid.mode': 'id_res',
+      },
+    });
+
+    expect(result).toMatchObject({
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      status: 'CONNECTED',
+      connectionType: 'CONNECTED_ACCOUNT',
+      message: 'Steam verificada e conectada com sucesso.',
+    });
+    expect(dependencies.steamClient.verifyCallback).toHaveBeenCalledWith(
+      { 'openid.mode': 'id_res' },
+      { expectedReturnTo: expect.stringContaining(`/api/auth/accounts/steam/link/callback?state=${encodeURIComponent(state)}`) },
+    );
+    expect(dependencies.connectedAccountService.connectExternalIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-id-1',
+        provider: 'STEAM',
+        externalId: '76561198000000000',
+        connectionType: 'CONNECTED_ACCOUNT',
+        status: 'CONNECTED',
+        dataSource: 'OFFICIAL',
+        metadata: expect.objectContaining({
+          source: 'steam_openid',
+          ownershipProof: 'openid',
+          ownershipVerifiedAt: expect.any(String),
+        }),
+      }),
+    );
+  });
+
   it('bloqueia linking quando identidade externa pertence a outro usuario', async () => {
     const dependencies = createDependencies();
     const service = createAccountConnectionService(dependencies);
@@ -318,6 +401,82 @@ describe('account connection service', () => {
     })).rejects.toMatchObject({
       statusCode: 409,
       reason: 'identity_conflict',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('bloqueia Steam OpenID quando SteamID64 pertence a outro usuario', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueSteamState(service, dependencies);
+    dependencies.repository.findByProviderExternalId.mockResolvedValueOnce(createAccount({
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      userId: 'other-user-id',
+    }));
+
+    await expect(service.completeLink({
+      provider: 'steam',
+      state,
+      openIdParams: { 'openid.mode': 'id_res' },
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('atualiza Steam existente do mesmo usuario sem duplicar ownership', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueSteamState(service, dependencies);
+    dependencies.repository.findByProviderExternalId.mockResolvedValueOnce(createAccount({
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      userId: 'user-id-1',
+    }));
+    dependencies.repository.findByUserProvider.mockResolvedValueOnce(createAccount({
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+      userId: 'user-id-1',
+      connectionType: 'CONNECTED_ACCOUNT',
+    }));
+
+    await expect(service.completeLink({
+      provider: 'steam',
+      state,
+      openIdParams: { 'openid.mode': 'id_res' },
+    })).resolves.toMatchObject({
+      provider: 'STEAM',
+      externalId: '76561198000000000',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'STEAM',
+        externalId: '76561198000000000',
+      }),
+    );
+  });
+
+  it('bloqueia Steam OpenID quando usuario ja possui SteamID64 diferente', async () => {
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueSteamState(service, dependencies);
+    dependencies.repository.findByUserProvider.mockResolvedValueOnce(createAccount({
+      provider: 'STEAM',
+      externalId: '76561198099999999',
+      userId: 'user-id-1',
+      connectionType: 'CONNECTED_ACCOUNT',
+    }));
+
+    await expect(service.completeLink({
+      provider: 'steam',
+      state,
+      openIdParams: { 'openid.mode': 'id_res' },
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+      clientMessage: 'Este usuário já possui outra identidade Steam vinculada.',
     });
     expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
   });

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -96,7 +96,7 @@ describe('integrations service layer', () => {
     expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
       'user-id-1',
       'STEAM',
-      { externalId: '76561198000000000' },
+      { externalId: '76561198000000000', dataSource: 'MANUAL' },
     );
     expect(persistence.upsertSteamLibraryGame).toHaveBeenNthCalledWith(
       1,
@@ -154,7 +154,7 @@ describe('integrations service layer', () => {
     expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
       'user-id-1',
       'STEAM',
-      { externalId: '76561198000000000' },
+      { externalId: '76561198000000000', dataSource: 'MANUAL' },
     );
     expect(persistence.upsertSteamLibraryGame).not.toHaveBeenCalled();
     expect(stdoutWriteSpy).toHaveBeenCalledWith(
@@ -162,6 +162,80 @@ describe('integrations service layer', () => {
     );
 
     stdoutWriteSpy.mockRestore();
+  });
+
+  it('preserva ownership oficial quando fallback manual usa o mesmo SteamID verificado', async () => {
+    const persistence = {
+      upsertPlatformIntegration: vi.fn().mockResolvedValue(undefined),
+      findPlatformIntegration: vi.fn().mockResolvedValue({
+        externalId: '76561198000000000',
+        dataSource: 'OFFICIAL',
+        accessToken: null,
+      }),
+      upsertSteamLibraryGame: vi.fn().mockResolvedValue(undefined),
+      upsertEpicLibraryGame: vi.fn(),
+    };
+
+    const service = createIntegrationsService({
+      steamClient: {
+        validateSteamId: vi.fn().mockResolvedValue(true),
+        getOwnedGames: vi.fn().mockResolvedValue([]),
+      },
+      igdbClient: {
+        searchGames: vi.fn(),
+        searchGame: vi.fn(),
+      },
+      epicClient: {
+        validateToken: vi.fn(),
+        getLibrary: vi.fn(),
+      },
+      persistence,
+    });
+
+    await service.connectSteam('user-id-1', '76561198000000000');
+
+    expect(persistence.upsertPlatformIntegration).toHaveBeenCalledWith(
+      'user-id-1',
+      'STEAM',
+      { externalId: '76561198000000000', dataSource: 'OFFICIAL' },
+    );
+  });
+
+  it('bloqueia fallback manual que trocaria uma Steam oficial verificada', async () => {
+    const persistence = {
+      upsertPlatformIntegration: vi.fn(),
+      findPlatformIntegration: vi.fn().mockResolvedValue({
+        externalId: '76561198000000000',
+        dataSource: 'OFFICIAL',
+        accessToken: null,
+      }),
+      upsertSteamLibraryGame: vi.fn(),
+      upsertEpicLibraryGame: vi.fn(),
+    };
+
+    const service = createIntegrationsService({
+      steamClient: {
+        validateSteamId: vi.fn().mockResolvedValue(true),
+        getOwnedGames: vi.fn(),
+      },
+      igdbClient: {
+        searchGames: vi.fn(),
+        searchGame: vi.fn(),
+      },
+      epicClient: {
+        validateToken: vi.fn(),
+        getLibrary: vi.fn(),
+      },
+      persistence,
+    });
+
+    await expect(
+      service.connectSteam('user-id-1', '76561198000000001'),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'conflict',
+    });
+    expect(persistence.upsertPlatformIntegration).not.toHaveBeenCalled();
   });
 
   it('traduz Steam nao conectado na sincronizacao', async () => {
@@ -197,6 +271,7 @@ describe('integrations service layer', () => {
       upsertPlatformIntegration: vi.fn(),
       findPlatformIntegration: vi.fn().mockResolvedValue({
         externalId: '76561198000000000',
+        dataSource: 'MANUAL',
       }),
       upsertSteamLibraryGame: vi.fn().mockResolvedValue(undefined),
       upsertEpicLibraryGame: vi.fn(),
@@ -471,7 +546,7 @@ describe('createPrismaIntegrationsPersistence', () => {
     expect(prisma.platformIntegration.upsert).not.toHaveBeenCalled();
   });
 
-  it('persiste Steam via connected account foundation com dataSource oficial', async () => {
+  it('persiste Steam manual via connected account foundation com dataSource manual', async () => {
     vi.mocked(prisma.platformIntegration.findUnique).mockResolvedValueOnce(null);
     vi.mocked(prisma.platformIntegration.upsert).mockResolvedValue({
       id: 'integration-id-1',
@@ -480,7 +555,7 @@ describe('createPrismaIntegrationsPersistence', () => {
       externalId: '76561198000000000',
       connectionType: 'CONNECTED_ACCOUNT',
       status: 'CONNECTED',
-      dataSource: 'OFFICIAL',
+      dataSource: 'MANUAL',
       metadata: null,
       publicProfileVisible: false,
       createdAt: new Date('2026-04-29T00:00:00.000Z'),
@@ -492,7 +567,7 @@ describe('createPrismaIntegrationsPersistence', () => {
     await persistence.upsertPlatformIntegration(
       'user-id-1',
       'STEAM',
-      { externalId: '76561198000000000' },
+      { externalId: '76561198000000000', dataSource: 'MANUAL' },
     );
 
     expect(prisma.platformIntegration.upsert).toHaveBeenCalledWith(
@@ -503,7 +578,7 @@ describe('createPrismaIntegrationsPersistence', () => {
           externalId: '76561198000000000',
           connectionType: 'CONNECTED_ACCOUNT',
           status: 'CONNECTED',
-          dataSource: 'OFFICIAL',
+          dataSource: 'MANUAL',
         }),
       }),
     );

--- a/docs/steam-myanimelist-connection-scope.md
+++ b/docs/steam-myanimelist-connection-scope.md
@@ -4,7 +4,8 @@
 
 - Steam Web Sign-In usa OpenID 2.0, nao OAuth2 comum.
 - A identidade forte para ownership externo e o SteamID64 retornado pela Claimed ID no formato `https://steamcommunity.com/openid/id/<steamid>`.
-- O CLUTCH ainda usa o fluxo legado de formulario com SteamID informado pelo usuario, mas persiste esse SteamID64 como `PlatformIntegration.externalId` via `ConnectedAccountService`.
+- O fluxo principal de conexao Steam deve usar Steam OpenID via navegador para provar ownership antes de persistir `PlatformIntegration.externalId` via `ConnectedAccountService`.
+- O formulario manual com SteamID permanece apenas como fallback de importacao/dados publicos e persiste `dataSource=MANUAL`; ele nao prova ownership da conta Steam.
 - A importacao de biblioteca usa `IPlayerService/GetOwnedGames` com `STEAM_API_KEY`, `include_appinfo=true` e `include_played_free_games=true`.
 - Quando a Steam nao retorna jogos por biblioteca privada ou detalhes nao visiveis, o CLUTCH trata como lista vazia e mantem a conexao, sem expor API key ou payload bruto ao frontend.
 - O contrato atual nao diferencia com confianca biblioteca realmente vazia, biblioteca privada e resposta sem jogos por regra de visibilidade da Steam. A UI deve comunicar esse fallback sem transformar a ausencia de jogos em erro fatal.

--- a/frontend/src/components/settings/connection-center.tsx
+++ b/frontend/src/components/settings/connection-center.tsx
@@ -42,7 +42,7 @@ const PROVIDER_COPY: Partial<Record<ConnectedAccountProvider, {
     connectionTypeLabel: 'Login social ou conta conectada',
   },
   STEAM: {
-    description: 'Biblioteca de jogos e sincronizacao pela SteamID publica.',
+    description: 'Verificacao de ownership via Steam e importacao de biblioteca quando os dados estiverem visiveis.',
     connectionTypeLabel: 'Conta conectada',
   },
   EPIC: {
@@ -189,9 +189,12 @@ function ConnectionProviderRow({
 }: ConnectionProviderRowProps) {
   const isBusy = busyProvider === definition.provider;
   const canOAuthConnect = definition.capabilities.includes('OAUTH_CONNECT') && definition.status === 'CONNECTED';
+  const canOpenIdConnect = definition.capabilities.includes('OPENID_CONNECT') && definition.status === 'CONNECTED';
+  const canBrowserConnect = canOAuthConnect || canOpenIdConnect;
   const canLegacyConnect = definition.capabilities.includes('TOKEN_CONNECT') ||
-    (definition.capabilities.includes('LIBRARY_IMPORT') && !definition.capabilities.includes('OAUTH_CONNECT'));
+    (definition.capabilities.includes('LIBRARY_IMPORT') && !canBrowserConnect);
   const canReauth = Boolean(account?.needsReauth) && canOAuthConnect;
+  const canVerifyOwnership = Boolean(account) && canOpenIdConnect;
   const canUnlink = Boolean(account?.canUnlink);
   const canPublish = Boolean(account?.connected) &&
     account?.status === 'CONNECTED' &&
@@ -280,7 +283,7 @@ function ConnectionProviderRow({
       ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
-        {!account && canOAuthConnect ? (
+        {!account && canBrowserConnect ? (
           <Button
             type="button"
             disabled={isBusy}
@@ -288,7 +291,20 @@ function ConnectionProviderRow({
               onConnect(definition.provider);
             }}
           >
-            {isBusy ? 'Abrindo...' : `Conectar ${definition.name}`}
+            {isBusy ? 'Abrindo...' : canOpenIdConnect ? `Verificar com ${definition.name}` : `Conectar ${definition.name}`}
+          </Button>
+        ) : null}
+
+        {canVerifyOwnership ? (
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={isBusy}
+            onClick={() => {
+              onConnect(definition.provider);
+            }}
+          >
+            {isBusy ? 'Abrindo...' : `Verificar ownership ${definition.name}`}
           </Button>
         ) : null}
 
@@ -318,7 +334,7 @@ function ConnectionProviderRow({
         ) : null}
       </div>
 
-      {!account && !canOAuthConnect && !canLegacyConnect ? (
+      {!account && !canBrowserConnect && !canLegacyConnect ? (
         <p className="text-sm text-secondary">
           Provider registrado, mas indisponivel para conexao nesta versao.
         </p>

--- a/frontend/src/components/settings/steam-integration-card.tsx
+++ b/frontend/src/components/settings/steam-integration-card.tsx
@@ -92,10 +92,10 @@ export function SteamIntegrationCard({
         <div className="space-y-2">
           <p className="text-xs uppercase tracking-[0.35em] text-secondary">Steam</p>
           <h2 className="font-display text-2xl font-semibold text-primary">
-            Biblioteca Steam
+            Fallback manual Steam
           </h2>
           <p className="text-sm leading-6 text-secondary">
-            Conecta sua conta pela SteamID publica e permite sincronizar a biblioteca real.
+            Use apenas quando o fluxo verificado pela Steam estiver indisponivel. SteamID manual ajuda a importar dados publicos, mas nao prova ownership da conta.
           </p>
         </div>
         <Badge tone={isConnected ? 'success' : 'neutral'}>
@@ -139,7 +139,7 @@ export function SteamIntegrationCard({
 
         <div className="flex flex-wrap items-center gap-3">
           <Button type="submit" disabled={isSubmitting || connectMutation.isPending}>
-            {isSubmitting || connectMutation.isPending ? 'Conectando...' : 'Conectar Steam'}
+            {isSubmitting || connectMutation.isPending ? 'Conectando...' : 'Vincular SteamID manualmente'}
           </Button>
           <Button
             type="button"

--- a/frontend/tests/unit/components/connection-center.test.tsx
+++ b/frontend/tests/unit/components/connection-center.test.tsx
@@ -89,7 +89,7 @@ const providerDefinitions: ConnectedAccountProviderDefinition[] = [
     displayName: 'Steam',
     status: 'CONNECTED',
     dataSource: 'OFFICIAL',
-    capabilities: ['CONNECTED_ACCOUNT', 'LIBRARY_IMPORT'],
+    capabilities: ['CONNECTED_ACCOUNT', 'OPENID_CONNECT', 'LIBRARY_IMPORT'],
   },
   {
     provider: 'EPIC',
@@ -150,6 +150,7 @@ describe('ConnectionCenter', () => {
 
     expect(screen.getByRole('button', { name: /conectar google/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /conectar discord/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /verificar com steam/i })).toBeInTheDocument();
   });
 
   it('renderiza MyAnimeList como planejado sem acao de conexao falsa', async () => {
@@ -169,7 +170,7 @@ describe('ConnectionCenter', () => {
     expect(mockedStartAccountLink).not.toHaveBeenCalled();
   });
 
-  it('renderiza Steam pelo provider registry sem acao OAuth indevida', async () => {
+  it('renderiza Steam pelo provider registry com acao OpenID sem social login', async () => {
     mockedFetchConnectedAccounts.mockResolvedValue({
       providers: providerDefinitions,
       accounts: [],
@@ -180,9 +181,10 @@ describe('ConnectionCenter', () => {
     const steamCard = await screen.findByTestId('connection-provider-steam');
 
     expect(steamCard).toHaveTextContent('Steam');
-    expect(steamCard).toHaveTextContent(/SteamID publica/i);
-    expect(steamCard).toHaveTextContent(/formulario especifico/i);
-    expect(within(steamCard).queryByRole('button', { name: /conectar steam/i })).not.toBeInTheDocument();
+    expect(steamCard).toHaveTextContent(/verificacao de ownership via steam/i);
+    expect(steamCard).toHaveTextContent('Conta conectada');
+    expect(within(steamCard).getByRole('button', { name: /verificar com steam/i })).toBeInTheDocument();
+    expect(steamCard).not.toHaveTextContent('Login social');
   });
 
   it('mostra erro de carregamento', async () => {
@@ -218,6 +220,56 @@ describe('ConnectionCenter', () => {
       expect(mockedStartAccountLink.mock.calls[0]?.[0]).toBe('GOOGLE');
     });
     expect(onRedirect).toHaveBeenCalledWith('https://accounts.google.com/o/oauth2/v2/auth?state=signed-state');
+  });
+
+  it('inicia Steam OpenID pelo Connection Center', async () => {
+    const onRedirect = vi.fn();
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [],
+    });
+    mockedStartAccountLink.mockResolvedValue({
+      provider: 'STEAM',
+      authorizationUrl: 'https://steamcommunity.com/openid/login?openid.mode=checkid_setup',
+    });
+
+    renderWithQuery(<ConnectionCenter onRedirect={onRedirect} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /verificar com steam/i }));
+
+    await waitFor(() => {
+      expect(mockedStartAccountLink).toHaveBeenCalledWith('STEAM', expect.anything());
+    });
+    expect(onRedirect).toHaveBeenCalledWith('https://steamcommunity.com/openid/login?openid.mode=checkid_setup');
+  });
+
+  it('permite verificar ownership Steam de conta ja conectada', async () => {
+    const onRedirect = vi.fn();
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [
+        createAccount({
+          provider: 'STEAM',
+          displayName: 'Steam',
+          externalId: '76561198000000000',
+          connectionType: 'CONNECTED_ACCOUNT',
+          capabilities: ['CONNECTED_ACCOUNT', 'OPENID_CONNECT', 'LIBRARY_IMPORT'],
+        }),
+      ],
+    });
+    mockedStartAccountLink.mockResolvedValue({
+      provider: 'STEAM',
+      authorizationUrl: 'https://steamcommunity.com/openid/login?openid.mode=checkid_setup',
+    });
+
+    renderWithQuery(<ConnectionCenter onRedirect={onRedirect} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /verificar ownership steam/i }));
+
+    await waitFor(() => {
+      expect(mockedStartAccountLink).toHaveBeenCalledWith('STEAM', expect.anything());
+    });
+    expect(onRedirect).toHaveBeenCalledWith('https://steamcommunity.com/openid/login?openid.mode=checkid_setup');
   });
 
   it('mostra NEEDS_REAUTH com CTA de reconectar', async () => {

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -212,7 +212,7 @@ describe('IntegrationsPageContent', () => {
       expect(screen.getByTestId('settings-integrations-success')).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/biblioteca steam/i)).toBeInTheDocument();
+    expect(screen.getByText(/fallback manual steam/i)).toBeInTheDocument();
     expect(screen.getByText(/biblioteca epic games/i)).toBeInTheDocument();
     expect(screen.getByText(/^discord$/i)).toBeInTheDocument();
     expect(

--- a/frontend/tests/unit/components/steam-integration-card.test.tsx
+++ b/frontend/tests/unit/components/steam-integration-card.test.tsx
@@ -47,7 +47,7 @@ describe('SteamIntegrationCard', () => {
     mockedSyncSteamLibrary.mockReset();
   });
 
-  it('connects steam with the form payload', async () => {
+  it('connects steam manually with the fallback form payload', async () => {
     mockedConnectSteam.mockResolvedValue({
       message: 'Steam conectado. 2 jogos importados.',
       imported: 2,
@@ -58,7 +58,9 @@ describe('SteamIntegrationCard', () => {
     fireEvent.change(screen.getByLabelText(/steamid/i), {
       target: { value: '76561198000000000' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /conectar steam/i }));
+    expect(screen.getByText(/nao prova ownership da conta/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /vincular steamid manualmente/i }));
 
     await waitFor(() => {
       expect(mockedConnectSteam).toHaveBeenCalled();

--- a/frontend/tests/unit/routes/auth-account-route.test.ts
+++ b/frontend/tests/unit/routes/auth-account-route.test.ts
@@ -51,6 +51,49 @@ describe('auth account connection frontend routes', () => {
     );
   });
 
+  it('redireciona callback Steam OpenID sem propagar query sensivel', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const backendUrl = new URL(String(input));
+
+      expect(backendUrl.origin).toBe('http://backend.test');
+      expect(backendUrl.pathname).toBe('/auth/accounts/steam/link/callback');
+      expect(backendUrl.searchParams.get('state')).toBe('signed-state');
+      expect(backendUrl.searchParams.get('openid.mode')).toBe('id_res');
+      expect(backendUrl.searchParams.get('openid.claimed_id')).toBe(
+        'https://steamcommunity.com/openid/id/76561198000000000',
+      );
+
+      return new Response(
+        JSON.stringify({
+          provider: 'STEAM',
+          externalId: '76561198000000000',
+          status: 'CONNECTED',
+          connectionType: 'CONNECTED_ACCOUNT',
+          message: 'Steam verificada e conectada com sucesso.',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }) as typeof fetch);
+
+    const response = await completeAccountLink(
+      new NextRequest(
+        'http://localhost/api/auth/accounts/steam/link/callback?state=signed-state&openid.mode=id_res&openid.claimed_id=https%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F76561198000000000',
+      ),
+      { params: Promise.resolve({ provider: 'steam' }) },
+    );
+    const location = response.headers.get('location') ?? '';
+
+    expect(response.status).toBe(307);
+    expect(location).toContain('connectionStatus=success');
+    expect(location).toContain('Steam+verificada');
+    expect(location).not.toContain('signed-state');
+    expect(location).not.toContain('openid');
+    expect(location).not.toContain('76561198000000000');
+  });
+
   it('redireciona erro de linking sem expor payload sensivel', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(
       JSON.stringify({


### PR DESCRIPTION
## Resumo
Implementa o fluxo mínimo de Steam OpenID para provar ownership da conta Steam antes de persistir a identidade externa como oficial. A mudança mantém Steam como conta conectada, sem transformá-la em social login, e preserva o fallback manual apenas como caminho não forte para dados públicos/importação.

Closes #286
Depends on #285

Base atual: `develop`.

## O que foi alterado
- Backend: adiciona client Steam OpenID 2.0, geração de authorization URL, validação de callback via `check_authentication` e extração segura do SteamID64 da Claimed ID.
- Backend: integra Steam OpenID ao fluxo existente de `GET /auth/accounts/:provider/link/start` e `GET /auth/accounts/:provider/link/callback`, reutilizando state assinado, TTL e `ConnectedAccountService`.
- Backend: adiciona capability `OPENID_CONNECT` para Steam, sem `SOCIAL_LOGIN` e sem `OAUTH_CONNECT`.
- Backend: preserva ownership `OFFICIAL` quando o fallback manual usa o mesmo SteamID já verificado e bloqueia troca manual de uma Steam oficial por outro SteamID.
- Frontend: ajusta Connection Center para iniciar o fluxo verificado Steam quando o backend expõe `OPENID_CONNECT`.
- Frontend: mantém o formulário manual Steam como fallback explícito e não como prova de ownership.
- Documentação/config: documenta `STEAM_OPENID_RETURN_URL`, `STEAM_OPENID_REALM` e o recorte Steam OpenID vs fallback manual.

## Motivação
A #274 consolidou Steam usando SteamID64 como `externalId`, mas o input manual não prova que o usuário controla a conta Steam. Steam Sign-In usa OpenID e retorna uma Claimed ID com o SteamID64; esta PR usa esse fluxo para transformar Steam em uma identidade externa forte para ownership, mantendo compatibilidade com importação de biblioteca existente.

## Como validar
- No backend:
  - `npm run test -- tests/unit/services/integrations.service.test.ts tests/unit/services/account-connection.service.test.ts tests/unit/providers/steam-openid.client.test.ts tests/unit/providers/provider-registry.test.ts tests/integration/routes/auth.routes.test.ts tests/integration/routes/integrations.routes.test.ts`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- No frontend:
  - `npm run test -- tests/unit/components/connection-center.test.tsx tests/unit/components/steam-integration-card.test.tsx tests/unit/components/integrations-page-content.test.tsx tests/unit/routes/auth-account-route.test.ts tests/unit/services/integrations.test.ts`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`

## Riscos e impactos
- Steam OpenID exige uma URL pública de callback consistente. Em produção, `STEAM_OPENID_RETURN_URL` deve estar configurada explicitamente; sem isso, o backend falha de forma clara em vez de aceitar callback inseguro.
- Smoke real com Steam não foi executado localmente por depender de callback público/navegador e configuração externa; a validação local usa mocks do provider.
- Steam continua sem social login. A capability entregue é de conta conectada via OpenID.
- MyAnimeList permanece fora do escopo e continua planejado/indisponível.
- O rebase para `develop` foi aplicado sem conflitos após o merge da #285; o diff remoto contém apenas mudanças da #286.

## Evidências
- Backend focado: 6 arquivos de teste, 134 testes passando.
- Frontend focado: 5 arquivos de teste, 39 testes passando.
- Backend typecheck/lint/build passaram; lint mantém 3 warnings preexistentes em `backend/src/config/rate-limit.ts`.
- Frontend typecheck/lint/build passaram.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados