### PR TITLE
feat(integrations): conecta MyAnimeList via OAuth2 PKCE

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -69,6 +69,22 @@ GOOGLE_REDIRECT_URI=
 GOOGLE_ACCOUNT_LINK_REDIRECT_URI=
 GOOGLE_ACCOUNT_REAUTH_REDIRECT_URI=
 
+# ── MyAnimeList Connected Account ────────────────────────────
+# Obter em: https://myanimelist.net/apiconfig
+# Obrigatório para conexão MyAnimeList via OAuth2/PKCE.
+MYANIMELIST_CLIENT_ID=
+MYANIMELIST_CLIENT_SECRET=
+# URL pública registrada para account linking MyAnimeList.
+# Exemplo local: http://localhost/api/auth/accounts/myanimelist/link/callback
+MYANIMELIST_REDIRECT_URI=
+# URLs públicas opcionais por fluxo. Se vazias, o backend deriva a
+# partir de MYANIMELIST_REDIRECT_URI quando possível.
+# Exemplos locais:
+# http://localhost/api/auth/accounts/myanimelist/link/callback
+# http://localhost/api/auth/accounts/myanimelist/reauth/callback
+MYANIMELIST_ACCOUNT_LINK_REDIRECT_URI=
+MYANIMELIST_ACCOUNT_REAUTH_REDIRECT_URI=
+
 # Segredo HMAC para state OAuth social. Se ausente fora de produção,
 # o backend usa fallback local de desenvolvimento.
 SOCIAL_OAUTH_STATE_SECRET=

--- a/backend/src/core/providers/provider-registry.ts
+++ b/backend/src/core/providers/provider-registry.ts
@@ -3,6 +3,7 @@ import type {
   PlatformIntegrationDataSource,
   PlatformIntegrationStatus,
 } from '@prisma/client';
+import { isMyAnimeListOAuthConfigured } from '../../infra/integrations/myanimelist/myanimelist-oauth.client';
 
 export type ProviderCapability =
   | 'SOCIAL_LOGIN'
@@ -93,11 +94,31 @@ const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
   },
 ];
 
-export function listProviderDefinitions(): ProviderDefinition[] {
-  return PROVIDER_DEFINITIONS.map((definition) => ({
+function resolveProviderDefinition(definition: ProviderDefinition): ProviderDefinition {
+  if (definition.provider !== 'MYANIMELIST') {
+    return definition;
+  }
+
+  if (!isMyAnimeListOAuthConfigured()) {
+    return definition;
+  }
+
+  return {
     ...definition,
-    capabilities: [...definition.capabilities],
-  }));
+    status: 'CONNECTED',
+    capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+  };
+}
+
+export function listProviderDefinitions(): ProviderDefinition[] {
+  return PROVIDER_DEFINITIONS.map((definition) => {
+    const resolvedDefinition = resolveProviderDefinition(definition);
+
+    return {
+      ...resolvedDefinition,
+      capabilities: [...resolvedDefinition.capabilities],
+    };
+  });
 }
 
 export function getProviderDefinition(provider: Platform): ProviderDefinition {
@@ -107,8 +128,10 @@ export function getProviderDefinition(provider: Platform): ProviderDefinition {
     throw new Error(`Provider ${provider} não está registrado.`);
   }
 
+  const resolvedDefinition = resolveProviderDefinition(definition);
+
   return {
-    ...definition,
-    capabilities: [...definition.capabilities],
+    ...resolvedDefinition,
+    capabilities: [...resolvedDefinition.capabilities],
   };
 }

--- a/backend/src/core/services/account-connection.service.ts
+++ b/backend/src/core/services/account-connection.service.ts
@@ -21,7 +21,6 @@ import {
 import {
   createInMemorySocialOAuthStateStore,
   type SocialAuthProvider,
-  type SocialAuthProviderClient,
   type SocialAuthProviderIdentity,
   type SocialOAuthStateStore,
 } from './social-auth.service';
@@ -29,6 +28,10 @@ import {
   discordSocialOAuthClient,
   googleSocialOAuthClient,
 } from '../../infra/integrations/social/social-oauth.clients';
+import {
+  createMyAnimeListCodeVerifier,
+  myAnimeListOAuthClient,
+} from '../../infra/integrations/myanimelist/myanimelist-oauth.client';
 import {
   steamOpenIdClient,
   type SteamOpenIdCallbackParams,
@@ -46,7 +49,34 @@ const ACCOUNT_CONNECTION_CALLBACK_PATHS: Record<AccountConnectionMode, string> =
 };
 
 export type AccountConnectionMode = 'link' | 'reauth';
-type BrowserAccountConnectionProvider = SocialAuthProvider | 'STEAM';
+export type OAuthAccountConnectionProvider = SocialAuthProvider | 'MYANIMELIST';
+type BrowserAccountConnectionProvider = OAuthAccountConnectionProvider | 'STEAM';
+
+export type AccountConnectionProviderIdentity = Omit<SocialAuthProviderIdentity, 'provider'> & {
+  provider: OAuthAccountConnectionProvider;
+};
+
+export type AccountConnectionProviderClient = {
+  provider: OAuthAccountConnectionProvider;
+  createAuthorizationUrl(input: {
+    state: string;
+    nonce: string;
+    redirectUri?: string;
+    codeChallenge?: string;
+  }): string;
+  exchangeCodeForIdentity(
+    code: string,
+    input?: {
+      redirectUri?: string;
+      codeVerifier?: string;
+    },
+  ): Promise<AccountConnectionProviderIdentity>;
+};
+
+export type AccountConnectionPkceStore = {
+  store(state: string, codeVerifier: string, ttlMs: number): Promise<void>;
+  consume(state: string): Promise<string | null>;
+};
 
 export type PublicConnectedAccount = {
   provider: Platform;
@@ -151,7 +181,7 @@ type AccountConnectionUserGateway = {
 };
 
 type AccountConnectionDependencies = {
-  providerClients?: Partial<Record<SocialAuthProvider, SocialAuthProviderClient>>;
+  providerClients?: Partial<Record<OAuthAccountConnectionProvider, AccountConnectionProviderClient>>;
   steamClient?: SteamOpenIdClient;
   users?: AccountConnectionUserGateway;
   repository?: Pick<
@@ -164,6 +194,7 @@ type AccountConnectionDependencies = {
   >;
   connectedAccountService?: Pick<ConnectedAccountService, 'connectExternalIdentity'>;
   stateStore?: SocialOAuthStateStore;
+  pkceStore?: AccountConnectionPkceStore;
 };
 
 type AccountConnectionStatePayload = {
@@ -217,8 +248,12 @@ function isSocialOAuthProvider(value: unknown): value is SocialAuthProvider {
   return value === 'GOOGLE' || value === 'DISCORD';
 }
 
+function isAccountConnectionOAuthProvider(value: unknown): value is OAuthAccountConnectionProvider {
+  return isSocialOAuthProvider(value) || value === 'MYANIMELIST';
+}
+
 function isBrowserAccountConnectionProvider(value: unknown): value is BrowserAccountConnectionProvider {
-  return isSocialOAuthProvider(value) || value === 'STEAM';
+  return isAccountConnectionOAuthProvider(value) || value === 'STEAM';
 }
 
 function decodeStatePayload(value: string): AccountConnectionStatePayload {
@@ -354,12 +389,12 @@ function normalizePlatform(provider: string): Platform {
   return knownProvider.provider;
 }
 
-function normalizeOAuthProvider(provider: string): SocialAuthProvider {
+function normalizeOAuthProvider(provider: string): OAuthAccountConnectionProvider {
   const normalizedProvider = normalizePlatform(provider);
   const definition = getProviderDefinition(normalizedProvider);
 
   if (
-    !isSocialOAuthProvider(normalizedProvider) ||
+    !isAccountConnectionOAuthProvider(normalizedProvider) ||
     definition.status === 'UNAVAILABLE' ||
     !definition.capabilities.includes('OAUTH_CONNECT')
   ) {
@@ -473,18 +508,26 @@ function getDefaultSocialRedirectUri(provider: SocialAuthProvider): string | und
   return process.env['DISCORD_SOCIAL_REDIRECT_URI']?.trim();
 }
 
+function getDefaultOAuthRedirectUri(provider: OAuthAccountConnectionProvider): string | undefined {
+  if (provider === 'MYANIMELIST') {
+    return process.env['MYANIMELIST_REDIRECT_URI']?.trim();
+  }
+
+  return getDefaultSocialRedirectUri(provider);
+}
+
 function getExplicitAccountConnectionRedirectUri(
-  provider: SocialAuthProvider,
+  provider: OAuthAccountConnectionProvider,
   mode: AccountConnectionMode,
 ): string | undefined {
   return process.env[`${provider}_ACCOUNT_${mode.toUpperCase()}_REDIRECT_URI`]?.trim();
 }
 
 function deriveAccountConnectionRedirectUri(
-  provider: SocialAuthProvider,
+  provider: OAuthAccountConnectionProvider,
   mode: AccountConnectionMode,
 ): string | undefined {
-  const defaultRedirectUri = getDefaultSocialRedirectUri(provider);
+  const defaultRedirectUri = getDefaultOAuthRedirectUri(provider);
 
   if (!defaultRedirectUri) {
     return undefined;
@@ -494,12 +537,26 @@ function deriveAccountConnectionRedirectUri(
     const parsedUrl = new URL(defaultRedirectUri);
     const providerSlug = provider.toLowerCase();
     const callbackMode = ACCOUNT_CONNECTION_CALLBACK_PATHS[mode];
-    const nextPathname = parsedUrl.pathname.replace(
-      `/auth/social/${providerSlug}/callback`,
+    const socialCallbackPath = `/auth/social/${providerSlug}/callback`;
+    const accountLinkCallbackPath = `/auth/accounts/${providerSlug}/link/callback`;
+    let nextPathname = parsedUrl.pathname.replace(
+      socialCallbackPath,
       `/auth/accounts/${providerSlug}/${callbackMode}/callback`,
     );
 
     if (nextPathname === parsedUrl.pathname) {
+      nextPathname = parsedUrl.pathname.replace(
+        accountLinkCallbackPath,
+        `/auth/accounts/${providerSlug}/${callbackMode}/callback`,
+      );
+    }
+
+    if (nextPathname === parsedUrl.pathname) {
+      if (parsedUrl.pathname === `/api/auth/accounts/${providerSlug}/${callbackMode}/callback` ||
+        parsedUrl.pathname === `/auth/accounts/${providerSlug}/${callbackMode}/callback`) {
+        return parsedUrl.toString();
+      }
+
       return undefined;
     }
 
@@ -512,7 +569,7 @@ function deriveAccountConnectionRedirectUri(
 }
 
 function resolveAccountConnectionRedirectUri(
-  provider: SocialAuthProvider,
+  provider: OAuthAccountConnectionProvider,
   mode: AccountConnectionMode,
 ): string | undefined {
   return getExplicitAccountConnectionRedirectUri(provider, mode)
@@ -612,7 +669,7 @@ function mapProviderFailure(error: unknown, provider: BrowserAccountConnectionPr
   });
 }
 
-function buildIdentityMetadata(identity: SocialAuthProviderIdentity): Prisma.InputJsonObject {
+function buildIdentityMetadata(identity: AccountConnectionProviderIdentity): Prisma.InputJsonObject {
   return {
     ...identity.metadata,
     email: identity.email,
@@ -624,6 +681,43 @@ function buildIdentityMetadata(identity: SocialAuthProviderIdentity): Prisma.Inp
   };
 }
 
+export function createInMemoryAccountConnectionPkceStore(): AccountConnectionPkceStore {
+  const verifiers = new Map<string, { codeVerifier: string; expiresAt: number }>();
+
+  function pruneExpiredVerifiers(): void {
+    const now = Date.now();
+
+    for (const [state, record] of verifiers.entries()) {
+      if (record.expiresAt <= now) {
+        verifiers.delete(state);
+      }
+    }
+  }
+
+  return {
+    async store(state, codeVerifier, ttlMs): Promise<void> {
+      pruneExpiredVerifiers();
+      verifiers.set(state, {
+        codeVerifier,
+        expiresAt: Date.now() + ttlMs,
+      });
+    },
+
+    async consume(state): Promise<string | null> {
+      pruneExpiredVerifiers();
+      const record = verifiers.get(state);
+
+      if (!record || record.expiresAt <= Date.now()) {
+        verifiers.delete(state);
+        return null;
+      }
+
+      verifiers.delete(state);
+      return record.codeVerifier;
+    },
+  };
+}
+
 export function createAccountConnectionService(
   dependencies: AccountConnectionDependencies = {},
 ): AccountConnectionService {
@@ -631,19 +725,25 @@ export function createAccountConnectionService(
   const repository = dependencies.repository ?? createConnectedAccountRepository();
   const connectedAccountService = dependencies.connectedAccountService ?? createConnectedAccountService();
   const stateStore = dependencies.stateStore ?? createInMemorySocialOAuthStateStore();
+  const pkceStore = dependencies.pkceStore ?? createInMemoryAccountConnectionPkceStore();
   const providerClients = {
     GOOGLE: dependencies.providerClients?.GOOGLE ?? googleSocialOAuthClient,
     DISCORD: dependencies.providerClients?.DISCORD ?? discordSocialOAuthClient,
+    MYANIMELIST: dependencies.providerClients?.MYANIMELIST ?? myAnimeListOAuthClient,
   };
   const steamClient = dependencies.steamClient ?? steamOpenIdClient;
 
   async function exchangeIdentity(
-    provider: SocialAuthProvider,
+    provider: OAuthAccountConnectionProvider,
     code: string,
     redirectUri?: string,
-  ): Promise<SocialAuthProviderIdentity> {
+    codeVerifier?: string,
+  ): Promise<AccountConnectionProviderIdentity> {
     try {
-      const identity = await providerClients[provider].exchangeCodeForIdentity(code, { redirectUri });
+      const identity = await providerClients[provider].exchangeCodeForIdentity(code, {
+        redirectUri,
+        codeVerifier,
+      });
 
       if (identity.provider !== provider) {
         throw createAccountConnectionError({
@@ -713,13 +813,21 @@ export function createAccountConnectionService(
       mode: input.mode,
       expectedExternalId: input.expectedExternalId,
     });
+    const codeVerifier = provider === 'MYANIMELIST'
+      ? createMyAnimeListCodeVerifier()
+      : undefined;
     const authorizationUrl = providerClients[provider].createAuthorizationUrl({
       state,
       nonce,
       redirectUri: resolveAccountConnectionRedirectUri(provider, input.mode),
+      codeChallenge: codeVerifier,
     });
 
     await stateStore.store(state, ACCOUNT_CONNECTION_STATE_TTL_MS);
+
+    if (codeVerifier) {
+      await pkceStore.store(state, codeVerifier, ACCOUNT_CONNECTION_STATE_TTL_MS);
+    }
 
     return {
       provider,
@@ -757,7 +865,7 @@ export function createAccountConnectionService(
     state?: string;
     providerError?: string;
     mode: AccountConnectionMode;
-  }): Promise<{ provider: SocialAuthProvider; identity: SocialAuthProviderIdentity; statePayload: AccountConnectionStatePayload }> {
+  }): Promise<{ provider: OAuthAccountConnectionProvider; identity: AccountConnectionProviderIdentity; statePayload: AccountConnectionStatePayload }> {
     const provider = normalizeOAuthProvider(input.provider);
 
     if (input.providerError) {
@@ -789,12 +897,26 @@ export function createAccountConnectionService(
       });
     }
 
+    const codeVerifier = provider === 'MYANIMELIST'
+      ? await pkceStore.consume(input.state) ?? undefined
+      : undefined;
+
+    if (provider === 'MYANIMELIST' && !codeVerifier) {
+      throw createAccountConnectionError({
+        statusCode: 400,
+        reason: 'invalid_state',
+        clientMessage: 'Callback de conexão inválido ou expirado.',
+        provider,
+      });
+    }
+
     return {
       provider,
       identity: await exchangeIdentity(
         provider,
         input.code,
         resolveAccountConnectionRedirectUri(provider, input.mode),
+        codeVerifier,
       ),
       statePayload,
     };
@@ -975,7 +1097,7 @@ export function createAccountConnectionService(
           userId: statePayload.userId,
           provider,
           externalId: identity.externalId,
-          connectionType: 'SOCIAL_LOGIN',
+          connectionType: provider === 'MYANIMELIST' ? 'CONNECTED_ACCOUNT' : 'SOCIAL_LOGIN',
           status: 'CONNECTED',
           dataSource: getProviderDefinition(provider).dataSource,
           accessToken: identity.accessToken,
@@ -1000,7 +1122,7 @@ export function createAccountConnectionService(
         provider,
         externalId: identity.externalId,
         status: 'CONNECTED',
-        connectionType: 'SOCIAL_LOGIN',
+        connectionType: provider === 'MYANIMELIST' ? 'CONNECTED_ACCOUNT' : 'SOCIAL_LOGIN',
         message: `${getProviderDefinition(provider).displayName} vinculado com sucesso.`,
       };
     },

--- a/backend/src/infra/integrations/integration.errors.ts
+++ b/backend/src/infra/integrations/integration.errors.ts
@@ -3,7 +3,7 @@ import {
   writeBackendRuntimeLog,
 } from '../../config/logging';
 
-export type IntegrationName = 'steam' | 'igdb' | 'epic' | 'discord' | 'google';
+export type IntegrationName = 'steam' | 'igdb' | 'epic' | 'discord' | 'google' | 'myanimelist';
 
 export type IntegrationErrorReason =
   | 'invalid_request'

--- a/backend/src/infra/integrations/myanimelist/myanimelist-oauth.client.ts
+++ b/backend/src/infra/integrations/myanimelist/myanimelist-oauth.client.ts
@@ -1,0 +1,285 @@
+import { randomBytes } from 'node:crypto';
+import axios from 'axios';
+import {
+  createIntegrationError,
+  logIntegrationProviderEvent,
+  translateUpstreamError,
+} from '../integration.errors';
+import type {
+  AccountConnectionProviderClient,
+  AccountConnectionProviderIdentity,
+} from '../../../core/services/account-connection.service';
+
+const MYANIMELIST_AUTHORIZE_URL = 'https://myanimelist.net/v1/oauth2/authorize';
+const MYANIMELIST_TOKEN_URL = 'https://myanimelist.net/v1/oauth2/token';
+const MYANIMELIST_ME_URL = 'https://api.myanimelist.net/v2/users/@me';
+const MYANIMELIST_TIMEOUT_MS = 10_000;
+const MYANIMELIST_PKCE_VERIFIER_BYTES = 48;
+
+type MyAnimeListOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+};
+
+type MyAnimeListTokenResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+};
+
+type MyAnimeListUserResponse = {
+  id?: number | string;
+  name?: string;
+  picture?: string;
+};
+
+export function isMyAnimeListOAuthConfigured(): boolean {
+  const clientId = process.env['MYANIMELIST_CLIENT_ID']?.trim();
+  const clientSecret = process.env['MYANIMELIST_CLIENT_SECRET']?.trim();
+  const redirectUri = process.env['MYANIMELIST_ACCOUNT_LINK_REDIRECT_URI']?.trim()
+    ?? process.env['MYANIMELIST_REDIRECT_URI']?.trim();
+
+  return Boolean(clientId && clientSecret && redirectUri);
+}
+
+export function createMyAnimeListCodeVerifier(): string {
+  return randomBytes(MYANIMELIST_PKCE_VERIFIER_BYTES).toString('base64url');
+}
+
+function assertValidRedirectUri(redirectUri: string): void {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(redirectUri);
+  } catch {
+    throw createIntegrationError(
+      'myanimelist',
+      503,
+      'misconfigured',
+      'Conexão MyAnimeList indisponível no runtime atual.',
+    );
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol) || parsedUrl.username || parsedUrl.password) {
+    throw createIntegrationError(
+      'myanimelist',
+      503,
+      'misconfigured',
+      'Conexão MyAnimeList indisponível no runtime atual.',
+    );
+  }
+}
+
+function resolveMyAnimeListOAuthConfig(redirectUriOverride?: string): MyAnimeListOAuthConfig {
+  const clientId = process.env['MYANIMELIST_CLIENT_ID']?.trim();
+  const clientSecret = process.env['MYANIMELIST_CLIENT_SECRET']?.trim();
+  const redirectUri = redirectUriOverride?.trim()
+    || process.env['MYANIMELIST_ACCOUNT_LINK_REDIRECT_URI']?.trim()
+    || process.env['MYANIMELIST_REDIRECT_URI']?.trim();
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    logIntegrationProviderEvent(
+      'myanimelist',
+      'integration_myanimelist_unavailable',
+      'misconfigured',
+      'MyAnimeList OAuth config is incomplete in the current runtime.',
+    );
+
+    throw createIntegrationError(
+      'myanimelist',
+      503,
+      'misconfigured',
+      'Conexão MyAnimeList indisponível no runtime atual.',
+    );
+  }
+
+  assertValidRedirectUri(redirectUri);
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri,
+  };
+}
+
+function buildMyAnimeListAuthorizationUrl(input: {
+  state: string;
+  redirectUri?: string;
+  codeChallenge?: string;
+}): string {
+  const config = resolveMyAnimeListOAuthConfig(input.redirectUri);
+
+  if (!input.codeChallenge || input.codeChallenge.trim().length === 0) {
+    throw createIntegrationError(
+      'myanimelist',
+      400,
+      'invalid_request',
+      'Código PKCE MyAnimeList inválido.',
+    );
+  }
+
+  const authorizationUrl = new URL(MYANIMELIST_AUTHORIZE_URL);
+
+  authorizationUrl.searchParams.set('response_type', 'code');
+  authorizationUrl.searchParams.set('client_id', config.clientId);
+  authorizationUrl.searchParams.set('redirect_uri', config.redirectUri);
+  authorizationUrl.searchParams.set('state', input.state);
+  authorizationUrl.searchParams.set('code_challenge', input.codeChallenge);
+  authorizationUrl.searchParams.set('code_challenge_method', 'plain');
+
+  return authorizationUrl.toString();
+}
+
+async function exchangeMyAnimeListCode(input: {
+  code: string;
+  codeVerifier?: string;
+  config: MyAnimeListOAuthConfig;
+}): Promise<MyAnimeListTokenResponse> {
+  if (!input.codeVerifier || input.codeVerifier.trim().length === 0) {
+    throw createIntegrationError(
+      'myanimelist',
+      400,
+      'invalid_request',
+      'Verifier PKCE MyAnimeList inválido.',
+    );
+  }
+
+  try {
+    const response = await axios.post<MyAnimeListTokenResponse>(
+      MYANIMELIST_TOKEN_URL,
+      new URLSearchParams({
+        client_id: input.config.clientId,
+        client_secret: input.config.clientSecret,
+        grant_type: 'authorization_code',
+        code: input.code,
+        redirect_uri: input.config.redirectUri,
+        code_verifier: input.codeVerifier,
+      }).toString(),
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        timeout: MYANIMELIST_TIMEOUT_MS,
+      },
+    );
+
+    return response.data;
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'response' in error &&
+      typeof (error as { response?: { status?: number } }).response?.status === 'number' &&
+      [400, 401, 403].includes((error as { response?: { status?: number } }).response?.status as number)
+    ) {
+      throw createIntegrationError(
+        'myanimelist',
+        400,
+        'invalid_request',
+        'Autorização MyAnimeList inválida ou expirada.',
+      );
+    }
+
+    throw translateUpstreamError(
+      'myanimelist',
+      error,
+      'Conexão MyAnimeList indisponível no momento.',
+      { targetUrl: MYANIMELIST_TOKEN_URL },
+    );
+  }
+}
+
+async function fetchMyAnimeListUser(accessToken: string): Promise<MyAnimeListUserResponse> {
+  try {
+    const response = await axios.get<MyAnimeListUserResponse>(
+      MYANIMELIST_ME_URL,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        timeout: MYANIMELIST_TIMEOUT_MS,
+      },
+    );
+
+    return response.data;
+  } catch (error) {
+    throw translateUpstreamError(
+      'myanimelist',
+      error,
+      'Conexão MyAnimeList indisponível no momento.',
+      { targetUrl: MYANIMELIST_ME_URL },
+    );
+  }
+}
+
+function normalizeMyAnimeListExternalId(value: MyAnimeListUserResponse['id']): string {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) {
+    return String(value);
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  throw createIntegrationError(
+    'myanimelist',
+    400,
+    'invalid_request',
+    'Identidade MyAnimeList inválida.',
+  );
+}
+
+export const myAnimeListOAuthClient: AccountConnectionProviderClient = {
+  provider: 'MYANIMELIST',
+
+  createAuthorizationUrl(input): string {
+    return buildMyAnimeListAuthorizationUrl(input);
+  },
+
+  async exchangeCodeForIdentity(code, input): Promise<AccountConnectionProviderIdentity> {
+    const config = resolveMyAnimeListOAuthConfig(input?.redirectUri);
+    const tokenSet = await exchangeMyAnimeListCode({
+      code,
+      codeVerifier: input?.codeVerifier,
+      config,
+    });
+
+    if (typeof tokenSet.access_token !== 'string' || tokenSet.access_token.trim().length === 0) {
+      throw createIntegrationError(
+        'myanimelist',
+        400,
+        'invalid_request',
+        'Token MyAnimeList inválido.',
+      );
+    }
+
+    const userInfo = await fetchMyAnimeListUser(tokenSet.access_token);
+    const externalId = normalizeMyAnimeListExternalId(userInfo.id);
+    const displayName = typeof userInfo.name === 'string' && userInfo.name.trim().length > 0
+      ? userInfo.name.trim()
+      : null;
+
+    return {
+      provider: 'MYANIMELIST',
+      externalId,
+      email: null,
+      emailVerified: false,
+      displayName,
+      username: displayName,
+      avatarUrl: typeof userInfo.picture === 'string' && userInfo.picture.trim().length > 0
+        ? userInfo.picture.trim()
+        : null,
+      accessToken: tokenSet.access_token,
+      refreshToken: tokenSet.refresh_token ?? null,
+      metadata: {
+        name: displayName,
+        picture: typeof userInfo.picture === 'string' ? userInfo.picture : null,
+        tokenType: tokenSet.token_type ?? null,
+        expiresIn: tokenSet.expires_in ?? null,
+        source: 'myanimelist_oauth',
+      },
+    };
+  },
+};

--- a/backend/src/infra/integrations/myanimelist/myanimelist-oauth.client.ts
+++ b/backend/src/infra/integrations/myanimelist/myanimelist-oauth.client.ts
@@ -126,6 +126,7 @@ function buildMyAnimeListAuthorizationUrl(input: {
   authorizationUrl.searchParams.set('client_id', config.clientId);
   authorizationUrl.searchParams.set('redirect_uri', config.redirectUri);
   authorizationUrl.searchParams.set('state', input.state);
+  // MyAnimeList currently documents only PKCE plain, so the verifier is also the challenge.
   authorizationUrl.searchParams.set('code_challenge', input.codeChallenge);
   authorizationUrl.searchParams.set('code_challenge_method', 'plain');
 

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -1057,6 +1057,33 @@ describe('Auth Routes', () => {
       await app.close();
     });
 
+    it('inicia linking MyAnimeList autenticado usando rota generica de contas', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      accountConnectionService.startLink.mockResolvedValueOnce({
+        provider: 'MYANIMELIST',
+        authorizationUrl: 'https://myanimelist.net/v1/oauth2/authorize?state=signed-state',
+      });
+      const app = await buildApp({ accountConnectionService });
+      const token = generateTestToken(app);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/myanimelist/link/start',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        provider: 'MYANIMELIST',
+        authorizationUrl: expect.stringContaining('myanimelist.net/v1/oauth2/authorize'),
+      });
+      expect(accountConnectionService.startLink).toHaveBeenCalledWith({
+        userId: 'user-id-1',
+        provider: 'myanimelist',
+      });
+      await app.close();
+    });
+
     it('bloqueia start de linking sem autenticacao', async () => {
       const accountConnectionService = createAccountConnectionService();
       const app = await buildApp({ accountConnectionService });

--- a/backend/tests/integration/routes/auth.routes.test.ts
+++ b/backend/tests/integration/routes/auth.routes.test.ts
@@ -1153,6 +1153,31 @@ describe('Auth Routes', () => {
       await app.close();
     });
 
+    it('bloqueia callback MyAnimeList sem code ou state antes de chamar service', async () => {
+      const accountConnectionService = createAccountConnectionService();
+      const app = await buildApp({ accountConnectionService });
+
+      const withoutCode = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/myanimelist/link/callback?state=signed-state',
+      });
+      const withoutState = await app.inject({
+        method: 'GET',
+        url: '/auth/accounts/myanimelist/link/callback?code=oauth-code',
+      });
+
+      expect(withoutCode.statusCode).toBe(400);
+      expect(withoutCode.json()).toMatchObject({
+        message: 'Callback de conexão inválido.',
+      });
+      expect(withoutState.statusCode).toBe(400);
+      expect(withoutState.json()).toMatchObject({
+        message: 'Callback de conexão inválido.',
+      });
+      expect(accountConnectionService.completeLink).not.toHaveBeenCalled();
+      await app.close();
+    });
+
     it('conclui callback Steam OpenID repassando parametros sem emitir sessao nova', async () => {
       const accountConnectionService = createAccountConnectionService();
       accountConnectionService.completeLink.mockResolvedValueOnce({

--- a/backend/tests/unit/providers/myanimelist-oauth.client.test.ts
+++ b/backend/tests/unit/providers/myanimelist-oauth.client.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios');
+
+import axios from 'axios';
+import {
+  createMyAnimeListCodeVerifier,
+  isMyAnimeListOAuthConfigured,
+  myAnimeListOAuthClient,
+} from '@/infra/integrations/myanimelist/myanimelist-oauth.client';
+
+const originalEnv = { ...process.env };
+
+describe('myAnimeListOAuthClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      MYANIMELIST_CLIENT_ID: 'mal-client-id',
+      MYANIMELIST_CLIENT_SECRET: 'mal-client-secret',
+      MYANIMELIST_REDIRECT_URI: 'http://localhost/api/auth/accounts/myanimelist/link/callback',
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('detecta configuracao OAuth completa sem expor segredo', () => {
+    expect(isMyAnimeListOAuthConfigured()).toBe(true);
+
+    delete process.env['MYANIMELIST_CLIENT_SECRET'];
+
+    expect(isMyAnimeListOAuthConfigured()).toBe(false);
+  });
+
+  it('gera authorization URL MyAnimeList com state e PKCE plain', () => {
+    const authorizationUrl = new URL(myAnimeListOAuthClient.createAuthorizationUrl({
+      state: 'signed-state',
+      nonce: 'unused-nonce',
+      codeChallenge: 'pkce-code-verifier',
+    }));
+
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe('https://myanimelist.net/v1/oauth2/authorize');
+    expect(authorizationUrl.searchParams.get('response_type')).toBe('code');
+    expect(authorizationUrl.searchParams.get('client_id')).toBe('mal-client-id');
+    expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(
+      'http://localhost/api/auth/accounts/myanimelist/link/callback',
+    );
+    expect(authorizationUrl.searchParams.get('state')).toBe('signed-state');
+    expect(authorizationUrl.searchParams.get('code_challenge')).toBe('pkce-code-verifier');
+    expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('plain');
+  });
+
+  it('falha de forma controlada quando config OAuth esta incompleta', () => {
+    delete process.env['MYANIMELIST_CLIENT_ID'];
+
+    expect(() => myAnimeListOAuthClient.createAuthorizationUrl({
+      state: 'signed-state',
+      nonce: 'unused-nonce',
+      codeChallenge: 'pkce-code-verifier',
+    })).toThrowError(
+      expect.objectContaining({
+        statusCode: 503,
+        reason: 'misconfigured',
+        clientMessage: 'Conexão MyAnimeList indisponível no runtime atual.',
+      }),
+    );
+  });
+
+  it('gera code verifier PKCE nao vazio e URL-safe', () => {
+    const verifier = createMyAnimeListCodeVerifier();
+
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/u);
+  });
+
+  it('usa id autenticado da MyAnimeList como externalId confiavel', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        access_token: 'mal-access-token',
+        refresh_token: 'mal-refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      },
+    } as never);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        id: 123456,
+        name: 'malplayer',
+        picture: 'https://cdn.myanimelist.net/images/user.jpg',
+      },
+    } as never);
+
+    const identity = await myAnimeListOAuthClient.exchangeCodeForIdentity('oauth-code', {
+      codeVerifier: 'pkce-code-verifier',
+    });
+
+    expect(identity).toMatchObject({
+      provider: 'MYANIMELIST',
+      externalId: '123456',
+      email: null,
+      emailVerified: false,
+      displayName: 'malplayer',
+      username: 'malplayer',
+      accessToken: 'mal-access-token',
+      refreshToken: 'mal-refresh-token',
+    });
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://myanimelist.net/v1/oauth2/token',
+      expect.stringContaining('code_verifier=pkce-code-verifier'),
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      }),
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.myanimelist.net/v2/users/@me',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer mal-access-token' },
+      }),
+    );
+  });
+
+  it('mapeia token exchange invalido para erro de dominio', async () => {
+    vi.mocked(axios.post).mockRejectedValue({
+      response: { status: 401 },
+    });
+
+    await expect(myAnimeListOAuthClient.exchangeCodeForIdentity('oauth-code', {
+      codeVerifier: 'pkce-code-verifier',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Autorização MyAnimeList inválida ou expirada.',
+    });
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it('rejeita payload autenticado sem id estavel', async () => {
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        access_token: 'mal-access-token',
+        token_type: 'Bearer',
+      },
+    } as never);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        name: 'malplayer',
+      },
+    } as never);
+
+    await expect(myAnimeListOAuthClient.exchangeCodeForIdentity('oauth-code', {
+      codeVerifier: 'pkce-code-verifier',
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_request',
+      clientMessage: 'Identidade MyAnimeList inválida.',
+    });
+  });
+});

--- a/backend/tests/unit/providers/provider-registry.test.ts
+++ b/backend/tests/unit/providers/provider-registry.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   getProviderDefinition,
   listProviderDefinitions,
 } from '@/core/providers/provider-registry';
 
+const originalEnv = { ...process.env };
+
 describe('provider registry', () => {
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
   it('descreve providers sem depender de implementacao de rota especifica', () => {
     const discord = getProviderDefinition('DISCORD');
 
@@ -34,12 +40,32 @@ describe('provider registry', () => {
   });
 
   it('mantem MyAnimeList planejado sem declarar OAuth antes do client real', () => {
+    delete process.env['MYANIMELIST_CLIENT_ID'];
+    delete process.env['MYANIMELIST_CLIENT_SECRET'];
+    delete process.env['MYANIMELIST_REDIRECT_URI'];
+    delete process.env['MYANIMELIST_ACCOUNT_LINK_REDIRECT_URI'];
     const myAnimeList = getProviderDefinition('MYANIMELIST');
 
     expect(myAnimeList.status).toBe('UNAVAILABLE');
     expect(myAnimeList.visibleInConnectionCenter).toBe(true);
     expect(myAnimeList.capabilities).toContain('CONNECTED_ACCOUNT');
     expect(myAnimeList.capabilities).not.toContain('OAUTH_CONNECT');
+    expect(myAnimeList.capabilities).not.toContain('SOCIAL_LOGIN');
+  });
+
+  it('expõe MyAnimeList como OAuth connect quando config segura existe', () => {
+    process.env['MYANIMELIST_CLIENT_ID'] = 'mal-client-id';
+    process.env['MYANIMELIST_CLIENT_SECRET'] = 'mal-client-secret';
+    process.env['MYANIMELIST_REDIRECT_URI'] = 'http://localhost/api/auth/accounts/myanimelist/link/callback';
+
+    const myAnimeList = getProviderDefinition('MYANIMELIST');
+
+    expect(myAnimeList.status).toBe('CONNECTED');
+    expect(myAnimeList.dataSource).toBe('OFFICIAL');
+    expect(myAnimeList.visibleInConnectionCenter).toBe(true);
+    expect(myAnimeList.capabilities).toEqual(
+      expect.arrayContaining(['CONNECTED_ACCOUNT', 'OAUTH_CONNECT']),
+    );
     expect(myAnimeList.capabilities).not.toContain('SOCIAL_LOGIN');
   });
 

--- a/backend/tests/unit/services/account-connection.service.test.ts
+++ b/backend/tests/unit/services/account-connection.service.test.ts
@@ -3,14 +3,12 @@ import type { Platform, User } from '@prisma/client';
 import {
   AccountConnectionError,
   createAccountConnectionService,
+  type AccountConnectionProviderClient,
+  type OAuthAccountConnectionProvider,
   type PublicConnectedAccount,
 } from '@/core/services/account-connection.service';
 import { ConnectedAccountConflictError } from '@/core/services/connected-account.service';
 import type { ConnectedAccountRecord } from '@/core/repositories/connected-account.repository';
-import type {
-  SocialAuthProvider,
-  SocialAuthProviderClient,
-} from '@/core/services/social-auth.service';
 
 const baseUser: User = {
   id: 'user-id-1',
@@ -22,10 +20,12 @@ const baseUser: User = {
   updatedAt: new Date('2026-04-28T00:00:00.000Z'),
 };
 
+const originalEnv = { ...process.env };
+
 function createProviderClient(
-  provider: SocialAuthProvider,
+  provider: OAuthAccountConnectionProvider,
   externalId = `${provider.toLowerCase()}-external-id`,
-): SocialAuthProviderClient {
+): AccountConnectionProviderClient {
   return {
     provider,
     createAuthorizationUrl: vi.fn().mockReturnValue(`https://provider.test/${provider.toLowerCase()}/authorize`),
@@ -67,6 +67,7 @@ function createDependencies() {
     providerClients: {
       GOOGLE: createProviderClient('GOOGLE'),
       DISCORD: createProviderClient('DISCORD'),
+      MYANIMELIST: createProviderClient('MYANIMELIST'),
     },
     steamClient: {
       createAuthorizationUrl: vi.fn().mockReturnValue('https://steamcommunity.com/openid/login?openid.mode=checkid_setup'),
@@ -91,7 +92,7 @@ function createDependencies() {
 async function issueState(
   service: ReturnType<typeof createAccountConnectionService>,
   dependencies: ReturnType<typeof createDependencies>,
-  provider: SocialAuthProvider,
+  provider: OAuthAccountConnectionProvider,
   mode: 'link' | 'reauth' = 'link',
 ): Promise<string> {
   if (mode === 'reauth') {
@@ -141,6 +142,7 @@ async function issueSteamState(
 describe('account connection service', () => {
   afterEach(() => {
     vi.useRealTimers();
+    process.env = { ...originalEnv };
   });
 
   it('lista contas conectadas sem expor tokens', async () => {
@@ -314,6 +316,94 @@ describe('account connection service', () => {
     });
   });
 
+  it('inicia linking MyAnimeList com PKCE quando OAuth esta configurado', async () => {
+    process.env['MYANIMELIST_CLIENT_ID'] = 'mal-client-id';
+    process.env['MYANIMELIST_CLIENT_SECRET'] = 'mal-client-secret';
+    process.env['MYANIMELIST_REDIRECT_URI'] = 'http://localhost/api/auth/accounts/myanimelist/link/callback';
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+
+    const result = await service.startLink({ userId: 'user-id-1', provider: 'myanimelist' });
+
+    expect(result).toMatchObject({
+      provider: 'MYANIMELIST',
+      authorizationUrl: 'https://provider.test/myanimelist/authorize',
+    });
+    expect(dependencies.providerClients.MYANIMELIST.createAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.stringContaining('.'),
+        nonce: expect.any(String),
+        redirectUri: 'http://localhost/api/auth/accounts/myanimelist/link/callback',
+        codeChallenge: expect.stringMatching(/^[A-Za-z0-9_-]+$/u),
+      }),
+    );
+  });
+
+  it('conecta MyAnimeList como conta conectada sem criar login social', async () => {
+    process.env['MYANIMELIST_CLIENT_ID'] = 'mal-client-id';
+    process.env['MYANIMELIST_CLIENT_SECRET'] = 'mal-client-secret';
+    process.env['MYANIMELIST_REDIRECT_URI'] = 'http://localhost/api/auth/accounts/myanimelist/link/callback';
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'MYANIMELIST');
+
+    const result = await service.completeLink({
+      provider: 'myanimelist',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(result).toMatchObject({
+      provider: 'MYANIMELIST',
+      externalId: 'myanimelist-external-id',
+      status: 'CONNECTED',
+      connectionType: 'CONNECTED_ACCOUNT',
+    });
+    expect(dependencies.providerClients.MYANIMELIST.exchangeCodeForIdentity).toHaveBeenCalledWith(
+      'oauth-code',
+      expect.objectContaining({
+        redirectUri: 'http://localhost/api/auth/accounts/myanimelist/link/callback',
+        codeVerifier: expect.stringMatching(/^[A-Za-z0-9_-]+$/u),
+      }),
+    );
+    expect(dependencies.connectedAccountService.connectExternalIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-id-1',
+        provider: 'MYANIMELIST',
+        externalId: 'myanimelist-external-id',
+        connectionType: 'CONNECTED_ACCOUNT',
+        accessToken: 'myanimelist-access-token',
+        refreshToken: 'myanimelist-refresh-token',
+      }),
+    );
+  });
+
+  it('falha callback MyAnimeList quando verifier PKCE nao existe mais', async () => {
+    process.env['MYANIMELIST_CLIENT_ID'] = 'mal-client-id';
+    process.env['MYANIMELIST_CLIENT_SECRET'] = 'mal-client-secret';
+    process.env['MYANIMELIST_REDIRECT_URI'] = 'http://localhost/api/auth/accounts/myanimelist/link/callback';
+    const dependencies = createDependencies();
+    const pkceStore = {
+      store: vi.fn().mockResolvedValue(undefined),
+      consume: vi.fn().mockResolvedValue(null),
+    };
+    const service = createAccountConnectionService({
+      ...dependencies,
+      pkceStore,
+    });
+    const state = await issueState(service, dependencies, 'MYANIMELIST');
+
+    await expect(service.completeLink({
+      provider: 'myanimelist',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_state',
+    });
+    expect(dependencies.providerClients.MYANIMELIST.exchangeCodeForIdentity).not.toHaveBeenCalled();
+  });
+
   it('conecta identidade externa ao usuario autenticado sem criar conta CLUTCH', async () => {
     const dependencies = createDependencies();
     const service = createAccountConnectionService(dependencies);
@@ -396,6 +486,31 @@ describe('account connection service', () => {
 
     await expect(service.completeLink({
       provider: 'discord',
+      code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'identity_conflict',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).not.toHaveBeenCalled();
+  });
+
+  it('bloqueia MyAnimeList quando identidade externa pertence a outro usuario', async () => {
+    process.env['MYANIMELIST_CLIENT_ID'] = 'mal-client-id';
+    process.env['MYANIMELIST_CLIENT_SECRET'] = 'mal-client-secret';
+    process.env['MYANIMELIST_REDIRECT_URI'] = 'http://localhost/api/auth/accounts/myanimelist/link/callback';
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'MYANIMELIST');
+    dependencies.repository.findByProviderExternalId.mockResolvedValueOnce(createAccount({
+      provider: 'MYANIMELIST',
+      externalId: 'myanimelist-external-id',
+      userId: 'other-user-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+    }));
+
+    await expect(service.completeLink({
+      provider: 'myanimelist',
       code: 'oauth-code',
       state,
     })).rejects.toMatchObject({
@@ -766,6 +881,43 @@ describe('account connection service', () => {
         userId: 'user-id-1',
         provider: 'DISCORD',
         externalId: 'discord-external-id',
+        connectionType: 'CONNECTED_ACCOUNT',
+        status: 'CONNECTED',
+      }),
+    );
+  });
+
+  it('reconecta MyAnimeList mantendo conta conectada e mesmo externalId', async () => {
+    process.env['MYANIMELIST_CLIENT_ID'] = 'mal-client-id';
+    process.env['MYANIMELIST_CLIENT_SECRET'] = 'mal-client-secret';
+    process.env['MYANIMELIST_REDIRECT_URI'] = 'http://localhost/api/auth/accounts/myanimelist/link/callback';
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'MYANIMELIST', 'reauth');
+    dependencies.repository.findByUserProvider.mockResolvedValueOnce(createAccount({
+      provider: 'MYANIMELIST',
+      externalId: 'myanimelist-external-id',
+      connectionType: 'CONNECTED_ACCOUNT',
+      status: 'NEEDS_REAUTH',
+    }));
+
+    const result = await service.completeReauth({
+      provider: 'myanimelist',
+      code: 'oauth-code',
+      state,
+    });
+
+    expect(result).toMatchObject({
+      provider: 'MYANIMELIST',
+      externalId: 'myanimelist-external-id',
+      status: 'CONNECTED',
+      connectionType: 'CONNECTED_ACCOUNT',
+    });
+    expect(dependencies.connectedAccountService.connectExternalIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-id-1',
+        provider: 'MYANIMELIST',
+        externalId: 'myanimelist-external-id',
         connectionType: 'CONNECTED_ACCOUNT',
         status: 'CONNECTED',
       }),

--- a/backend/tests/unit/services/account-connection.service.test.ts
+++ b/backend/tests/unit/services/account-connection.service.test.ts
@@ -153,6 +153,11 @@ describe('account connection service', () => {
         externalId: 'discord-user-id',
         connectionType: 'CONNECTED_ACCOUNT',
         status: 'NEEDS_REAUTH',
+        metadata: {
+          rawProfile: { id: 'discord-user-id' },
+          code: 'oauth-code',
+          accessToken: 'discord-access-token',
+        },
       }),
     ]);
     const service = createAccountConnectionService(dependencies);
@@ -170,6 +175,10 @@ describe('account connection service', () => {
     });
     expect(result.accounts[0]).not.toHaveProperty('accessToken');
     expect(result.accounts[0]).not.toHaveProperty('refreshToken');
+    expect(result.accounts[0]).not.toHaveProperty('metadata');
+    expect(JSON.stringify(result.accounts[0])).not.toContain('rawProfile');
+    expect(JSON.stringify(result.accounts[0])).not.toContain('oauth-code');
+    expect(JSON.stringify(result.accounts[0])).not.toContain('discord-access-token');
     expect(result.providers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -396,6 +405,32 @@ describe('account connection service', () => {
     await expect(service.completeLink({
       provider: 'myanimelist',
       code: 'oauth-code',
+      state,
+    })).rejects.toMatchObject({
+      statusCode: 400,
+      reason: 'invalid_state',
+    });
+    expect(dependencies.providerClients.MYANIMELIST.exchangeCodeForIdentity).not.toHaveBeenCalled();
+  });
+
+  it('falha callback MyAnimeList com state reutilizado antes de trocar token novamente', async () => {
+    process.env['MYANIMELIST_CLIENT_ID'] = 'mal-client-id';
+    process.env['MYANIMELIST_CLIENT_SECRET'] = 'mal-client-secret';
+    process.env['MYANIMELIST_REDIRECT_URI'] = 'http://localhost/api/auth/accounts/myanimelist/link/callback';
+    const dependencies = createDependencies();
+    const service = createAccountConnectionService(dependencies);
+    const state = await issueState(service, dependencies, 'MYANIMELIST');
+
+    await service.completeLink({
+      provider: 'myanimelist',
+      code: 'oauth-code',
+      state,
+    });
+
+    vi.mocked(dependencies.providerClients.MYANIMELIST.exchangeCodeForIdentity).mockClear();
+    await expect(service.completeLink({
+      provider: 'myanimelist',
+      code: 'oauth-code-again',
       state,
     })).rejects.toMatchObject({
       statusCode: 400,

--- a/frontend/src/components/settings/connection-center.tsx
+++ b/frontend/src/components/settings/connection-center.tsx
@@ -50,7 +50,7 @@ const PROVIDER_COPY: Partial<Record<ConnectedAccountProvider, {
     connectionTypeLabel: 'Conta conectada experimental',
   },
   MYANIMELIST: {
-    description: 'Provider planejado para showcase otaku; OAuth/API ainda nao estao habilitados nesta versao.',
+    description: 'Conexao OAuth2/PKCE para identidade MyAnimeList. Importacao de listas fica fora deste fluxo.',
     connectionTypeLabel: 'Conta conectada otaku',
   },
 };
@@ -520,8 +520,8 @@ export function ConnectionCenter({ onRedirect }: ConnectionCenterProps = {}) {
             Nenhuma conta conectada
           </h3>
           <p className="text-sm leading-6 text-secondary">
-            Conecte Google ou Discord por OAuth, use os formularios de Steam e Epic
-            nesta pagina, e acompanhe providers planejados quando estiverem indisponiveis.
+            Conecte Google, Discord, Steam ou MyAnimeList quando o provider estiver configurado,
+            e use os formularios legados desta pagina apenas quando indicados.
           </p>
         </Card>
       ) : null}

--- a/frontend/tests/unit/components/connection-center.test.tsx
+++ b/frontend/tests/unit/components/connection-center.test.tsx
@@ -165,9 +165,37 @@ describe('ConnectionCenter', () => {
 
     expect(myAnimeListCard).toHaveTextContent('MyAnimeList');
     expect(myAnimeListCard).toHaveTextContent('Indisponivel');
-    expect(myAnimeListCard).toHaveTextContent(/OAuth\/API ainda nao estao habilitados/i);
+    expect(myAnimeListCard).toHaveTextContent(/OAuth2\/PKCE/i);
     expect(within(myAnimeListCard).queryByRole('button', { name: /conectar myanimelist/i })).not.toBeInTheDocument();
     expect(mockedStartAccountLink).not.toHaveBeenCalled();
+  });
+
+  it('renderiza MyAnimeList conectavel quando backend declara OAUTH_CONNECT', async () => {
+    const onRedirect = vi.fn();
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions.map((provider) =>
+        provider.provider === 'MYANIMELIST'
+          ? {
+            ...provider,
+            status: 'CONNECTED',
+            capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+          }
+          : provider),
+      accounts: [],
+    });
+    mockedStartAccountLink.mockResolvedValue({
+      provider: 'MYANIMELIST',
+      authorizationUrl: 'https://myanimelist.net/v1/oauth2/authorize?state=signed-state',
+    });
+
+    renderWithQuery(<ConnectionCenter onRedirect={onRedirect} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /conectar myanimelist/i }));
+
+    await waitFor(() => {
+      expect(mockedStartAccountLink).toHaveBeenCalledWith('MYANIMELIST', expect.anything());
+    });
+    expect(onRedirect).toHaveBeenCalledWith('https://myanimelist.net/v1/oauth2/authorize?state=signed-state');
   });
 
   it('renderiza Steam pelo provider registry com acao OpenID sem social login', async () => {

--- a/frontend/tests/unit/routes/auth-account-route.test.ts
+++ b/frontend/tests/unit/routes/auth-account-route.test.ts
@@ -94,6 +94,41 @@ describe('auth account connection frontend routes', () => {
     expect(location).not.toContain('76561198000000000');
   });
 
+  it('redireciona callback MyAnimeList sem propagar code ou state', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        'http://backend.test/auth/accounts/myanimelist/link/callback?code=oauth-code&state=signed-state',
+      );
+
+      return new Response(
+        JSON.stringify({
+          provider: 'MYANIMELIST',
+          externalId: '123456',
+          status: 'CONNECTED',
+          connectionType: 'CONNECTED_ACCOUNT',
+          message: 'MyAnimeList vinculado com sucesso.',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }) as typeof fetch);
+
+    const response = await completeAccountLink(
+      new NextRequest('http://localhost/api/auth/accounts/myanimelist/link/callback?code=oauth-code&state=signed-state'),
+      { params: Promise.resolve({ provider: 'myanimelist' }) },
+    );
+    const location = response.headers.get('location') ?? '';
+
+    expect(response.status).toBe(307);
+    expect(location).toContain('connectionStatus=success');
+    expect(location).toContain('MyAnimeList+vinculado');
+    expect(location).not.toContain('oauth-code');
+    expect(location).not.toContain('signed-state');
+    expect(location).not.toContain('123456');
+  });
+
   it('redireciona erro de linking sem expor payload sensivel', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(
       JSON.stringify({


### PR DESCRIPTION
## Resumo
Implementa o primeiro slice real de conexão MyAnimeList via OAuth2/PKCE dentro da foundation de connected accounts. O fluxo reutiliza `/auth/accounts/:provider/link/*`, mantém MyAnimeList fora de social login e não importa listas de anime/manga nesta PR.

## O que foi alterado
- Backend:
  - adiciona client OAuth2/PKCE para MyAnimeList com authorization URL, token exchange e busca de identidade autenticada em `users/@me`;
  - usa `id` da MyAnimeList como `externalId` forte para ownership externo;
  - ativa `OAUTH_CONNECT` para `MYANIMELIST` apenas quando `MYANIMELIST_CLIENT_ID`, `MYANIMELIST_CLIENT_SECRET` e redirect URI estão configurados;
  - adiciona store server-side com TTL para `code_verifier`, separado do `state` público;
  - persiste MyAnimeList como `CONNECTED_ACCOUNT`, não como `SOCIAL_LOGIN`.
- Frontend:
  - ajusta o Connection Center para representar MyAnimeList como OAuth2/PKCE quando o backend declarar capability real;
  - mantém estado indisponível honesto quando o backend não declarar `OAUTH_CONNECT`;
  - cobre callback sem propagar `code`, `state` ou identificador externo no redirect final.
- Configuração e testes:
  - documenta envs MyAnimeList no `.env.example`;
  - adiciona testes unitários/integrados para registry, client OAuth MAL, account linking, rota auth e Connection Center.

## Motivação
A #274 deixou MyAnimeList como provider planejado/indisponível porque ainda não havia client OAuth seguro no repo. Esta PR entrega o primeiro caminho real de conexão, mantendo tokens server-side e criptografados pela foundation existente, sem antecipar importação de listas.

## Como validar
- `cd backend && npm run test -- tests/unit/providers/provider-registry.test.ts tests/unit/providers/myanimelist-oauth.client.test.ts tests/unit/services/account-connection.service.test.ts tests/integration/routes/auth.routes.test.ts`
- `cd backend && npm run typecheck`
- `cd backend && npm run lint`
- `cd backend && npm run build`
- `cd frontend && npm run test -- tests/unit/components/connection-center.test.tsx tests/unit/routes/auth-account-route.test.ts tests/unit/services/integrations.test.ts`
- `cd frontend && npm run test:coverage`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Riscos e impactos
- MyAnimeList usa PKCE com método `plain`, conforme referências consultadas; o verifier fica em store server-side com TTL e consumo único.
- Ambientes sem envs MyAnimeList continuam mostrando o provider como indisponível, sem conexão falsa.
- Não há smoke OAuth real nesta PR porque não há client secret/redirect URI reais no ambiente local.
- `npm run test:coverage` do backend falhou localmente em duas suítes por Postgres indisponível em `localhost:5432`; os testes focados do slice passaram.

## Evidências
- Backend focado: 4 arquivos de teste, 98 testes passaram.
- Frontend focado: 3 arquivos de teste, 37 testes passaram.
- Frontend coverage: 70 arquivos, 257 testes passaram, cobertura global 82,31%.
- Backend lint passou com 3 warnings preexistentes em `src/config/rate-limit.ts`.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #288