### PR TITLE
feat(otaku): importar resumo inicial do MyAnimeList

### DIFF
--- a/backend/prisma/migrations/20260430162000_add_mal_media_import_fields/migration.sql
+++ b/backend/prisma/migrations/20260430162000_add_mal_media_import_fields/migration.sql
@@ -1,0 +1,12 @@
+-- Adds stable external identifiers for imported media titles and basic per-user progress.
+-- Existing media titles remain local/private because externalSource and externalId stay null.
+ALTER TABLE "media_titles"
+  ADD COLUMN "externalSource" "Platform",
+  ADD COLUMN "externalId" TEXT;
+
+CREATE UNIQUE INDEX "media_titles_externalSource_externalId_kind_key"
+  ON "media_titles"("externalSource", "externalId", "kind");
+
+ALTER TABLE "user_media_entries"
+  ADD COLUMN "progress" INTEGER,
+  ADD COLUMN "score" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -247,11 +247,14 @@ model MediaTitle {
   kind           MediaKind
   canonicalTitle String
   coverUrl       String?
+  externalSource Platform?
+  externalId     String?
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
 
   userEntries UserMediaEntry[]
 
+  @@unique([externalSource, externalId, kind])
   @@map("media_titles")
 }
 
@@ -260,6 +263,8 @@ model UserMediaEntry {
   userId       String
   mediaTitleId String
   status       MediaConsumptionStatus
+  progress     Int?
+  score        Int?
   showcaseRank Int?
   createdAt    DateTime               @default(now())
   updatedAt    DateTime               @updatedAt

--- a/backend/src/api/routes/integrations.routes.ts
+++ b/backend/src/api/routes/integrations.routes.ts
@@ -103,6 +103,21 @@ export async function integrationRoutes(app: FastifyInstance): Promise<void> {
     },
   );
 
+  // ── POST /integrations/myanimelist/import ───────────────
+  app.post(
+    '/myanimelist/import',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      try {
+        const resultPayload = await app.integrationsService.importMyAnimeListLists(request.userId);
+        return reply.status(200).send(resultPayload);
+      } catch (error) {
+        const integrationError = replyWithIntegrationError(request, error);
+        return reply.status(integrationError.statusCode).send(integrationError.payload);
+      }
+    },
+  );
+
   // ── GET /integrations/igdb/search ───────────────────────
   app.get<{ Querystring: { q: string } }>(
     '/igdb/search',

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -1,8 +1,12 @@
 /* eslint-disable no-unused-vars */
 import { prisma } from '../../infra/database/client';
 import type {
+  MediaConsumptionStatus,
+  MediaKind,
   PlatformIntegrationDataSource,
+  PlatformIntegrationStatus,
 } from '@prisma/client';
+import { revealSensitiveToken } from '../../config/protected-token';
 import { buildExperimentalEpicExternalId } from '../providers/epic-identity';
 import {
   createIntegrationError,
@@ -11,6 +15,12 @@ import {
 } from '../../infra/integrations/integration.errors';
 import { epicService, type EpicGame } from '../../infra/integrations/epic/epic.service';
 import { igdbService, type IgdbGame } from '../../infra/integrations/igdb/igdb.service';
+import {
+  myAnimeListListClient,
+  type MyAnimeListListClient,
+  type MyAnimeListListItem,
+  type MyAnimeListListStatus,
+} from '../../infra/integrations/myanimelist/myanimelist-list.client';
 import { steamService, type SteamGame } from '../../infra/integrations/steam/steam.service';
 import { writeBackendRuntimeLog } from '../../config/logging';
 import {
@@ -18,10 +28,11 @@ import {
   createConnectedAccountService,
 } from './connected-account.service';
 
-type PlatformIntegrationPlatform = 'STEAM' | 'EPIC';
+type PlatformIntegrationPlatform = 'STEAM' | 'EPIC' | 'MYANIMELIST';
 
 type PersistedIntegration = {
   externalId: string;
+  status: PlatformIntegrationStatus;
   dataSource: PlatformIntegrationDataSource;
   accessToken?: string | null;
 };
@@ -35,6 +46,13 @@ type PersistIntegrationInput = {
 type SteamIntegrationClient = Pick<typeof steamService, 'validateSteamId' | 'getOwnedGames'>;
 type IgdbIntegrationClient = Pick<typeof igdbService, 'searchGame' | 'searchGames'>;
 type EpicIntegrationClient = Pick<typeof epicService, 'validateToken' | 'getLibrary'>;
+
+export type MyAnimeListImportResult = {
+  imported: number;
+  anime: number;
+  manga: number;
+  message: string;
+};
 
 type IntegrationsPersistence = {
   upsertPlatformIntegration(
@@ -55,6 +73,25 @@ type IntegrationsPersistence = {
     userId: string,
     game: EpicGame,
   ): Promise<void>;
+  upsertOtakuMediaEntry?(
+    userId: string,
+    item: NormalizedMyAnimeListImportItem,
+  ): Promise<void>;
+  touchPlatformIntegrationLastSyncAt?(
+    userId: string,
+    platform: PlatformIntegrationPlatform,
+    syncedAt: Date,
+  ): Promise<void>;
+};
+
+type NormalizedMyAnimeListImportItem = {
+  externalId: string;
+  title: string;
+  kind: MediaKind;
+  coverUrl: string | null;
+  status: MediaConsumptionStatus;
+  progress: number | null;
+  score: number | null;
 };
 
 export type IntegrationsService = ReturnType<typeof createIntegrationsService>;
@@ -103,6 +140,7 @@ export function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
 
       return {
         externalId: integration.externalId,
+        status: integration.status,
         dataSource: integration.dataSource,
         accessToken: integration.accessToken,
       };
@@ -156,6 +194,92 @@ export function createPrismaIntegrationsPersistence(): IntegrationsPersistence {
         },
       });
     },
+    async upsertOtakuMediaEntry(userId, item): Promise<void> {
+      const mediaTitle = await prisma.mediaTitle.upsert({
+        where: {
+          externalSource_externalId_kind: {
+            externalSource: 'MYANIMELIST',
+            externalId: item.externalId,
+            kind: item.kind,
+          },
+        },
+        create: {
+          kind: item.kind,
+          canonicalTitle: item.title,
+          coverUrl: item.coverUrl,
+          externalSource: 'MYANIMELIST',
+          externalId: item.externalId,
+        },
+        update: {
+          canonicalTitle: item.title,
+          coverUrl: item.coverUrl,
+        },
+      });
+
+      await prisma.userMediaEntry.upsert({
+        where: {
+          userId_mediaTitleId: {
+            userId,
+            mediaTitleId: mediaTitle.id,
+          },
+        },
+        create: {
+          userId,
+          mediaTitleId: mediaTitle.id,
+          status: item.status,
+          progress: item.progress,
+          score: item.score,
+          showcaseRank: null,
+        },
+        update: {
+          status: item.status,
+          progress: item.progress,
+          score: item.score,
+        },
+      });
+    },
+    async touchPlatformIntegrationLastSyncAt(userId, platform, syncedAt): Promise<void> {
+      await prisma.platformIntegration.update({
+        where: {
+          userId_platform: {
+            userId,
+            platform,
+          },
+        },
+        data: {
+          lastSyncAt: syncedAt,
+        },
+      });
+    },
+  };
+}
+
+export function mapMyAnimeListStatus(status: MyAnimeListListStatus): MediaConsumptionStatus {
+  switch (status) {
+    case 'watching':
+    case 'reading':
+      return 'CONSUMING';
+    case 'completed':
+      return 'COMPLETED';
+    case 'plan_to_watch':
+    case 'plan_to_read':
+      return 'PLANNING';
+    case 'on_hold':
+      return 'PAUSED';
+    case 'dropped':
+      return 'DROPPED';
+  }
+}
+
+function normalizeMyAnimeListImportItem(item: MyAnimeListListItem): NormalizedMyAnimeListImportItem {
+  return {
+    externalId: item.id,
+    title: item.title,
+    kind: item.kind,
+    coverUrl: item.coverUrl,
+    status: mapMyAnimeListStatus(item.status),
+    progress: item.progress,
+    score: item.score,
   };
 }
 
@@ -189,16 +313,19 @@ export function createIntegrationsService(dependencies?: {
   steamClient?: SteamIntegrationClient;
   igdbClient?: IgdbIntegrationClient;
   epicClient?: EpicIntegrationClient;
+  myAnimeListClient?: MyAnimeListListClient;
   persistence?: IntegrationsPersistence;
 }): {
   connectSteam: (userId: string, steamId: string) => Promise<{ imported: number; message: string }>;
   syncSteamLibrary: (userId: string) => Promise<{ synced: number; message: string }>;
   searchIgdbGames: (query: string) => Promise<IgdbGame[]>;
   connectEpic: (userId: string, authToken: string) => Promise<{ imported: number; message: string }>;
+  importMyAnimeListLists: (userId: string) => Promise<MyAnimeListImportResult>;
 } {
   const steamClient = dependencies?.steamClient ?? steamService;
   const igdbClient = dependencies?.igdbClient ?? igdbService;
   const epicClient = dependencies?.epicClient ?? epicService;
+  const myAnimeListClient = dependencies?.myAnimeListClient ?? myAnimeListListClient;
   const persistence = dependencies?.persistence ?? createPrismaIntegrationsPersistence();
 
   return {
@@ -323,6 +450,86 @@ export function createIntegrationsService(dependencies?: {
       return {
         imported: games.length,
         message: `Epic conectado. ${games.length} jogos importados.`,
+      };
+    },
+
+    async importMyAnimeListLists(userId: string): Promise<MyAnimeListImportResult> {
+      const integration = await persistence.findPlatformIntegration(userId, 'MYANIMELIST');
+
+      if (!integration) {
+        throw createIntegrationError(
+          'myanimelist',
+          404,
+          'not_connected',
+          'MyAnimeList não conectado.',
+        );
+      }
+
+      if (integration.status !== 'CONNECTED') {
+        throw createIntegrationError(
+          'myanimelist',
+          409,
+          'reauth_required',
+          'Reconecte o MyAnimeList antes de importar listas.',
+        );
+      }
+
+      let accessToken: string | null;
+
+      try {
+        accessToken = revealSensitiveToken(integration.accessToken);
+      } catch (error) {
+        if (error instanceof Error && error.message === 'Token protegido inválido.') {
+          throw createIntegrationError(
+            'myanimelist',
+            409,
+            'reauth_required',
+            'Reconecte o MyAnimeList antes de importar listas.',
+          );
+        }
+
+        throw error;
+      }
+
+      if (!accessToken) {
+        throw createIntegrationError(
+          'myanimelist',
+          409,
+          'reauth_required',
+          'Reconecte o MyAnimeList antes de importar listas.',
+        );
+      }
+
+      let animeItems: MyAnimeListListItem[];
+      let mangaItems: MyAnimeListListItem[];
+
+      [animeItems, mangaItems] = await Promise.all([
+        myAnimeListClient.fetchAnimeList(accessToken),
+        myAnimeListClient.fetchMangaList(accessToken),
+      ]);
+
+      const normalizedItems = [...animeItems, ...mangaItems].map(normalizeMyAnimeListImportItem);
+
+      if (!persistence.upsertOtakuMediaEntry || !persistence.touchPlatformIntegrationLastSyncAt) {
+        throw createIntegrationError(
+          'myanimelist',
+          503,
+          'misconfigured',
+          'Importação MyAnimeList indisponível no runtime atual.',
+        );
+      }
+
+      for (const item of normalizedItems) {
+        await persistence.upsertOtakuMediaEntry(userId, item);
+      }
+
+      await persistence.touchPlatformIntegrationLastSyncAt(userId, 'MYANIMELIST', new Date());
+
+      return {
+        imported: normalizedItems.length,
+        anime: animeItems.length,
+        manga: mangaItems.length,
+        message: `${normalizedItems.length} itens MyAnimeList importados de forma privada.`,
       };
     },
   };

--- a/backend/src/core/services/integrations.service.ts
+++ b/backend/src/core/services/integrations.service.ts
@@ -479,7 +479,7 @@ export function createIntegrationsService(dependencies?: {
       try {
         accessToken = revealSensitiveToken(integration.accessToken);
       } catch (error) {
-        if (error instanceof Error && error.message === 'Token protegido inválido.') {
+        if (error instanceof Error) {
           throw createIntegrationError(
             'myanimelist',
             409,

--- a/backend/src/infra/integrations/integration.errors.ts
+++ b/backend/src/infra/integrations/integration.errors.ts
@@ -8,6 +8,7 @@ export type IntegrationName = 'steam' | 'igdb' | 'epic' | 'discord' | 'google' |
 export type IntegrationErrorReason =
   | 'invalid_request'
   | 'invalid_credentials'
+  | 'reauth_required'
   | 'conflict'
   | 'not_found'
   | 'not_connected'

--- a/backend/src/infra/integrations/myanimelist/myanimelist-list.client.ts
+++ b/backend/src/infra/integrations/myanimelist/myanimelist-list.client.ts
@@ -1,0 +1,183 @@
+/* eslint-disable no-unused-vars */
+import axios from 'axios';
+import {
+  createIntegrationError,
+  translateUpstreamError,
+} from '../integration.errors';
+
+const MYANIMELIST_API_BASE_URL = 'https://api.myanimelist.net/v2';
+const MYANIMELIST_LIST_TIMEOUT_MS = 10_000;
+const MYANIMELIST_LIST_LIMIT = 50;
+const MYANIMELIST_LIST_FIELDS = 'list_status,main_picture';
+
+export type MyAnimeListMediaKind = 'ANIME' | 'MANGA';
+
+export type MyAnimeListListStatus =
+  | 'watching'
+  | 'reading'
+  | 'completed'
+  | 'on_hold'
+  | 'dropped'
+  | 'plan_to_watch'
+  | 'plan_to_read';
+
+export type MyAnimeListListItem = {
+  id: string;
+  title: string;
+  kind: MyAnimeListMediaKind;
+  coverUrl: string | null;
+  status: MyAnimeListListStatus;
+  progress: number | null;
+  score: number | null;
+};
+
+type MyAnimeListApiNode = {
+  id?: number | string;
+  title?: string;
+  main_picture?: {
+    medium?: string;
+    large?: string;
+  };
+};
+
+type MyAnimeListApiListStatus = {
+  status?: string;
+  score?: number;
+  num_episodes_watched?: number;
+  num_chapters_read?: number;
+};
+
+type MyAnimeListApiListEntry = {
+  node?: MyAnimeListApiNode;
+  list_status?: MyAnimeListApiListStatus;
+};
+
+type MyAnimeListListResponse = {
+  data?: MyAnimeListApiListEntry[];
+  paging?: {
+    next?: string;
+  };
+};
+
+export type MyAnimeListListClient = {
+  fetchAnimeList(accessToken: string): Promise<MyAnimeListListItem[]>;
+  fetchMangaList(accessToken: string): Promise<MyAnimeListListItem[]>;
+};
+
+function normalizeExternalId(value: MyAnimeListApiNode['id']): string | null {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) {
+    return String(value);
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return null;
+}
+
+function normalizeTitle(value: MyAnimeListApiNode['title']): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function normalizeStatus(value: MyAnimeListApiListStatus['status']): MyAnimeListListStatus | null {
+  const allowedStatuses = new Set<MyAnimeListListStatus>([
+    'watching',
+    'reading',
+    'completed',
+    'on_hold',
+    'dropped',
+    'plan_to_watch',
+    'plan_to_read',
+  ]);
+
+  return typeof value === 'string' && allowedStatuses.has(value as MyAnimeListListStatus)
+    ? value as MyAnimeListListStatus
+    : null;
+}
+
+function normalizeOptionalNonNegativeInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function normalizeListEntry(entry: MyAnimeListApiListEntry, kind: MyAnimeListMediaKind): MyAnimeListListItem | null {
+  const externalId = normalizeExternalId(entry.node?.id);
+  const title = normalizeTitle(entry.node?.title);
+  const status = normalizeStatus(entry.list_status?.status);
+
+  if (!externalId || !title || !status) {
+    return null;
+  }
+
+  return {
+    id: externalId,
+    title,
+    kind,
+    coverUrl: entry.node?.main_picture?.large ?? entry.node?.main_picture?.medium ?? null,
+    status,
+    progress: kind === 'ANIME'
+      ? normalizeOptionalNonNegativeInteger(entry.list_status?.num_episodes_watched)
+      : normalizeOptionalNonNegativeInteger(entry.list_status?.num_chapters_read),
+    score: normalizeOptionalNonNegativeInteger(entry.list_status?.score),
+  };
+}
+
+async function fetchList(
+  accessToken: string,
+  kind: MyAnimeListMediaKind,
+): Promise<MyAnimeListListItem[]> {
+  const path = kind === 'ANIME' ? 'animelist' : 'mangalist';
+
+  try {
+    const response = await axios.get<MyAnimeListListResponse>(
+      `${MYANIMELIST_API_BASE_URL}/users/@me/${path}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        params: {
+          fields: MYANIMELIST_LIST_FIELDS,
+          limit: MYANIMELIST_LIST_LIMIT,
+          offset: 0,
+        },
+        timeout: MYANIMELIST_LIST_TIMEOUT_MS,
+      },
+    );
+
+    return (response.data.data ?? [])
+      .map((entry) => normalizeListEntry(entry, kind))
+      .filter((entry): entry is MyAnimeListListItem => entry !== null);
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'response' in error &&
+      typeof (error as { response?: { status?: number } }).response?.status === 'number' &&
+      [401, 403].includes((error as { response?: { status?: number } }).response?.status as number)
+    ) {
+      throw createIntegrationError(
+        'myanimelist',
+        401,
+        'invalid_credentials',
+        'MyAnimeList precisa ser reconectado antes da importação.',
+      );
+    }
+
+    throw translateUpstreamError(
+      'myanimelist',
+      error,
+      'Listas MyAnimeList indisponíveis no momento.',
+      { targetUrl: `${MYANIMELIST_API_BASE_URL}/users/@me/${path}` },
+    );
+  }
+}
+
+export const myAnimeListListClient: MyAnimeListListClient = {
+  fetchAnimeList(accessToken: string): Promise<MyAnimeListListItem[]> {
+    return fetchList(accessToken, 'ANIME');
+  },
+
+  fetchMangaList(accessToken: string): Promise<MyAnimeListListItem[]> {
+    return fetchList(accessToken, 'MANGA');
+  },
+};

--- a/backend/tests/integration/routes/integrations.routes.test.ts
+++ b/backend/tests/integration/routes/integrations.routes.test.ts
@@ -9,6 +9,7 @@ const createMockIntegrationsService = () => ({
   syncSteamLibrary: vi.fn(),
   searchIgdbGames: vi.fn(),
   connectEpic: vi.fn(),
+  importMyAnimeListLists: vi.fn(),
 });
 
 const createMockDiscordOAuthService = () => ({
@@ -117,6 +118,72 @@ describe('Integrations Routes', () => {
 
       expect(response.statusCode).toBe(404);
       expect(integrationsService.syncSteamLibrary).toHaveBeenCalledWith('user-id-1');
+      await app.close();
+    });
+  });
+
+  describe('POST /integrations/myanimelist/import', () => {
+    it('retorna 401 sem token', async () => {
+      const integrationsService = createMockIntegrationsService();
+      const app = await buildApp({ integrationsService });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/myanimelist/import',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(integrationsService.importMyAnimeListLists).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('retorna resumo da importacao MyAnimeList autenticada sem payload sensivel', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.importMyAnimeListLists.mockResolvedValue({
+        imported: 2,
+        anime: 1,
+        manga: 1,
+        message: '2 itens MyAnimeList importados de forma privada.',
+      });
+      const app = await buildApp({ integrationsService });
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/myanimelist/import',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        imported: 2,
+        anime: 1,
+        manga: 1,
+        message: '2 itens MyAnimeList importados de forma privada.',
+      });
+      expect(JSON.stringify(response.json())).not.toContain('access-token');
+      expect(integrationsService.importMyAnimeListLists).toHaveBeenCalledWith('user-id-1');
+      await app.close();
+    });
+
+    it('retorna erro coerente quando MyAnimeList precisa reconectar', async () => {
+      const integrationsService = createMockIntegrationsService();
+      integrationsService.importMyAnimeListLists.mockRejectedValue(
+        createIntegrationError('myanimelist', 409, 'reauth_required', 'Reconecte o MyAnimeList antes de importar listas.'),
+      );
+      const app = await buildApp({ integrationsService });
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/integrations/myanimelist/import',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json()).toEqual({
+        message: 'Reconecte o MyAnimeList antes de importar listas.',
+      });
       await app.close();
     });
   });

--- a/backend/tests/unit/providers/myanimelist-list.client.test.ts
+++ b/backend/tests/unit/providers/myanimelist-list.client.test.ts
@@ -105,6 +105,47 @@ describe('myAnimeListListClient', () => {
     ]);
   });
 
+  it('ignora status desconhecido sem quebrar os demais itens da pagina inicial', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            node: { id: 1, title: 'Valid Anime' },
+            list_status: { status: 'watching', num_episodes_watched: 3 },
+          },
+          {
+            node: { id: 2, title: 'Unknown Status Anime' },
+            list_status: { status: 'rewatching_later' },
+          },
+        ],
+        paging: { next: 'https://api.myanimelist.net/v2/users/@me/animelist?offset=50' },
+      },
+    });
+
+    const result = await myAnimeListListClient.fetchAnimeList('mal-access-token');
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.myanimelist.net/v2/users/@me/animelist',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          limit: 50,
+          offset: 0,
+        }),
+      }),
+    );
+    expect(result).toEqual([
+      {
+        id: '1',
+        title: 'Valid Anime',
+        kind: 'ANIME',
+        coverUrl: null,
+        status: 'watching',
+        progress: 3,
+        score: null,
+      },
+    ]);
+  });
+
   it('mapeia 401/403 como reauth sem vazar token', async () => {
     vi.mocked(axios.get).mockRejectedValueOnce({
       response: { status: 401 },
@@ -115,6 +156,26 @@ describe('myAnimeListListClient', () => {
       statusCode: 401,
       reason: 'invalid_credentials',
       clientMessage: 'MyAnimeList precisa ser reconectado antes da importação.',
+    });
+  });
+
+  it('traduz rate limit sem vazar authorization header ou payload bruto', async () => {
+    vi.mocked(axios.get).mockRejectedValueOnce({
+      response: {
+        status: 429,
+        data: {
+          error: 'rate_limited',
+          access_token: 'mal-access-token',
+        },
+      },
+      config: { headers: { Authorization: 'Bearer mal-access-token' } },
+    });
+
+    await expect(myAnimeListListClient.fetchMangaList('mal-access-token')).rejects.toMatchObject({
+      statusCode: 503,
+      reason: 'upstream_unavailable',
+      clientMessage: 'Listas MyAnimeList indisponíveis no momento.',
+      message: expect.not.stringContaining('mal-access-token'),
     });
   });
 });

--- a/backend/tests/unit/providers/myanimelist-list.client.test.ts
+++ b/backend/tests/unit/providers/myanimelist-list.client.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios');
+
+import axios from 'axios';
+import { myAnimeListListClient } from '@/infra/integrations/myanimelist/myanimelist-list.client';
+
+describe('myAnimeListListClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('busca anime list com token bearer, limite inicial e normaliza itens minimos', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            node: {
+              id: 5114,
+              title: 'Fullmetal Alchemist: Brotherhood',
+              main_picture: { medium: 'https://cdn.mal/fma-medium.jpg', large: 'https://cdn.mal/fma-large.jpg' },
+            },
+            list_status: {
+              status: 'completed',
+              score: 10,
+              num_episodes_watched: 64,
+            },
+          },
+        ],
+        paging: { next: 'https://api.myanimelist.net/v2/users/@me/animelist?offset=50' },
+      },
+    });
+
+    const result = await myAnimeListListClient.fetchAnimeList('mal-access-token');
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.myanimelist.net/v2/users/@me/animelist',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer mal-access-token' },
+        params: {
+          fields: 'list_status,main_picture',
+          limit: 50,
+          offset: 0,
+        },
+      }),
+    );
+    expect(result).toEqual([
+      {
+        id: '5114',
+        title: 'Fullmetal Alchemist: Brotherhood',
+        kind: 'ANIME',
+        coverUrl: 'https://cdn.mal/fma-large.jpg',
+        status: 'completed',
+        progress: 64,
+        score: 10,
+      },
+    ]);
+  });
+
+  it('busca manga list e ignora registros sem identidade ou status confiavel', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        data: [
+          {
+            node: {
+              id: '2',
+              title: 'Berserk',
+              main_picture: { medium: 'https://cdn.mal/berserk.jpg' },
+            },
+            list_status: {
+              status: 'reading',
+              num_chapters_read: 12,
+            },
+          },
+          {
+            node: { id: 0, title: 'Invalid' },
+            list_status: { status: 'completed' },
+          },
+          {
+            node: { id: 3, title: 'Missing status' },
+            list_status: { status: 'unknown' },
+          },
+        ],
+      },
+    });
+
+    const result = await myAnimeListListClient.fetchMangaList('mal-access-token');
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.myanimelist.net/v2/users/@me/mangalist',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer mal-access-token' },
+      }),
+    );
+    expect(result).toEqual([
+      {
+        id: '2',
+        title: 'Berserk',
+        kind: 'MANGA',
+        coverUrl: 'https://cdn.mal/berserk.jpg',
+        status: 'reading',
+        progress: 12,
+        score: null,
+      },
+    ]);
+  });
+
+  it('mapeia 401/403 como reauth sem vazar token', async () => {
+    vi.mocked(axios.get).mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { headers: { Authorization: 'Bearer mal-access-token' } },
+    });
+
+    await expect(myAnimeListListClient.fetchAnimeList('mal-access-token')).rejects.toMatchObject({
+      statusCode: 401,
+      reason: 'invalid_credentials',
+      clientMessage: 'MyAnimeList precisa ser reconectado antes da importação.',
+    });
+  });
+});

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -190,6 +190,41 @@ describe('integrations service layer', () => {
     expect(persistence.upsertOtakuMediaEntry).not.toHaveBeenCalled();
   });
 
+  it('bloqueia importacao MyAnimeList quando token criptografado esta invalido', async () => {
+    const persistence = {
+      upsertPlatformIntegration: vi.fn(),
+      findPlatformIntegration: vi.fn().mockResolvedValue({
+        externalId: '12345',
+        status: 'CONNECTED',
+        dataSource: 'OFFICIAL',
+        accessToken: 'enc:v1:invalid:protected:token',
+      }),
+      upsertSteamLibraryGame: vi.fn(),
+      upsertEpicLibraryGame: vi.fn(),
+      upsertOtakuMediaEntry: vi.fn(),
+      touchPlatformIntegrationLastSyncAt: vi.fn(),
+    };
+    const myAnimeListClient = {
+      fetchAnimeList: vi.fn(),
+      fetchMangaList: vi.fn(),
+    };
+    const service = createIntegrationsService({
+      steamClient: { validateSteamId: vi.fn(), getOwnedGames: vi.fn() },
+      igdbClient: { searchGame: vi.fn(), searchGames: vi.fn() },
+      epicClient: { validateToken: vi.fn(), getLibrary: vi.fn() },
+      myAnimeListClient,
+      persistence,
+    });
+
+    await expect(service.importMyAnimeListLists('user-id-1')).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'reauth_required',
+      clientMessage: 'Reconecte o MyAnimeList antes de importar listas.',
+    });
+    expect(myAnimeListClient.fetchAnimeList).not.toHaveBeenCalled();
+    expect(persistence.upsertOtakuMediaEntry).not.toHaveBeenCalled();
+  });
+
   it('persiste MediaTitle e UserMediaEntry via upsert sem expor payload bruto', async () => {
     vi.mocked(prisma.mediaTitle.upsert).mockResolvedValue({
       id: 'media-title-id',
@@ -261,6 +296,153 @@ describe('integrations service layer', () => {
       },
     });
     expect(JSON.stringify(vi.mocked(prisma.userMediaEntry.upsert).mock.calls)).not.toContain('access-token');
+  });
+
+  it('usa chave externa composta para evitar duplicidade e colisao entre anime e manga com mesmo MAL id', async () => {
+    vi.mocked(prisma.mediaTitle.upsert)
+      .mockResolvedValueOnce({
+        id: 'anime-media-title-id',
+        kind: 'ANIME',
+        canonicalTitle: 'Shared MAL Id Anime',
+        coverUrl: null,
+        externalSource: 'MYANIMELIST',
+        externalId: '100',
+        createdAt: new Date('2026-04-30T16:00:00.000Z'),
+        updatedAt: new Date('2026-04-30T16:00:00.000Z'),
+      })
+      .mockResolvedValueOnce({
+        id: 'manga-media-title-id',
+        kind: 'MANGA',
+        canonicalTitle: 'Shared MAL Id Manga',
+        coverUrl: null,
+        externalSource: 'MYANIMELIST',
+        externalId: '100',
+        createdAt: new Date('2026-04-30T16:00:00.000Z'),
+        updatedAt: new Date('2026-04-30T16:00:00.000Z'),
+      })
+      .mockResolvedValueOnce({
+        id: 'anime-media-title-id',
+        kind: 'ANIME',
+        canonicalTitle: 'Shared MAL Id Anime',
+        coverUrl: null,
+        externalSource: 'MYANIMELIST',
+        externalId: '100',
+        createdAt: new Date('2026-04-30T16:00:00.000Z'),
+        updatedAt: new Date('2026-04-30T16:00:00.000Z'),
+      });
+    vi.mocked(prisma.userMediaEntry.upsert).mockResolvedValue({
+      id: 'entry-id',
+      userId: 'user-id-1',
+      mediaTitleId: 'anime-media-title-id',
+      status: 'CONSUMING',
+      progress: 1,
+      score: null,
+      showcaseRank: null,
+      createdAt: new Date('2026-04-30T16:00:00.000Z'),
+      updatedAt: new Date('2026-04-30T16:00:00.000Z'),
+    });
+    const persistence = createPrismaIntegrationsPersistence();
+
+    await persistence.upsertOtakuMediaEntry?.('user-id-1', {
+      externalId: '100',
+      title: 'Shared MAL Id Anime',
+      kind: 'ANIME',
+      coverUrl: null,
+      status: 'CONSUMING',
+      progress: 1,
+      score: null,
+    });
+    await persistence.upsertOtakuMediaEntry?.('user-id-1', {
+      externalId: '100',
+      title: 'Shared MAL Id Manga',
+      kind: 'MANGA',
+      coverUrl: null,
+      status: 'PLANNING',
+      progress: 0,
+      score: null,
+    });
+    await persistence.upsertOtakuMediaEntry?.('user-id-1', {
+      externalId: '100',
+      title: 'Shared MAL Id Anime',
+      kind: 'ANIME',
+      coverUrl: null,
+      status: 'COMPLETED',
+      progress: 12,
+      score: 8,
+    });
+
+    expect(prisma.mediaTitle.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          externalSource_externalId_kind: {
+            externalSource: 'MYANIMELIST',
+            externalId: '100',
+            kind: 'ANIME',
+          },
+        },
+      }),
+    );
+    expect(prisma.mediaTitle.upsert).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          externalSource_externalId_kind: {
+            externalSource: 'MYANIMELIST',
+            externalId: '100',
+            kind: 'MANGA',
+          },
+        },
+      }),
+    );
+    expect(prisma.mediaTitle.upsert).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        where: {
+          externalSource_externalId_kind: {
+            externalSource: 'MYANIMELIST',
+            externalId: '100',
+            kind: 'ANIME',
+          },
+        },
+      }),
+    );
+    expect(prisma.userMediaEntry.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          userId_mediaTitleId: {
+            userId: 'user-id-1',
+            mediaTitleId: 'anime-media-title-id',
+          },
+        },
+      }),
+    );
+    expect(prisma.userMediaEntry.upsert).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          userId_mediaTitleId: {
+            userId: 'user-id-1',
+            mediaTitleId: 'manga-media-title-id',
+          },
+        },
+      }),
+    );
+    expect(prisma.userMediaEntry.upsert).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        where: {
+          userId_mediaTitleId: {
+            userId: 'user-id-1',
+            mediaTitleId: 'anime-media-title-id',
+          },
+        },
+        create: expect.objectContaining({
+          showcaseRank: null,
+        }),
+      }),
+    );
   });
 
   afterEach(() => {

--- a/backend/tests/unit/services/integrations.service.test.ts
+++ b/backend/tests/unit/services/integrations.service.test.ts
@@ -13,7 +13,9 @@ import { redis } from '@/infra/cache/redis';
 import {
   createPrismaIntegrationsPersistence,
   createIntegrationsService,
+  mapMyAnimeListStatus,
 } from '@/core/services/integrations.service';
+import { protectSensitiveToken } from '@/config/protected-token';
 import { IntegrationError } from '@/infra/integrations/integration.errors';
 import { epicService } from '@/infra/integrations/epic/epic.service';
 import { igdbService } from '@/infra/integrations/igdb/igdb.service';
@@ -27,6 +29,12 @@ vi.mock('@/infra/database/client', () => ({
       findUnique: vi.fn(),
     },
     userGameLibrary: {
+      upsert: vi.fn(),
+    },
+    mediaTitle: {
+      upsert: vi.fn(),
+    },
+    userMediaEntry: {
       upsert: vi.fn(),
     },
   },
@@ -48,7 +56,215 @@ describe('integrations service layer', () => {
     vi.clearAllMocks();
   });
 
+  it('mapeia status MyAnimeList para status de consumo CLUTCH', () => {
+    expect(mapMyAnimeListStatus('watching')).toBe('CONSUMING');
+    expect(mapMyAnimeListStatus('reading')).toBe('CONSUMING');
+    expect(mapMyAnimeListStatus('completed')).toBe('COMPLETED');
+    expect(mapMyAnimeListStatus('plan_to_watch')).toBe('PLANNING');
+    expect(mapMyAnimeListStatus('plan_to_read')).toBe('PLANNING');
+    expect(mapMyAnimeListStatus('on_hold')).toBe('PAUSED');
+    expect(mapMyAnimeListStatus('dropped')).toBe('DROPPED');
+  });
+
+  it('importa listas MyAnimeList conectadas e persiste entradas otaku privadas', async () => {
+    const syncedAt = new Date('2026-04-30T16:30:00.000Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(syncedAt);
+    const persistence = {
+      upsertPlatformIntegration: vi.fn(),
+      findPlatformIntegration: vi.fn().mockResolvedValue({
+        externalId: '12345',
+        status: 'CONNECTED',
+        dataSource: 'OFFICIAL',
+        accessToken: protectSensitiveToken('mal-access-token'),
+      }),
+      upsertSteamLibraryGame: vi.fn(),
+      upsertEpicLibraryGame: vi.fn(),
+      upsertOtakuMediaEntry: vi.fn().mockResolvedValue(undefined),
+      touchPlatformIntegrationLastSyncAt: vi.fn().mockResolvedValue(undefined),
+    };
+    const myAnimeListClient = {
+      fetchAnimeList: vi.fn().mockResolvedValue([
+        {
+          id: '5114',
+          title: 'Fullmetal Alchemist: Brotherhood',
+          kind: 'ANIME',
+          coverUrl: 'https://cdn.mal/anime.jpg',
+          status: 'completed',
+          progress: 64,
+          score: 10,
+        },
+      ]),
+      fetchMangaList: vi.fn().mockResolvedValue([
+        {
+          id: '2',
+          title: 'Berserk',
+          kind: 'MANGA',
+          coverUrl: null,
+          status: 'reading',
+          progress: 12,
+          score: 0,
+        },
+      ]),
+    };
+    const service = createIntegrationsService({
+      steamClient: { validateSteamId: vi.fn(), getOwnedGames: vi.fn() },
+      igdbClient: { searchGame: vi.fn(), searchGames: vi.fn() },
+      epicClient: { validateToken: vi.fn(), getLibrary: vi.fn() },
+      myAnimeListClient,
+      persistence,
+    });
+
+    const result = await service.importMyAnimeListLists('user-id-1');
+
+    expect(result).toEqual({
+      imported: 2,
+      anime: 1,
+      manga: 1,
+      message: '2 itens MyAnimeList importados de forma privada.',
+    });
+    expect(myAnimeListClient.fetchAnimeList).toHaveBeenCalledWith('mal-access-token');
+    expect(myAnimeListClient.fetchMangaList).toHaveBeenCalledWith('mal-access-token');
+    expect(persistence.upsertOtakuMediaEntry).toHaveBeenNthCalledWith(1, 'user-id-1', {
+      externalId: '5114',
+      title: 'Fullmetal Alchemist: Brotherhood',
+      kind: 'ANIME',
+      coverUrl: 'https://cdn.mal/anime.jpg',
+      status: 'COMPLETED',
+      progress: 64,
+      score: 10,
+    });
+    expect(persistence.upsertOtakuMediaEntry).toHaveBeenNthCalledWith(2, 'user-id-1', {
+      externalId: '2',
+      title: 'Berserk',
+      kind: 'MANGA',
+      coverUrl: null,
+      status: 'CONSUMING',
+      progress: 12,
+      score: 0,
+    });
+    expect(persistence.touchPlatformIntegrationLastSyncAt).toHaveBeenCalledWith(
+      'user-id-1',
+      'MYANIMELIST',
+      syncedAt,
+    );
+  });
+
+  it('bloqueia importacao MyAnimeList quando conta precisa reconectar ou token esta ausente', async () => {
+    const persistence = {
+      upsertPlatformIntegration: vi.fn(),
+      findPlatformIntegration: vi.fn()
+        .mockResolvedValueOnce({
+          externalId: '12345',
+          status: 'NEEDS_REAUTH',
+          dataSource: 'OFFICIAL',
+          accessToken: protectSensitiveToken('mal-access-token'),
+        })
+        .mockResolvedValueOnce({
+          externalId: '12345',
+          status: 'CONNECTED',
+          dataSource: 'OFFICIAL',
+          accessToken: null,
+        }),
+      upsertSteamLibraryGame: vi.fn(),
+      upsertEpicLibraryGame: vi.fn(),
+      upsertOtakuMediaEntry: vi.fn(),
+      touchPlatformIntegrationLastSyncAt: vi.fn(),
+    };
+    const service = createIntegrationsService({
+      steamClient: { validateSteamId: vi.fn(), getOwnedGames: vi.fn() },
+      igdbClient: { searchGame: vi.fn(), searchGames: vi.fn() },
+      epicClient: { validateToken: vi.fn(), getLibrary: vi.fn() },
+      myAnimeListClient: { fetchAnimeList: vi.fn(), fetchMangaList: vi.fn() },
+      persistence,
+    });
+
+    await expect(service.importMyAnimeListLists('user-id-1')).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'reauth_required',
+    });
+    await expect(service.importMyAnimeListLists('user-id-1')).rejects.toMatchObject({
+      statusCode: 409,
+      reason: 'reauth_required',
+    });
+    expect(persistence.upsertOtakuMediaEntry).not.toHaveBeenCalled();
+  });
+
+  it('persiste MediaTitle e UserMediaEntry via upsert sem expor payload bruto', async () => {
+    vi.mocked(prisma.mediaTitle.upsert).mockResolvedValue({
+      id: 'media-title-id',
+      kind: 'ANIME',
+      canonicalTitle: 'Sousou no Frieren',
+      coverUrl: 'https://cdn.mal/frieren.jpg',
+      externalSource: 'MYANIMELIST',
+      externalId: '52991',
+      createdAt: new Date('2026-04-30T16:00:00.000Z'),
+      updatedAt: new Date('2026-04-30T16:00:00.000Z'),
+    });
+    vi.mocked(prisma.userMediaEntry.upsert).mockResolvedValue({
+      id: 'entry-id',
+      userId: 'user-id-1',
+      mediaTitleId: 'media-title-id',
+      status: 'CONSUMING',
+      progress: 4,
+      score: 9,
+      showcaseRank: null,
+      createdAt: new Date('2026-04-30T16:00:00.000Z'),
+      updatedAt: new Date('2026-04-30T16:00:00.000Z'),
+    });
+    const persistence = createPrismaIntegrationsPersistence();
+    expect(persistence.upsertOtakuMediaEntry).toBeDefined();
+
+    await persistence.upsertOtakuMediaEntry?.('user-id-1', {
+      externalId: '52991',
+      title: 'Sousou no Frieren',
+      kind: 'ANIME',
+      coverUrl: 'https://cdn.mal/frieren.jpg',
+      status: 'CONSUMING',
+      progress: 4,
+      score: 9,
+    });
+
+    expect(prisma.mediaTitle.upsert).toHaveBeenCalledWith({
+      where: {
+        externalSource_externalId_kind: {
+          externalSource: 'MYANIMELIST',
+          externalId: '52991',
+          kind: 'ANIME',
+        },
+      },
+      create: expect.objectContaining({
+        externalSource: 'MYANIMELIST',
+        externalId: '52991',
+      }),
+      update: {
+        canonicalTitle: 'Sousou no Frieren',
+        coverUrl: 'https://cdn.mal/frieren.jpg',
+      },
+    });
+    expect(prisma.userMediaEntry.upsert).toHaveBeenCalledWith({
+      where: {
+        userId_mediaTitleId: {
+          userId: 'user-id-1',
+          mediaTitleId: 'media-title-id',
+        },
+      },
+      create: expect.objectContaining({
+        showcaseRank: null,
+        progress: 4,
+        score: 9,
+      }),
+      update: {
+        status: 'CONSUMING',
+        progress: 4,
+        score: 9,
+      },
+    });
+    expect(JSON.stringify(vi.mocked(prisma.userMediaEntry.upsert).mock.calls)).not.toContain('access-token');
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     process.env = { ...originalEnv };
   });
 

--- a/frontend/src/components/settings/connection-center.tsx
+++ b/frontend/src/components/settings/connection-center.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@/schemas/integrations';
 import {
   fetchConnectedAccounts,
+  importMyAnimeListLists,
   IntegrationsRequestError,
   startAccountLink,
   startAccountReauth,
@@ -175,6 +176,7 @@ type ConnectionProviderRowProps = {
   onConnect(provider: ConnectedAccountProvider): void;
   onReauth(provider: ConnectedAccountProvider): void;
   onUnlink(provider: ConnectedAccountProvider): void;
+  onImportMyAnimeList(): void;
   onVisibilityChange(provider: ConnectedAccountProvider, publicProfileVisible: boolean): void;
 };
 
@@ -185,6 +187,7 @@ function ConnectionProviderRow({
   onConnect,
   onReauth,
   onUnlink,
+  onImportMyAnimeList,
   onVisibilityChange,
 }: ConnectionProviderRowProps) {
   const isBusy = busyProvider === definition.provider;
@@ -200,6 +203,10 @@ function ConnectionProviderRow({
     account?.status === 'CONNECTED' &&
     !account.experimental &&
     account.dataSource === 'OFFICIAL';
+  const canImportMyAnimeList = definition.provider === 'MYANIMELIST' &&
+    Boolean(account?.connected) &&
+    account?.status === 'CONNECTED' &&
+    !account.needsReauth;
 
   return (
     <Card className="space-y-5" data-testid={`connection-provider-${definition.provider.toLowerCase()}`}>
@@ -240,6 +247,12 @@ function ConnectionProviderRow({
       {account?.needsReauth ? (
         <p className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
           Esta conta precisa ser reconectada antes de voltar ao estado ativo.
+        </p>
+      ) : null}
+
+      {definition.provider === 'MYANIMELIST' && account?.connected ? (
+        <p className="rounded-control border border-border bg-background-tertiary/40 px-control-x py-control-y text-sm text-secondary">
+          A importacao e manual, limitada e privada por padrao. Nada sera publicado no perfil ou no feed automaticamente.
         </p>
       ) : null}
 
@@ -317,6 +330,17 @@ function ConnectionProviderRow({
             }}
           >
             {isBusy ? 'Abrindo...' : `Reconectar ${definition.name}`}
+          </Button>
+        ) : null}
+
+        {canImportMyAnimeList ? (
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={isBusy}
+            onClick={onImportMyAnimeList}
+          >
+            {isBusy ? 'Importando...' : 'Importar listas do MyAnimeList'}
           </Button>
         ) : null}
 
@@ -467,6 +491,25 @@ export function ConnectionCenter({ onRedirect }: ConnectionCenterProps = {}) {
     },
   });
 
+  const myAnimeListImportMutation = useMutation({
+    mutationFn: importMyAnimeListLists,
+    onMutate: () => {
+      setBusyProvider('MYANIMELIST');
+      setErrorMessage(null);
+      setFeedbackMessage(null);
+    },
+    onSuccess: async (response) => {
+      setFeedbackMessage(response.message);
+      await queryClient.invalidateQueries({ queryKey: ['connected-accounts'] });
+    },
+    onError: (error) => {
+      setErrorMessage(resolveErrorMessage(error, 'Nao foi possivel importar listas do MyAnimeList agora.'));
+    },
+    onSettled: () => {
+      setBusyProvider(null);
+    },
+  });
+
   if (accountsQuery.isPending) {
     return (
       <Card className="space-y-4" data-testid="connection-center-loading">
@@ -541,6 +584,9 @@ export function ConnectionCenter({ onRedirect }: ConnectionCenterProps = {}) {
             }}
             onUnlink={(provider) => {
               unlinkMutation.mutate(provider);
+            }}
+            onImportMyAnimeList={() => {
+              myAnimeListImportMutation.mutate();
             }}
             onVisibilityChange={(provider, publicProfileVisible) => {
               visibilityMutation.mutate({ provider, publicProfileVisible });

--- a/frontend/src/schemas/integrations.ts
+++ b/frontend/src/schemas/integrations.ts
@@ -14,6 +14,13 @@ export const steamSyncResponseSchema = z.object({
   synced: z.number().int().min(0),
 });
 
+export const myAnimeListImportResponseSchema = z.object({
+  message: z.string().min(1),
+  imported: z.number().int().min(0),
+  anime: z.number().int().min(0),
+  manga: z.number().int().min(0),
+});
+
 export const epicConnectRequestSchema = z.object({
   authToken: z.string().trim().min(1, 'Token Epic e obrigatorio.'),
 });
@@ -139,6 +146,7 @@ export const connectedAccountVisibilityUpdateRequestSchema = z.object({
 export type SteamConnectValues = z.infer<typeof steamConnectRequestSchema>;
 export type SteamConnectResponse = z.infer<typeof steamConnectResponseSchema>;
 export type SteamSyncResponse = z.infer<typeof steamSyncResponseSchema>;
+export type MyAnimeListImportResponse = z.infer<typeof myAnimeListImportResponseSchema>;
 export type EpicConnectValues = z.infer<typeof epicConnectRequestSchema>;
 export type EpicConnectResponse = z.infer<typeof epicConnectResponseSchema>;
 export type DiscordOAuthStartResponse = z.infer<typeof discordOAuthStartResponseSchema>;

--- a/frontend/src/services/integrations.ts
+++ b/frontend/src/services/integrations.ts
@@ -11,6 +11,7 @@ import {
   connectedAccountsResponseSchema,
   connectedAccountSchema,
   connectedAccountVisibilityUpdateRequestSchema,
+  myAnimeListImportResponseSchema,
   type AccountConnectionStartResponse,
   type AccountUnlinkResponse,
   type ConnectedAccountsResponse,
@@ -28,6 +29,7 @@ import {
   type SteamConnectResponse,
   type SteamConnectValues,
   type SteamSyncResponse,
+  type MyAnimeListImportResponse,
 } from '@/schemas/integrations';
 
 type ErrorResponse = {
@@ -111,6 +113,22 @@ export async function syncSteamLibrary(): Promise<SteamSyncResponse> {
   }
 
   return steamSyncResponseSchema.parse(responsePayload);
+}
+
+export async function importMyAnimeListLists(): Promise<MyAnimeListImportResponse> {
+  const response = await apiRequest('/integrations/myanimelist/import', {
+    method: 'POST',
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new IntegrationsRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel importar listas do MyAnimeList agora.'),
+    );
+  }
+
+  return myAnimeListImportResponseSchema.parse(responsePayload);
 }
 
 export async function connectEpic(

--- a/frontend/tests/unit/components/connection-center.test.tsx
+++ b/frontend/tests/unit/components/connection-center.test.tsx
@@ -6,6 +6,7 @@ import { ConnectionCenter } from '@/components/settings/connection-center';
 import type { ConnectedAccount, ConnectedAccountProviderDefinition } from '@/schemas/integrations';
 import {
   fetchConnectedAccounts,
+  importMyAnimeListLists,
   startAccountLink,
   startAccountReauth,
   unlinkConnectedAccount,
@@ -14,6 +15,7 @@ import {
 
 vi.mock('@/services/integrations', () => ({
   fetchConnectedAccounts: vi.fn(),
+  importMyAnimeListLists: vi.fn(),
   startAccountLink: vi.fn(),
   startAccountReauth: vi.fn(),
   unlinkConnectedAccount: vi.fn(),
@@ -30,6 +32,7 @@ vi.mock('@/services/integrations', () => ({
 }));
 
 const mockedFetchConnectedAccounts = vi.mocked(fetchConnectedAccounts);
+const mockedImportMyAnimeListLists = vi.mocked(importMyAnimeListLists);
 const mockedStartAccountLink = vi.mocked(startAccountLink);
 const mockedStartAccountReauth = vi.mocked(startAccountReauth);
 const mockedUnlinkConnectedAccount = vi.mocked(unlinkConnectedAccount);
@@ -110,6 +113,7 @@ const providerDefinitions: ConnectedAccountProviderDefinition[] = [
 describe('ConnectionCenter', () => {
   beforeEach(() => {
     mockedFetchConnectedAccounts.mockReset();
+    mockedImportMyAnimeListLists.mockReset();
     mockedStartAccountLink.mockReset();
     mockedStartAccountReauth.mockReset();
     mockedUnlinkConnectedAccount.mockReset();
@@ -196,6 +200,94 @@ describe('ConnectionCenter', () => {
       expect(mockedStartAccountLink).toHaveBeenCalledWith('MYANIMELIST', expect.anything());
     });
     expect(onRedirect).toHaveBeenCalledWith('https://myanimelist.net/v1/oauth2/authorize?state=signed-state');
+  });
+
+  it('mostra importacao privada quando MyAnimeList esta conectado e ativo', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions.map((provider) =>
+        provider.provider === 'MYANIMELIST'
+          ? {
+            ...provider,
+            status: 'CONNECTED',
+            capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+          }
+          : provider),
+      accounts: [
+        createAccount({
+          provider: 'MYANIMELIST',
+          displayName: 'MyAnimeList',
+          externalId: '12345',
+          connectionType: 'CONNECTED_ACCOUNT',
+          capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+        }),
+      ],
+    });
+    mockedImportMyAnimeListLists.mockResolvedValue({
+      imported: 2,
+      anime: 1,
+      manga: 1,
+      message: '2 itens MyAnimeList importados de forma privada.',
+    });
+
+    renderWithQuery(<ConnectionCenter />);
+
+    const myAnimeListCard = await screen.findByTestId('connection-provider-myanimelist');
+
+    expect(myAnimeListCard).toHaveTextContent(/nada sera publicado no perfil ou no feed automaticamente/i);
+    fireEvent.click(within(myAnimeListCard).getByRole('button', { name: /importar listas do myanimelist/i }));
+
+    await waitFor(() => {
+      expect(mockedImportMyAnimeListLists).toHaveBeenCalled();
+    });
+    expect(await screen.findByText('2 itens MyAnimeList importados de forma privada.')).toBeInTheDocument();
+  });
+
+  it('nao oferece importacao quando MyAnimeList precisa reconectar', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [
+        createAccount({
+          provider: 'MYANIMELIST',
+          displayName: 'MyAnimeList',
+          externalId: '12345',
+          connectionType: 'CONNECTED_ACCOUNT',
+          status: 'NEEDS_REAUTH',
+          connected: false,
+          needsReauth: true,
+          capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+        }),
+      ],
+    });
+
+    renderWithQuery(<ConnectionCenter />);
+
+    const myAnimeListCard = await screen.findByTestId('connection-provider-myanimelist');
+
+    expect(within(myAnimeListCard).queryByRole('button', { name: /importar listas do myanimelist/i }))
+      .not.toBeInTheDocument();
+    expect(myAnimeListCard).toHaveTextContent(/precisa ser reconectada/i);
+  });
+
+  it('mostra erro seguro quando importacao MyAnimeList falha', async () => {
+    mockedFetchConnectedAccounts.mockResolvedValue({
+      providers: providerDefinitions,
+      accounts: [
+        createAccount({
+          provider: 'MYANIMELIST',
+          displayName: 'MyAnimeList',
+          externalId: '12345',
+          connectionType: 'CONNECTED_ACCOUNT',
+          capabilities: ['CONNECTED_ACCOUNT', 'OAUTH_CONNECT'],
+        }),
+      ],
+    });
+    mockedImportMyAnimeListLists.mockRejectedValue(new Error('network'));
+
+    renderWithQuery(<ConnectionCenter />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /importar listas do myanimelist/i }));
+
+    expect(await screen.findByText('Nao foi possivel importar listas do MyAnimeList agora.')).toBeInTheDocument();
   });
 
   it('renderiza Steam pelo provider registry com acao OpenID sem social login', async () => {

--- a/frontend/tests/unit/services/integrations.test.ts
+++ b/frontend/tests/unit/services/integrations.test.ts
@@ -5,6 +5,7 @@ import {
   connectEpic,
   connectSteam,
   fetchConnectedAccounts,
+  importMyAnimeListLists,
   startAccountLink,
   startAccountReauth,
   unlinkConnectedAccount,
@@ -81,6 +82,50 @@ describe('integrations service', () => {
     expect(mockedApiRequest).toHaveBeenCalledWith('/integrations/steam/sync', {
       method: 'POST',
     });
+  });
+
+  it('imports MyAnimeList lists with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: '2 itens MyAnimeList importados de forma privada.',
+          imported: 2,
+          anime: 1,
+          manga: 1,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const response = await importMyAnimeListLists();
+
+    expect(response).toEqual({
+      message: '2 itens MyAnimeList importados de forma privada.',
+      imported: 2,
+      anime: 1,
+      manga: 1,
+    });
+    expect(mockedApiRequest).toHaveBeenCalledWith('/integrations/myanimelist/import', {
+      method: 'POST',
+    });
+  });
+
+  it('maps MyAnimeList import errors without leaking sensitive payload', async () => {
+    mockedApiRequest.mockResolvedValue(new Response(
+      JSON.stringify({
+        message: 'Reconecte o MyAnimeList antes de importar listas.',
+        accessToken: 'should-not-leak',
+      }),
+      {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ));
+
+    await expect(importMyAnimeListLists()).rejects.toMatchObject({
+      status: 409,
+      message: 'Reconecte o MyAnimeList antes de importar listas.',
+    } satisfies Partial<IntegrationsRequestError>);
   });
 
   it('connects epic with the real contract', async () => {


### PR DESCRIPTION
﻿## Resumo
Implementa o primeiro slice manual de importação MyAnimeList para o domínio otaku do CLUTCH. A mudança usa a conta MyAnimeList conectada via OAuth2/PKCE, importa um resumo limitado de anime/manga lists e mantém os dados privados por padrão, sem publicar feed ou perfil automaticamente.

Closes #290

## O que foi alterado
- Backend:
  - adiciona campos de origem externa em `MediaTitle` e progresso/score em `UserMediaEntry` para suportar upsert idempotente de itens importados;
  - adiciona client MyAnimeList para buscar `@me/animelist` e `@me/mangalist` com token server-side;
  - adiciona importação manual em `IntegrationsService`, com normalização de status MAL para status CLUTCH e atualização de `lastSyncAt`;
  - adiciona `POST /integrations/myanimelist/import` autenticado;
  - adiciona tratamento de reauth/configuração/token protegido inválido sem expor token ou payload bruto.
- Frontend:
  - adiciona service e schema para acionar a importação;
  - adiciona ação mínima no Connection Center para importar listas do MyAnimeList quando a conta estiver conectada e ativa;
  - adiciona feedback de loading/sucesso/erro e microcopy de privacidade.
- Testes:
  - cobre client MAL, mapeamento/persistência da importação, rota backend, idempotência de upsert, status desconhecido, erro/rate limit e comportamento do Connection Center.

## Motivação
A conexão OAuth do MyAnimeList já permite obter token server-side e identidade externa confiável, mas ainda não havia uso inicial desses dados no domínio otaku. Este slice cria uma importação manual, limitada e segura para popular `MediaTitle`/`UserMediaEntry` sem transformar isso em sync completo, feed ou exposição pública automática.

## Como validar
- Backend:
  - `cd backend`
  - `npm run test -- tests/unit/providers/myanimelist-list.client.test.ts tests/unit/services/integrations.service.test.ts tests/integration/routes/integrations.routes.test.ts`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Frontend:
  - `cd frontend`
  - `npm run test -- tests/unit/services/integrations.test.ts tests/unit/components/connection-center.test.tsx`
  - `npm run test:coverage`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Observação: `npm run test:coverage` do backend foi executado, mas o ambiente local não tinha Postgres disponível em `localhost:5432` e Redis local respondeu com conexão recusada; as falhas ficaram em suites de integração/timeout dependentes do ambiente.

## Riscos e impactos
- Inclui migration Prisma para novos campos em `MediaTitle` e `UserMediaEntry`; os campos são opcionais para preservar dados existentes.
- A importação usa apenas a primeira página de anime e manga, com `limit=50` por lista, para evitar sync grande nesta PR.
- Score MAL é persistido quando disponível no modelo local, mas nenhuma publicação pública é feita automaticamente.
- A importação depende de token MyAnimeList válido; contas em `NEEDS_REAUTH`, sem token ou com token protegido inválido retornam erro de domínio.
- Status MAL desconhecido é ignorado item a item para não quebrar a importação inteira por enum novo/inesperado.
- Não há smoke real contra MyAnimeList nesta PR; validação foi feita com mocks locais.

## Evidências
- Backend focado: 3 arquivos de teste, 58 testes passando.
- Frontend focado: 2 arquivos de teste, 33 testes passando.
- Backend typecheck/lint/build passaram; lint manteve 3 warnings preexistentes em `backend/src/config/rate-limit.ts`.
- Frontend typecheck/lint/build passaram.
- Frontend coverage: 70 arquivos, 262 testes passando, cobertura global de 82.4%.
- Backend coverage local: 405 testes passaram e 3 foram pulados antes de falhar por Postgres/Redis local indisponíveis em suites de integração.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados
