### PR TITLE
feat(profile): permite showcase opt-in de anime e manga

### DIFF
--- a/backend/src/api/routes/otaku.routes.ts
+++ b/backend/src/api/routes/otaku.routes.ts
@@ -1,0 +1,77 @@
+import { FastifyInstance, FastifyReply } from 'fastify';
+import { z } from 'zod';
+import {
+  otakuShowcaseService,
+  OtakuShowcaseServiceError,
+  OTAKU_SHOWCASE_MAX_FEATURED,
+} from '../../core/services/otaku-showcase.service';
+
+const entryParamsSchema = z.object({
+  entryId: z.string().uuid('Item otaku inválido.'),
+});
+
+const updateShowcaseSchema = z.object({
+  showcaseRank: z.number().int().nullable(),
+});
+
+function sendOtakuShowcaseServiceError(
+  error: OtakuShowcaseServiceError,
+  reply: FastifyReply,
+): FastifyReply {
+  const statusByCode: Record<OtakuShowcaseServiceError['code'], number> = {
+    OTAKU_ENTRY_NOT_FOUND: 404,
+    OTAKU_SHOWCASE_LIMIT_EXCEEDED: 409,
+    OTAKU_SHOWCASE_RANK_INVALID: 400,
+  };
+
+  return reply.status(statusByCode[error.code]).send({ message: error.message });
+}
+
+export async function otakuRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    '/library',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const entries = await otakuShowcaseService.listUserLibrary(request.userId);
+
+      return reply.status(200).send({
+        entries,
+        maxShowcaseItems: OTAKU_SHOWCASE_MAX_FEATURED,
+      });
+    },
+  );
+
+  app.patch<{ Params: { entryId: string } }>(
+    '/library/:entryId/showcase',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = entryParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({ message: params.error.errors[0]?.message ?? 'Parâmetros inválidos.' });
+      }
+
+      const body = updateShowcaseSchema.safeParse(request.body);
+
+      if (!body.success) {
+        return reply.status(400).send({ message: body.error.errors[0]?.message ?? 'Dados inválidos.' });
+      }
+
+      try {
+        const entry = await otakuShowcaseService.updateEntryShowcase(
+          request.userId,
+          params.data.entryId,
+          body.data.showcaseRank,
+        );
+
+        return reply.status(200).send({ entry });
+      } catch (error) {
+        if (error instanceof OtakuShowcaseServiceError) {
+          return sendOtakuShowcaseServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+}

--- a/backend/src/api/routes/otaku.routes.ts
+++ b/backend/src/api/routes/otaku.routes.ts
@@ -11,7 +11,12 @@ const entryParamsSchema = z.object({
 });
 
 const updateShowcaseSchema = z.object({
-  showcaseRank: z.number().int().nullable(),
+  showcaseRank: z
+    .number()
+    .int()
+    .min(1)
+    .max(OTAKU_SHOWCASE_MAX_FEATURED)
+    .nullable(),
 });
 
 function sendOtakuShowcaseServiceError(
@@ -20,6 +25,7 @@ function sendOtakuShowcaseServiceError(
 ): FastifyReply {
   const statusByCode: Record<OtakuShowcaseServiceError['code'], number> = {
     OTAKU_ENTRY_NOT_FOUND: 404,
+    OTAKU_SHOWCASE_CONCURRENT_UPDATE: 409,
     OTAKU_SHOWCASE_LIMIT_EXCEEDED: 409,
     OTAKU_SHOWCASE_RANK_INVALID: 400,
   };

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,6 +10,7 @@ import { postRoutes } from './api/routes/posts.routes';
 import { notificationRoutes } from './api/routes/notifications.routes';
 import { uploadRoutes } from './api/routes/uploads.routes';
 import { communityRoutes } from './api/routes/communities.routes';
+import { otakuRoutes } from './api/routes/otaku.routes';
 import { authenticate } from './api/middlewares/authenticate';
 import {
   runReadinessChecks,
@@ -195,6 +196,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await app.register(notificationRoutes, { prefix: '/notifications' });
   await app.register(uploadRoutes, { prefix: '/uploads' });
   await app.register(communityRoutes, { prefix: '/communities' });
+  await app.register(otakuRoutes, { prefix: '/otaku' });
 
   await app.ready();
 

--- a/backend/src/core/services/otaku-showcase.service.ts
+++ b/backend/src/core/services/otaku-showcase.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from '../../infra/database/client';
 
 export const OTAKU_SHOWCASE_MAX_FEATURED = 3;
@@ -31,7 +32,8 @@ export interface OtakuLibraryEntry {
 export type OtakuShowcaseServiceErrorCode =
   | 'OTAKU_ENTRY_NOT_FOUND'
   | 'OTAKU_SHOWCASE_LIMIT_EXCEEDED'
-  | 'OTAKU_SHOWCASE_RANK_INVALID';
+  | 'OTAKU_SHOWCASE_RANK_INVALID'
+  | 'OTAKU_SHOWCASE_CONCURRENT_UPDATE';
 
 export class OtakuShowcaseServiceError extends Error {
   readonly code: OtakuShowcaseServiceErrorCode;
@@ -149,61 +151,98 @@ export const otakuShowcaseService = {
       );
     }
 
-    const existingEntry = await prisma.userMediaEntry.findUnique({
-      where: { id: entryId },
-      select: {
-        id: true,
-        userId: true,
-        showcaseRank: true,
-      },
-    });
-
-    if (!existingEntry || existingEntry.userId !== userId) {
-      throw new OtakuShowcaseServiceError(
-        'OTAKU_ENTRY_NOT_FOUND',
-        'Item otaku não encontrado.',
-      );
-    }
-
-    if (showcaseRank !== null && existingEntry.showcaseRank === null) {
-      const currentShowcaseCount = await prisma.userMediaEntry.count({
-        where: {
-          userId,
-          showcaseRank: {
-            not: null,
+    try {
+      const updatedEntry = (await prisma.$transaction(async (tx) => {
+        const existingEntry = await tx.userMediaEntry.findUnique({
+          where: { id: entryId },
+          select: {
+            id: true,
+            userId: true,
+            showcaseRank: true,
           },
-        },
-      });
+        });
 
-      if (currentShowcaseCount >= OTAKU_SHOWCASE_MAX_FEATURED) {
+        if (!existingEntry || existingEntry.userId !== userId) {
+          throw new OtakuShowcaseServiceError(
+            'OTAKU_ENTRY_NOT_FOUND',
+            'Item otaku não encontrado.',
+          );
+        }
+
+        if (showcaseRank !== null && existingEntry.showcaseRank === null) {
+          const currentShowcaseCount = await tx.userMediaEntry.count({
+            where: {
+              userId,
+              showcaseRank: {
+                not: null,
+              },
+            },
+          });
+
+          if (currentShowcaseCount >= OTAKU_SHOWCASE_MAX_FEATURED) {
+            throw new OtakuShowcaseServiceError(
+              'OTAKU_SHOWCASE_LIMIT_EXCEEDED',
+              `O showcase otaku aceita no máximo ${OTAKU_SHOWCASE_MAX_FEATURED} itens.`,
+            );
+          }
+        }
+
+        if (showcaseRank !== null) {
+          await tx.userMediaEntry.updateMany({
+            where: {
+              userId,
+              showcaseRank,
+              id: {
+                not: entryId,
+              },
+            },
+            data: {
+              showcaseRank: null,
+            },
+          });
+        }
+
+        return tx.userMediaEntry.update({
+          where: { id: entryId },
+          data: { showcaseRank },
+          select: {
+            id: true,
+            status: true,
+            progress: true,
+            score: true,
+            showcaseRank: true,
+            updatedAt: true,
+            mediaTitle: {
+              select: {
+                kind: true,
+                canonicalTitle: true,
+                coverUrl: true,
+              },
+            },
+          },
+        });
+      }, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      })) as UserLibraryEntryRecord;
+
+      return toLibraryEntry(updatedEntry);
+    } catch (error) {
+      if (error instanceof OtakuShowcaseServiceError) {
+        throw error;
+      }
+
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2034'
+      ) {
         throw new OtakuShowcaseServiceError(
-          'OTAKU_SHOWCASE_LIMIT_EXCEEDED',
-          `O showcase otaku aceita no máximo ${OTAKU_SHOWCASE_MAX_FEATURED} itens.`,
+          'OTAKU_SHOWCASE_CONCURRENT_UPDATE',
+          'O showcase foi alterado ao mesmo tempo. Tente novamente.',
         );
       }
+
+      throw error;
     }
-
-    const updatedEntry = (await prisma.userMediaEntry.update({
-      where: { id: entryId },
-      data: { showcaseRank },
-      select: {
-        id: true,
-        status: true,
-        progress: true,
-        score: true,
-        showcaseRank: true,
-        updatedAt: true,
-        mediaTitle: {
-          select: {
-            kind: true,
-            canonicalTitle: true,
-            coverUrl: true,
-          },
-        },
-      },
-    })) as UserLibraryEntryRecord;
-
-    return toLibraryEntry(updatedEntry);
   },
 
   async summarizeUser(userId: string): Promise<OtakuShowcaseSummary | null> {

--- a/backend/src/core/services/otaku-showcase.service.ts
+++ b/backend/src/core/services/otaku-showcase.service.ts
@@ -1,5 +1,7 @@
 import { prisma } from '../../infra/database/client';
 
+export const OTAKU_SHOWCASE_MAX_FEATURED = 3;
+
 export interface OtakuShowcaseItem {
   id: string;
   kind: 'ANIME' | 'MANGA';
@@ -14,11 +16,52 @@ export interface OtakuShowcaseSummary {
   completedCount: number;
 }
 
+export interface OtakuLibraryEntry {
+  id: string;
+  kind: 'ANIME' | 'MANGA';
+  title: string;
+  coverUrl: string | null;
+  status: 'PLANNING' | 'CONSUMING' | 'COMPLETED' | 'PAUSED' | 'DROPPED';
+  progress: number | null;
+  score: number | null;
+  showcaseRank: number | null;
+  updatedAt: Date;
+}
+
+export type OtakuShowcaseServiceErrorCode =
+  | 'OTAKU_ENTRY_NOT_FOUND'
+  | 'OTAKU_SHOWCASE_LIMIT_EXCEEDED'
+  | 'OTAKU_SHOWCASE_RANK_INVALID';
+
+export class OtakuShowcaseServiceError extends Error {
+  readonly code: OtakuShowcaseServiceErrorCode;
+
+  constructor(code: OtakuShowcaseServiceErrorCode, message: string) {
+    super(message);
+    this.name = 'OtakuShowcaseServiceError';
+    this.code = code;
+  }
+}
+
 type PublicShowcaseEntry = {
   showcaseRank: number | null;
   status: 'PLANNING' | 'CONSUMING' | 'COMPLETED' | 'PAUSED' | 'DROPPED';
   mediaTitle: {
     id: string;
+    kind: 'ANIME' | 'MANGA';
+    canonicalTitle: string;
+    coverUrl: string | null;
+  };
+};
+
+type UserLibraryEntryRecord = {
+  id: string;
+  status: 'PLANNING' | 'CONSUMING' | 'COMPLETED' | 'PAUSED' | 'DROPPED';
+  progress: number | null;
+  score: number | null;
+  showcaseRank: number | null;
+  updatedAt: Date;
+  mediaTitle: {
     kind: 'ANIME' | 'MANGA';
     canonicalTitle: string;
     coverUrl: string | null;
@@ -45,7 +88,124 @@ function toShowcaseItem(entry: PublicShowcaseEntry): OtakuShowcaseItem {
   };
 }
 
+function toLibraryEntry(entry: UserLibraryEntryRecord): OtakuLibraryEntry {
+  return {
+    id: entry.id,
+    kind: entry.mediaTitle.kind,
+    title: entry.mediaTitle.canonicalTitle,
+    coverUrl: entry.mediaTitle.coverUrl,
+    status: entry.status,
+    progress: entry.progress,
+    score: entry.score,
+    showcaseRank: entry.showcaseRank,
+    updatedAt: entry.updatedAt,
+  };
+}
+
 export const otakuShowcaseService = {
+  async listUserLibrary(userId: string): Promise<OtakuLibraryEntry[]> {
+    const entries = (await prisma.userMediaEntry.findMany({
+      where: {
+        userId,
+      },
+      orderBy: [
+        { showcaseRank: 'asc' },
+        { updatedAt: 'desc' },
+      ],
+      select: {
+        id: true,
+        status: true,
+        progress: true,
+        score: true,
+        showcaseRank: true,
+        updatedAt: true,
+        mediaTitle: {
+          select: {
+            kind: true,
+            canonicalTitle: true,
+            coverUrl: true,
+          },
+        },
+      },
+    })) as UserLibraryEntryRecord[];
+
+    return entries.map(toLibraryEntry);
+  },
+
+  async updateEntryShowcase(
+    userId: string,
+    entryId: string,
+    showcaseRank: number | null,
+  ): Promise<OtakuLibraryEntry> {
+    if (
+      showcaseRank !== null &&
+      (!Number.isInteger(showcaseRank) ||
+        showcaseRank < 1 ||
+        showcaseRank > OTAKU_SHOWCASE_MAX_FEATURED)
+    ) {
+      throw new OtakuShowcaseServiceError(
+        'OTAKU_SHOWCASE_RANK_INVALID',
+        `Escolha uma posição de destaque entre 1 e ${OTAKU_SHOWCASE_MAX_FEATURED}.`,
+      );
+    }
+
+    const existingEntry = await prisma.userMediaEntry.findUnique({
+      where: { id: entryId },
+      select: {
+        id: true,
+        userId: true,
+        showcaseRank: true,
+      },
+    });
+
+    if (!existingEntry || existingEntry.userId !== userId) {
+      throw new OtakuShowcaseServiceError(
+        'OTAKU_ENTRY_NOT_FOUND',
+        'Item otaku não encontrado.',
+      );
+    }
+
+    if (showcaseRank !== null && existingEntry.showcaseRank === null) {
+      const currentShowcaseCount = await prisma.userMediaEntry.count({
+        where: {
+          userId,
+          showcaseRank: {
+            not: null,
+          },
+        },
+      });
+
+      if (currentShowcaseCount >= OTAKU_SHOWCASE_MAX_FEATURED) {
+        throw new OtakuShowcaseServiceError(
+          'OTAKU_SHOWCASE_LIMIT_EXCEEDED',
+          `O showcase otaku aceita no máximo ${OTAKU_SHOWCASE_MAX_FEATURED} itens.`,
+        );
+      }
+    }
+
+    const updatedEntry = (await prisma.userMediaEntry.update({
+      where: { id: entryId },
+      data: { showcaseRank },
+      select: {
+        id: true,
+        status: true,
+        progress: true,
+        score: true,
+        showcaseRank: true,
+        updatedAt: true,
+        mediaTitle: {
+          select: {
+            kind: true,
+            canonicalTitle: true,
+            coverUrl: true,
+          },
+        },
+      },
+    })) as UserLibraryEntryRecord;
+
+    return toLibraryEntry(updatedEntry);
+  },
+
   async summarizeUser(userId: string): Promise<OtakuShowcaseSummary | null> {
     const publicEntries = (await prisma.userMediaEntry.findMany({
       where: {

--- a/backend/tests/integration/routes/otaku.routes.test.ts
+++ b/backend/tests/integration/routes/otaku.routes.test.ts
@@ -191,5 +191,28 @@ describe('Otaku Routes', () => {
       expect(response.json()).toEqual({ message: 'O showcase otaku aceita no máximo 3 itens.' });
       await app.close();
     });
+
+    it.each([
+      ['zero', { showcaseRank: 0 }],
+      ['negativo', { showcaseRank: -1 }],
+      ['decimal', { showcaseRank: 1.5 }],
+      ['string', { showcaseRank: '1' }],
+      ['acima do limite', { showcaseRank: 4 }],
+      ['payload malformado', { rank: 1 }],
+    ])('rejeita showcaseRank invalido: %s', async (_caseName, payload) => {
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/otaku/library/${mockEntry.id}/showcase`,
+        headers: { Authorization: `Bearer ${token}` },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(otakuShowcaseService.updateEntryShowcase).not.toHaveBeenCalled();
+      await app.close();
+    });
   });
 });

--- a/backend/tests/integration/routes/otaku.routes.test.ts
+++ b/backend/tests/integration/routes/otaku.routes.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildApp, generateTestToken } from '../../helpers/build-app';
+import {
+  OtakuShowcaseServiceError,
+} from '@/core/services/otaku-showcase.service';
+
+vi.mock('@/core/services/otaku-showcase.service', () => ({
+  OTAKU_SHOWCASE_MAX_FEATURED: 3,
+  OtakuShowcaseServiceError: class OtakuShowcaseServiceError extends Error {
+    readonly code: string;
+
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = 'OtakuShowcaseServiceError';
+      this.code = code;
+    }
+  },
+  otakuShowcaseService: {
+    listUserLibrary: vi.fn(),
+    updateEntryShowcase: vi.fn(),
+    summarizeUser: vi.fn(),
+  },
+}));
+
+import { otakuShowcaseService } from '@/core/services/otaku-showcase.service';
+
+const mockEntry = {
+  id: '11111111-1111-4111-8111-111111111111',
+  kind: 'ANIME' as const,
+  title: 'Sousou no Frieren',
+  coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+  status: 'CONSUMING' as const,
+  progress: 4,
+  score: 9,
+  showcaseRank: null,
+  updatedAt: new Date('2026-04-30T18:00:00.000Z'),
+};
+
+describe('Otaku Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /otaku/library', () => {
+    it('exige autenticacao', async () => {
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/otaku/library',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(otakuShowcaseService.listUserLibrary).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('lista entradas otaku do usuario autenticado sem payload sensivel', async () => {
+      vi.mocked(otakuShowcaseService.listUserLibrary).mockResolvedValue([mockEntry]);
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/otaku/library',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        maxShowcaseItems: 3,
+        entries: [
+          {
+            id: mockEntry.id,
+            title: 'Sousou no Frieren',
+            showcaseRank: null,
+          },
+        ],
+      });
+      expect(JSON.stringify(response.json())).not.toContain('externalId');
+      expect(JSON.stringify(response.json())).not.toContain('metadata');
+      expect(JSON.stringify(response.json())).not.toContain('raw');
+      expect(otakuShowcaseService.listUserLibrary).toHaveBeenCalledWith('user-id-1');
+      await app.close();
+    });
+  });
+
+  describe('PATCH /otaku/library/:entryId/showcase', () => {
+    it('exige autenticacao', async () => {
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/otaku/library/${mockEntry.id}/showcase`,
+        payload: { showcaseRank: 1 },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(otakuShowcaseService.updateEntryShowcase).not.toHaveBeenCalled();
+      await app.close();
+    });
+
+    it('atualiza destaque de entrada propria', async () => {
+      vi.mocked(otakuShowcaseService.updateEntryShowcase).mockResolvedValue({
+        ...mockEntry,
+        showcaseRank: 1,
+      });
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/otaku/library/${mockEntry.id}/showcase`,
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { showcaseRank: 1 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toMatchObject({
+        entry: {
+          id: mockEntry.id,
+          showcaseRank: 1,
+        },
+      });
+      expect(otakuShowcaseService.updateEntryShowcase).toHaveBeenCalledWith(
+        'user-id-1',
+        mockEntry.id,
+        1,
+      );
+      await app.close();
+    });
+
+    it('remove destaque com showcaseRank null', async () => {
+      vi.mocked(otakuShowcaseService.updateEntryShowcase).mockResolvedValue(mockEntry);
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/otaku/library/${mockEntry.id}/showcase`,
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { showcaseRank: null },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(otakuShowcaseService.updateEntryShowcase).toHaveBeenCalledWith(
+        'user-id-1',
+        mockEntry.id,
+        null,
+      );
+      await app.close();
+    });
+
+    it('retorna erro coerente quando item nao pertence ao usuario', async () => {
+      vi.mocked(otakuShowcaseService.updateEntryShowcase).mockRejectedValue(
+        new OtakuShowcaseServiceError('OTAKU_ENTRY_NOT_FOUND', 'Item otaku não encontrado.'),
+      );
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/otaku/library/${mockEntry.id}/showcase`,
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { showcaseRank: 1 },
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toEqual({ message: 'Item otaku não encontrado.' });
+      await app.close();
+    });
+
+    it('bloqueia limite maximo de destaques', async () => {
+      vi.mocked(otakuShowcaseService.updateEntryShowcase).mockRejectedValue(
+        new OtakuShowcaseServiceError(
+          'OTAKU_SHOWCASE_LIMIT_EXCEEDED',
+          'O showcase otaku aceita no máximo 3 itens.',
+        ),
+      );
+      const app = await buildApp();
+      const token = generateTestToken(app, 'user-id-1');
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: `/otaku/library/${mockEntry.id}/showcase`,
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { showcaseRank: 1 },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json()).toEqual({ message: 'O showcase otaku aceita no máximo 3 itens.' });
+      await app.close();
+    });
+  });
+});

--- a/backend/tests/integration/routes/profile.routes.test.ts
+++ b/backend/tests/integration/routes/profile.routes.test.ts
@@ -16,7 +16,10 @@ vi.mock('@/core/services/social-continuity.service', () => ({
 }));
 
 vi.mock('@/core/services/otaku-showcase.service', () => ({
+  OTAKU_SHOWCASE_MAX_FEATURED: 3,
   otakuShowcaseService: {
+    listUserLibrary: vi.fn(),
+    updateEntryShowcase: vi.fn(),
     summarizeUser: vi.fn(),
   },
 }));

--- a/backend/tests/unit/services/otaku-showcase.service.test.ts
+++ b/backend/tests/unit/services/otaku-showcase.service.test.ts
@@ -6,10 +6,12 @@ import {
 
 vi.mock('@/infra/database/client', () => ({
   prisma: {
+    $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(prisma)),
     userMediaEntry: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
       count: vi.fn(),
+      updateMany: vi.fn(),
       update: vi.fn(),
     },
   },
@@ -214,6 +216,18 @@ describe('otakuShowcaseService', () => {
         },
       },
     });
+    expect(prisma.userMediaEntry.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-1',
+        showcaseRank: 3,
+        id: {
+          not: 'entry-1',
+        },
+      },
+      data: {
+        showcaseRank: null,
+      },
+    });
     expect(prisma.userMediaEntry.update).toHaveBeenCalledWith(expect.objectContaining({
       where: { id: 'entry-1' },
       data: { showcaseRank: 3 },
@@ -248,6 +262,7 @@ describe('otakuShowcaseService', () => {
     const entry = await otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', null);
 
     expect(prisma.userMediaEntry.count).not.toHaveBeenCalled();
+    expect(prisma.userMediaEntry.updateMany).not.toHaveBeenCalled();
     expect(prisma.userMediaEntry.update).toHaveBeenCalledWith(expect.objectContaining({
       data: { showcaseRank: null },
     }));
@@ -272,6 +287,45 @@ describe('otakuShowcaseService', () => {
     expect(prisma.userMediaEntry.update).not.toHaveBeenCalled();
   });
 
+  it('normaliza rank duplicado removendo destaque anterior da mesma posicao', async () => {
+    vi.mocked(prisma.userMediaEntry.findUnique).mockResolvedValue({
+      id: 'entry-2',
+      userId: 'user-1',
+      showcaseRank: 2,
+    } as never);
+    vi.mocked(prisma.userMediaEntry.updateMany).mockResolvedValue({ count: 1 } as never);
+    vi.mocked(prisma.userMediaEntry.update).mockResolvedValue({
+      id: 'entry-2',
+      status: 'COMPLETED',
+      progress: 12,
+      score: 8,
+      showcaseRank: 1,
+      updatedAt: new Date('2026-04-30T18:00:00.000Z'),
+      mediaTitle: {
+        kind: 'MANGA',
+        canonicalTitle: 'Berserk',
+        coverUrl: null,
+      },
+    } as never);
+
+    const entry = await otakuShowcaseService.updateEntryShowcase('user-1', 'entry-2', 1);
+
+    expect(prisma.userMediaEntry.count).not.toHaveBeenCalled();
+    expect(prisma.userMediaEntry.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-1',
+        showcaseRank: 1,
+        id: {
+          not: 'entry-2',
+        },
+      },
+      data: {
+        showcaseRank: null,
+      },
+    });
+    expect(entry.showcaseRank).toBe(1);
+  });
+
   it('aplica limite maximo de destaques', async () => {
     vi.mocked(prisma.userMediaEntry.findUnique).mockResolvedValue({
       id: 'entry-4',
@@ -289,6 +343,22 @@ describe('otakuShowcaseService', () => {
 
   it('valida showcaseRank dentro do intervalo publico permitido', async () => {
     await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', 4))
+      .rejects.toMatchObject({
+        code: 'OTAKU_SHOWCASE_RANK_INVALID',
+      });
+    expect(prisma.userMediaEntry.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejeita showcaseRank decimal, zero e negativo antes de consultar o banco', async () => {
+    await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', 1.5))
+      .rejects.toMatchObject({
+        code: 'OTAKU_SHOWCASE_RANK_INVALID',
+      });
+    await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', 0))
+      .rejects.toMatchObject({
+        code: 'OTAKU_SHOWCASE_RANK_INVALID',
+      });
+    await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', -1))
       .rejects.toMatchObject({
         code: 'OTAKU_SHOWCASE_RANK_INVALID',
       });

--- a/backend/tests/unit/services/otaku-showcase.service.test.ts
+++ b/backend/tests/unit/services/otaku-showcase.service.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { otakuShowcaseService } from '@/core/services/otaku-showcase.service';
+import {
+  otakuShowcaseService,
+  OtakuShowcaseServiceError,
+} from '@/core/services/otaku-showcase.service';
 
 vi.mock('@/infra/database/client', () => ({
   prisma: {
     userMediaEntry: {
       findMany: vi.fn(),
+      findUnique: vi.fn(),
+      count: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -90,6 +96,26 @@ describe('otakuShowcaseService', () => {
       consumingCount: 2,
       completedCount: 1,
     });
+    expect(prisma.userMediaEntry.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        userId: 'user-1',
+        showcaseRank: {
+          not: null,
+        },
+      },
+      select: expect.objectContaining({
+        mediaTitle: {
+          select: {
+            id: true,
+            kind: true,
+            canonicalTitle: true,
+            coverUrl: true,
+          },
+        },
+      }),
+    }));
+    expect(JSON.stringify(vi.mocked(prisma.userMediaEntry.findMany).mock.calls)).not.toContain('externalId');
+    expect(JSON.stringify(vi.mocked(prisma.userMediaEntry.findMany).mock.calls)).not.toContain('metadata');
   });
 
   it('retorna null quando o usuario nao tem entradas publicas no showcase', async () => {
@@ -98,5 +124,174 @@ describe('otakuShowcaseService', () => {
     const summary = await otakuShowcaseService.summarizeUser('user-1');
 
     expect(summary).toBeNull();
+  });
+
+  it('lista biblioteca otaku privada do usuario sem identidade externa bruta', async () => {
+    vi.mocked(prisma.userMediaEntry.findMany).mockResolvedValue([
+      {
+        id: 'entry-1',
+        status: 'CONSUMING',
+        progress: 4,
+        score: 9,
+        showcaseRank: null,
+        updatedAt: new Date('2026-04-30T18:00:00.000Z'),
+        mediaTitle: {
+          kind: 'ANIME',
+          canonicalTitle: 'Sousou no Frieren',
+          coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+        },
+      },
+    ] as never);
+
+    const entries = await otakuShowcaseService.listUserLibrary('user-1');
+
+    expect(entries).toEqual([
+      {
+        id: 'entry-1',
+        kind: 'ANIME',
+        title: 'Sousou no Frieren',
+        coverUrl: 'https://cdn.clutch.gg/frieren.jpg',
+        status: 'CONSUMING',
+        progress: 4,
+        score: 9,
+        showcaseRank: null,
+        updatedAt: new Date('2026-04-30T18:00:00.000Z'),
+      },
+    ]);
+    expect(prisma.userMediaEntry.findMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      orderBy: [
+        { showcaseRank: 'asc' },
+        { updatedAt: 'desc' },
+      ],
+      select: expect.objectContaining({
+        id: true,
+        status: true,
+        progress: true,
+        score: true,
+        showcaseRank: true,
+        updatedAt: true,
+        mediaTitle: {
+          select: {
+            kind: true,
+            canonicalTitle: true,
+            coverUrl: true,
+          },
+        },
+      }),
+    });
+    expect(JSON.stringify(vi.mocked(prisma.userMediaEntry.findMany).mock.calls)).not.toContain('externalId');
+  });
+
+  it('define showcaseRank em entrada propria respeitando limite de destaques', async () => {
+    vi.mocked(prisma.userMediaEntry.findUnique).mockResolvedValue({
+      id: 'entry-1',
+      userId: 'user-1',
+      showcaseRank: null,
+    } as never);
+    vi.mocked(prisma.userMediaEntry.count).mockResolvedValue(2);
+    vi.mocked(prisma.userMediaEntry.update).mockResolvedValue({
+      id: 'entry-1',
+      status: 'COMPLETED',
+      progress: 12,
+      score: 8,
+      showcaseRank: 3,
+      updatedAt: new Date('2026-04-30T18:00:00.000Z'),
+      mediaTitle: {
+        kind: 'MANGA',
+        canonicalTitle: 'Berserk',
+        coverUrl: null,
+      },
+    } as never);
+
+    const entry = await otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', 3);
+
+    expect(prisma.userMediaEntry.count).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-1',
+        showcaseRank: {
+          not: null,
+        },
+      },
+    });
+    expect(prisma.userMediaEntry.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'entry-1' },
+      data: { showcaseRank: 3 },
+    }));
+    expect(entry).toMatchObject({
+      id: 'entry-1',
+      title: 'Berserk',
+      showcaseRank: 3,
+    });
+  });
+
+  it('remove destaque sem apagar entrada importada', async () => {
+    vi.mocked(prisma.userMediaEntry.findUnique).mockResolvedValue({
+      id: 'entry-1',
+      userId: 'user-1',
+      showcaseRank: 1,
+    } as never);
+    vi.mocked(prisma.userMediaEntry.update).mockResolvedValue({
+      id: 'entry-1',
+      status: 'CONSUMING',
+      progress: 4,
+      score: null,
+      showcaseRank: null,
+      updatedAt: new Date('2026-04-30T18:00:00.000Z'),
+      mediaTitle: {
+        kind: 'ANIME',
+        canonicalTitle: 'Dungeon Meshi',
+        coverUrl: null,
+      },
+    } as never);
+
+    const entry = await otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', null);
+
+    expect(prisma.userMediaEntry.count).not.toHaveBeenCalled();
+    expect(prisma.userMediaEntry.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: { showcaseRank: null },
+    }));
+    expect(entry.showcaseRank).toBeNull();
+  });
+
+  it('bloqueia alteracao de entrada inexistente ou de outro usuario', async () => {
+    vi.mocked(prisma.userMediaEntry.findUnique)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'entry-2',
+        userId: 'other-user',
+        showcaseRank: null,
+      } as never);
+
+    await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-missing', 1))
+      .rejects.toBeInstanceOf(OtakuShowcaseServiceError);
+    await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-2', 1))
+      .rejects.toMatchObject({
+        code: 'OTAKU_ENTRY_NOT_FOUND',
+      });
+    expect(prisma.userMediaEntry.update).not.toHaveBeenCalled();
+  });
+
+  it('aplica limite maximo de destaques', async () => {
+    vi.mocked(prisma.userMediaEntry.findUnique).mockResolvedValue({
+      id: 'entry-4',
+      userId: 'user-1',
+      showcaseRank: null,
+    } as never);
+    vi.mocked(prisma.userMediaEntry.count).mockResolvedValue(3);
+
+    await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-4', 1))
+      .rejects.toMatchObject({
+        code: 'OTAKU_SHOWCASE_LIMIT_EXCEEDED',
+      });
+    expect(prisma.userMediaEntry.update).not.toHaveBeenCalled();
+  });
+
+  it('valida showcaseRank dentro do intervalo publico permitido', async () => {
+    await expect(otakuShowcaseService.updateEntryShowcase('user-1', 'entry-1', 4))
+      .rejects.toMatchObject({
+        code: 'OTAKU_SHOWCASE_RANK_INVALID',
+      });
+    expect(prisma.userMediaEntry.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/settings/integrations-page-content.tsx
+++ b/frontend/src/components/settings/integrations-page-content.tsx
@@ -6,6 +6,7 @@ import { ConnectionCenter } from '@/components/settings/connection-center';
 import { DiscordIntegrationCard } from '@/components/settings/discord-integration-card';
 import { EpicIntegrationCard } from '@/components/settings/epic-integration-card';
 import { IgdbSearchCard } from '@/components/settings/igdb-search-card';
+import { OtakuShowcaseManager } from '@/components/settings/otaku-showcase-manager';
 import { SettingsNav } from '@/components/settings/settings-nav';
 import { SteamIntegrationCard } from '@/components/settings/steam-integration-card';
 import { Card } from '@/components/ui/card';
@@ -116,6 +117,8 @@ export function IntegrationsPageContent() {
       ) : null}
 
       <ConnectionCenter />
+
+      <OtakuShowcaseManager />
 
       <div className="grid gap-section xl:grid-cols-2">
         <SteamIntegrationCard

--- a/frontend/src/components/settings/otaku-showcase-manager.tsx
+++ b/frontend/src/components/settings/otaku-showcase-manager.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import Image from 'next/image';
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import type { OtakuLibraryEntry } from '@/schemas/otaku';
+import {
+  fetchOtakuLibrary,
+  OtakuRequestError,
+  updateOtakuShowcaseEntry,
+} from '@/services/otaku';
+
+const statusLabel: Record<OtakuLibraryEntry['status'], string> = {
+  PLANNING: 'Planejado',
+  CONSUMING: 'Em consumo',
+  COMPLETED: 'Concluido',
+  PAUSED: 'Pausado',
+  DROPPED: 'Abandonado',
+};
+
+function resolveErrorMessage(error: unknown): string {
+  return error instanceof OtakuRequestError
+    ? error.message
+    : 'Nao foi possivel atualizar o showcase otaku agora.';
+}
+
+function resolveNextShowcaseRank(entries: OtakuLibraryEntry[], maxShowcaseItems: number): number | null {
+  const usedRanks = new Set(
+    entries
+      .map((entry) => entry.showcaseRank)
+      .filter((rank): rank is number => rank !== null),
+  );
+
+  for (let rank = 1; rank <= maxShowcaseItems; rank += 1) {
+    if (!usedRanks.has(rank)) {
+      return rank;
+    }
+  }
+
+  return null;
+}
+
+type OtakuLibraryRowProps = {
+  entry: OtakuLibraryEntry;
+  isBusy: boolean;
+  limitReached: boolean;
+  onFeature(entry: OtakuLibraryEntry): void;
+  onRemove(entry: OtakuLibraryEntry): void;
+};
+
+function OtakuLibraryRow({
+  entry,
+  isBusy,
+  limitReached,
+  onFeature,
+  onRemove,
+}: OtakuLibraryRowProps) {
+  const isFeatured = entry.showcaseRank !== null;
+
+  return (
+    <li
+      className="grid gap-4 rounded-control border border-border bg-background-secondary/70 p-4 sm:grid-cols-[72px_1fr_auto]"
+      data-testid="otaku-library-entry"
+    >
+      <div className="relative h-24 w-[72px] overflow-hidden rounded-control border border-border bg-background-tertiary">
+        {entry.coverUrl ? (
+          <Image
+            src={entry.coverUrl}
+            alt={entry.title}
+            fill
+            sizes="72px"
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-[10px] uppercase tracking-[0.2em] text-secondary">
+            Sem capa
+          </div>
+        )}
+      </div>
+
+      <div className="min-w-0 space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <Badge tone="neutral">{entry.kind}</Badge>
+          <Badge tone={entry.status === 'CONSUMING' ? 'success' : 'neutral'}>
+            {statusLabel[entry.status]}
+          </Badge>
+          {isFeatured ? <Badge tone="accent">Destaque #{entry.showcaseRank}</Badge> : null}
+        </div>
+
+        <p className="truncate text-sm font-semibold text-primary">{entry.title}</p>
+        <p className="text-xs leading-5 text-secondary">
+          {typeof entry.progress === 'number' ? `Progresso ${entry.progress}` : 'Progresso nao informado'}
+          {typeof entry.score === 'number' ? ` · Nota ${entry.score}` : ''}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-start sm:justify-end">
+        {isFeatured ? (
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={isBusy}
+            onClick={() => {
+              onRemove(entry);
+            }}
+          >
+            Remover destaque
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={isBusy || limitReached}
+            onClick={() => {
+              onFeature(entry);
+            }}
+          >
+            Destacar
+          </Button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export function OtakuShowcaseManager() {
+  const queryClient = useQueryClient();
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [busyEntryId, setBusyEntryId] = useState<string | null>(null);
+
+  const libraryQuery = useQuery({
+    queryKey: ['otaku-library'],
+    queryFn: fetchOtakuLibrary,
+  });
+
+  const showcaseMutation = useMutation({
+    mutationFn: (input: { entryId: string; showcaseRank: number | null }) =>
+      updateOtakuShowcaseEntry(input.entryId, { showcaseRank: input.showcaseRank }),
+    onMutate: ({ entryId }) => {
+      setBusyEntryId(entryId);
+      setFeedbackMessage(null);
+      setErrorMessage(null);
+    },
+    onSuccess: async (response) => {
+      setFeedbackMessage(
+        response.entry.showcaseRank === null
+          ? `${response.entry.title} saiu do showcase publico.`
+          : `${response.entry.title} agora aparece no showcase publico.`,
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['otaku-library'] }),
+        queryClient.invalidateQueries({ queryKey: ['profile'] }),
+      ]);
+    },
+    onError: (error) => {
+      setErrorMessage(resolveErrorMessage(error));
+    },
+    onSettled: () => {
+      setBusyEntryId(null);
+    },
+  });
+
+  const entries = useMemo(() => libraryQuery.data?.entries ?? [], [libraryQuery.data?.entries]);
+  const maxShowcaseItems = libraryQuery.data?.maxShowcaseItems ?? 3;
+  const featuredCount = entries.filter((entry) => entry.showcaseRank !== null).length;
+  const nextShowcaseRank = useMemo(
+    () => resolveNextShowcaseRank(entries, maxShowcaseItems),
+    [entries, maxShowcaseItems],
+  );
+  const limitReached = featuredCount >= maxShowcaseItems;
+
+  return (
+    <Card data-testid="otaku-showcase-manager">
+      <div className="space-y-5">
+        <SectionHeading
+          eyebrow="Anime e manga"
+          title="Showcase otaku"
+          description="Escolha ate tres obras importadas para aparecer no perfil publico. A biblioteca completa continua privada."
+        />
+
+        {feedbackMessage ? (
+          <div className="rounded-control border border-status-online/40 bg-[rgba(16,185,129,0.12)] px-control-x py-control-y text-sm text-primary">
+            {feedbackMessage}
+          </div>
+        ) : null}
+
+        {errorMessage ? (
+          <div className="rounded-control border border-status-afk/40 bg-[rgba(245,158,11,0.12)] px-control-x py-control-y text-sm text-primary">
+            {errorMessage}
+          </div>
+        ) : null}
+
+        {libraryQuery.isPending ? (
+          <div className="rounded-control border border-border bg-background-tertiary/60 px-4 py-4 text-sm text-secondary">
+            Carregando obras importadas...
+          </div>
+        ) : null}
+
+        {libraryQuery.isError ? (
+          <div className="rounded-control border border-border bg-background-tertiary/60 px-4 py-4 text-sm text-secondary">
+            Nao foi possivel carregar os itens otaku agora.
+          </div>
+        ) : null}
+
+        {libraryQuery.isSuccess && entries.length === 0 ? (
+          <div data-testid="otaku-library-empty" className="rounded-control border border-border bg-background-tertiary/60 px-4 py-4 text-sm text-secondary">
+            Importe listas do MyAnimeList para selecionar destaques aqui.
+          </div>
+        ) : null}
+
+        {libraryQuery.isSuccess && entries.length > 0 ? (
+          <>
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-control border border-border bg-background-tertiary/50 px-4 py-3">
+              <p className="text-sm text-secondary">
+                {featuredCount} de {maxShowcaseItems} destaques selecionados. Nada e publicado no feed.
+              </p>
+              {limitReached ? <Badge tone="warning">Limite atingido</Badge> : null}
+            </div>
+
+            <ul className="space-y-3">
+              {entries.map((entry) => (
+                <OtakuLibraryRow
+                  key={entry.id}
+                  entry={entry}
+                  isBusy={busyEntryId === entry.id}
+                  limitReached={limitReached}
+                  onFeature={(selectedEntry) => {
+                    if (nextShowcaseRank !== null) {
+                      showcaseMutation.mutate({
+                        entryId: selectedEntry.id,
+                        showcaseRank: nextShowcaseRank,
+                      });
+                    }
+                  }}
+                  onRemove={(selectedEntry) => {
+                    showcaseMutation.mutate({
+                      entryId: selectedEntry.id,
+                      showcaseRank: null,
+                    });
+                  }}
+                />
+              ))}
+            </ul>
+          </>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/schemas/otaku.ts
+++ b/frontend/src/schemas/otaku.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const otakuLibraryEntrySchema = z.object({
+  id: z.string().min(1),
+  kind: z.enum(['ANIME', 'MANGA']),
+  title: z.string().min(1),
+  coverUrl: z.string().nullable(),
+  status: z.enum(['PLANNING', 'CONSUMING', 'COMPLETED', 'PAUSED', 'DROPPED']),
+  progress: z.number().int().min(0).nullable(),
+  score: z.number().int().min(0).nullable(),
+  showcaseRank: z.number().int().min(1).nullable(),
+  updatedAt: z.string().min(1),
+});
+
+export const otakuLibraryResponseSchema = z.object({
+  entries: z.array(otakuLibraryEntrySchema),
+  maxShowcaseItems: z.number().int().min(1),
+});
+
+export const otakuShowcaseUpdateRequestSchema = z.object({
+  showcaseRank: z.number().int().min(1).nullable(),
+});
+
+export const otakuShowcaseUpdateResponseSchema = z.object({
+  entry: otakuLibraryEntrySchema,
+});
+
+export type OtakuLibraryEntry = z.infer<typeof otakuLibraryEntrySchema>;
+export type OtakuLibraryResponse = z.infer<typeof otakuLibraryResponseSchema>;
+export type OtakuShowcaseUpdateValues = z.infer<typeof otakuShowcaseUpdateRequestSchema>;
+export type OtakuShowcaseUpdateResponse = z.infer<typeof otakuShowcaseUpdateResponseSchema>;

--- a/frontend/src/services/otaku.ts
+++ b/frontend/src/services/otaku.ts
@@ -1,0 +1,86 @@
+import { apiRequest } from '@/lib/api';
+import {
+  otakuLibraryResponseSchema,
+  otakuShowcaseUpdateRequestSchema,
+  otakuShowcaseUpdateResponseSchema,
+  type OtakuLibraryResponse,
+  type OtakuShowcaseUpdateResponse,
+  type OtakuShowcaseUpdateValues,
+} from '@/schemas/otaku';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+export class OtakuRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'OtakuRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchOtakuLibrary(): Promise<OtakuLibraryResponse> {
+  const response = await apiRequest('/otaku/library', {
+    method: 'GET',
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new OtakuRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel carregar a biblioteca otaku agora.'),
+    );
+  }
+
+  return otakuLibraryResponseSchema.parse(responsePayload);
+}
+
+export async function updateOtakuShowcaseEntry(
+  entryId: string,
+  input: OtakuShowcaseUpdateValues,
+): Promise<OtakuShowcaseUpdateResponse> {
+  const payload = otakuShowcaseUpdateRequestSchema.parse(input);
+  const response = await apiRequest(`/otaku/library/${encodeURIComponent(entryId)}/showcase`, {
+    method: 'PATCH',
+    body: payload,
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new OtakuRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel atualizar o showcase otaku agora.'),
+    );
+  }
+
+  return otakuShowcaseUpdateResponseSchema.parse(responsePayload);
+}

--- a/frontend/tests/unit/components/integrations-page-content.test.tsx
+++ b/frontend/tests/unit/components/integrations-page-content.test.tsx
@@ -50,6 +50,10 @@ vi.mock('@/components/settings/connection-center', () => ({
   ConnectionCenter: () => <div data-testid="connection-center" />,
 }));
 
+vi.mock('@/components/settings/otaku-showcase-manager', () => ({
+  OtakuShowcaseManager: () => <div data-testid="otaku-showcase-manager" />,
+}));
+
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedFetchProfileByUsername = vi.mocked(fetchProfileByUsername);
 const mockedFetchConnectedAccounts = vi.mocked(fetchConnectedAccounts);
@@ -222,5 +226,6 @@ describe('IntegrationsPageContent', () => {
     expect(screen.queryByText(/conta vinculada: clutch guild/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/clutchplayer/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/ainda fora do contrato frontend atual/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('otaku-showcase-manager')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/otaku-showcase-manager.test.tsx
+++ b/frontend/tests/unit/components/otaku-showcase-manager.test.tsx
@@ -1,0 +1,201 @@
+import React, { type ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OtakuShowcaseManager } from '@/components/settings/otaku-showcase-manager';
+import {
+  fetchOtakuLibrary,
+  updateOtakuShowcaseEntry,
+} from '@/services/otaku';
+
+vi.mock('next/image', () => ({
+  default: (props: { alt?: string }) => <span data-testid="mock-image">{props.alt}</span>,
+}));
+
+vi.mock('@/services/otaku', () => ({
+  fetchOtakuLibrary: vi.fn(),
+  updateOtakuShowcaseEntry: vi.fn(),
+  OtakuRequestError: class OtakuRequestError extends Error {
+    public readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = 'OtakuRequestError';
+      this.status = status;
+    }
+  },
+}));
+
+const mockedFetchOtakuLibrary = vi.mocked(fetchOtakuLibrary);
+const mockedUpdateOtakuShowcaseEntry = vi.mocked(updateOtakuShowcaseEntry);
+
+function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+const baseEntry = {
+  id: 'entry-1',
+  kind: 'ANIME' as const,
+  title: 'Sousou no Frieren',
+  coverUrl: null,
+  status: 'CONSUMING' as const,
+  progress: 4,
+  score: 9,
+  showcaseRank: null,
+  updatedAt: '2026-04-30T18:00:00.000Z',
+};
+
+describe('OtakuShowcaseManager', () => {
+  beforeEach(() => {
+    mockedFetchOtakuLibrary.mockReset();
+    mockedUpdateOtakuShowcaseEntry.mockReset();
+  });
+
+  it('mostra empty state quando nao ha importacao otaku', async () => {
+    mockedFetchOtakuLibrary.mockResolvedValue({
+      maxShowcaseItems: 3,
+      entries: [],
+    });
+
+    renderWithQuery(<OtakuShowcaseManager />);
+
+    expect(await screen.findByTestId('otaku-library-empty')).toHaveTextContent(
+      /importe listas do myanimelist/i,
+    );
+  });
+
+  it('renderiza itens importados com copy de privacidade', async () => {
+    mockedFetchOtakuLibrary.mockResolvedValue({
+      maxShowcaseItems: 3,
+      entries: [baseEntry],
+    });
+
+    renderWithQuery(<OtakuShowcaseManager />);
+
+    const manager = await screen.findByTestId('otaku-showcase-manager');
+    await screen.findByText('Sousou no Frieren');
+
+    expect(manager).toHaveTextContent('Showcase otaku');
+    expect(manager).toHaveTextContent(/biblioteca completa continua privada/i);
+    expect(manager).toHaveTextContent(/nada e publicado no feed/i);
+    expect(within(manager).getByText('Sousou no Frieren')).toBeInTheDocument();
+    expect(within(manager).getByRole('button', { name: /destacar/i })).toBeInTheDocument();
+  });
+
+  it('permite destacar item usando proxima posicao livre', async () => {
+    mockedFetchOtakuLibrary.mockResolvedValue({
+      maxShowcaseItems: 3,
+      entries: [
+        {
+          ...baseEntry,
+          id: 'entry-1',
+          title: 'Blue Lock',
+          showcaseRank: 1,
+        },
+        {
+          ...baseEntry,
+          id: 'entry-2',
+          title: 'Dungeon Meshi',
+          showcaseRank: null,
+        },
+      ],
+    });
+    mockedUpdateOtakuShowcaseEntry.mockResolvedValue({
+      entry: {
+        ...baseEntry,
+        id: 'entry-2',
+        title: 'Dungeon Meshi',
+        showcaseRank: 2,
+      },
+    });
+
+    renderWithQuery(<OtakuShowcaseManager />);
+
+    const dungeonRow = await screen.findByText('Dungeon Meshi');
+    const row = dungeonRow.closest('[data-testid="otaku-library-entry"]');
+
+    expect(row).not.toBeNull();
+    fireEvent.click(within(row as HTMLElement).getByRole('button', { name: /destacar/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateOtakuShowcaseEntry).toHaveBeenCalledWith('entry-2', {
+        showcaseRank: 2,
+      });
+    });
+    expect(await screen.findByText(/dungeon meshi agora aparece no showcase publico/i))
+      .toBeInTheDocument();
+  });
+
+  it('permite remover destaque sem apagar item', async () => {
+    mockedFetchOtakuLibrary.mockResolvedValue({
+      maxShowcaseItems: 3,
+      entries: [
+        {
+          ...baseEntry,
+          showcaseRank: 1,
+        },
+      ],
+    });
+    mockedUpdateOtakuShowcaseEntry.mockResolvedValue({
+      entry: {
+        ...baseEntry,
+        showcaseRank: null,
+      },
+    });
+
+    renderWithQuery(<OtakuShowcaseManager />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /remover destaque/i }));
+
+    await waitFor(() => {
+      expect(mockedUpdateOtakuShowcaseEntry).toHaveBeenCalledWith('entry-1', {
+        showcaseRank: null,
+      });
+    });
+    expect(await screen.findByText(/sousou no frieren saiu do showcase publico/i))
+      .toBeInTheDocument();
+  });
+
+  it('desabilita destaque quando limite foi atingido', async () => {
+    mockedFetchOtakuLibrary.mockResolvedValue({
+      maxShowcaseItems: 3,
+      entries: [
+        { ...baseEntry, id: 'entry-1', title: 'A', showcaseRank: 1 },
+        { ...baseEntry, id: 'entry-2', title: 'B', showcaseRank: 2 },
+        { ...baseEntry, id: 'entry-3', title: 'C', showcaseRank: 3 },
+        { ...baseEntry, id: 'entry-4', title: 'D', showcaseRank: null },
+      ],
+    });
+
+    renderWithQuery(<OtakuShowcaseManager />);
+
+    expect(await screen.findByText(/limite atingido/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^destacar$/i })).toBeDisabled();
+  });
+
+  it('mostra erro seguro quando backend bloqueia alteracao', async () => {
+    mockedFetchOtakuLibrary.mockResolvedValue({
+      maxShowcaseItems: 3,
+      entries: [baseEntry],
+    });
+    mockedUpdateOtakuShowcaseEntry.mockRejectedValue(
+      new Error('O showcase otaku aceita no máximo 3 itens.'),
+    );
+
+    renderWithQuery(<OtakuShowcaseManager />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /destacar/i }));
+
+    expect(await screen.findByText(/nao foi possivel atualizar o showcase otaku agora/i))
+      .toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/services/otaku.test.ts
+++ b/frontend/tests/unit/services/otaku.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchOtakuLibrary,
+  OtakuRequestError,
+  updateOtakuShowcaseEntry,
+} from '@/services/otaku';
+import { apiRequest } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+function createJsonResponse(status: number, payload: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(payload),
+  } as Response;
+}
+
+describe('otaku service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('lista biblioteca otaku segura', async () => {
+    mockedApiRequest.mockResolvedValue(createJsonResponse(200, {
+      maxShowcaseItems: 3,
+      entries: [
+        {
+          id: 'entry-1',
+          kind: 'ANIME',
+          title: 'Sousou no Frieren',
+          coverUrl: null,
+          status: 'CONSUMING',
+          progress: 4,
+          score: 9,
+          showcaseRank: null,
+          updatedAt: '2026-04-30T18:00:00.000Z',
+        },
+      ],
+    }));
+
+    await expect(fetchOtakuLibrary()).resolves.toMatchObject({
+      maxShowcaseItems: 3,
+      entries: [
+        {
+          id: 'entry-1',
+          title: 'Sousou no Frieren',
+        },
+      ],
+    });
+    expect(mockedApiRequest).toHaveBeenCalledWith('/otaku/library', {
+      method: 'GET',
+    });
+  });
+
+  it('atualiza showcaseRank de item otaku', async () => {
+    mockedApiRequest.mockResolvedValue(createJsonResponse(200, {
+      entry: {
+        id: 'entry-1',
+        kind: 'MANGA',
+        title: 'Berserk',
+        coverUrl: null,
+        status: 'COMPLETED',
+        progress: 12,
+        score: null,
+        showcaseRank: 1,
+        updatedAt: '2026-04-30T18:00:00.000Z',
+      },
+    }));
+
+    await expect(updateOtakuShowcaseEntry('entry-1', { showcaseRank: 1 }))
+      .resolves.toMatchObject({
+        entry: {
+          id: 'entry-1',
+          showcaseRank: 1,
+        },
+      });
+    expect(mockedApiRequest).toHaveBeenCalledWith('/otaku/library/entry-1/showcase', {
+      method: 'PATCH',
+      body: { showcaseRank: 1 },
+    });
+  });
+
+  it('mapeia erro do backend sem depender de payload sensivel', async () => {
+    mockedApiRequest.mockResolvedValue(createJsonResponse(409, {
+      message: 'O showcase otaku aceita no máximo 3 itens.',
+      externalId: 'mal-123',
+      metadata: { raw: true },
+    }));
+
+    const result = updateOtakuShowcaseEntry('entry-1', { showcaseRank: 1 });
+
+    await expect(result).rejects.toBeInstanceOf(OtakuRequestError);
+    await expect(result).rejects.toMatchObject({
+      status: 409,
+      message: 'O showcase otaku aceita no máximo 3 itens.',
+    });
+  });
+});


### PR DESCRIPTION
﻿## Resumo
Implementa o primeiro slice de curadoria opt-in para o showcase p?blico de anime/manga no perfil. A mudan?a permite listar a biblioteca otaku privada do usu?rio, destacar/remover itens manualmente e manter o perfil p?blico limitado apenas aos itens com `showcaseRank` definido.

Closes #292

## O que foi alterado
- Backend:
  - Adiciona rotas autenticadas `GET /otaku/library` e `PATCH /otaku/library/:entryId/showcase`.
  - Expande `OtakuShowcaseService` com listagem segura da biblioteca do usu?rio e atualiza??o de destaque.
  - Aplica limite m?ximo de 3 itens destacados, valida ownership e rejeita ranks fora de `1`, `2`, `3` ou `null`.
  - Normaliza rank duplicado removendo o destaque anterior da mesma posi??o em transa??o serializ?vel.
  - Mant?m o perfil p?blico derivado apenas de entradas com `showcaseRank` definido.
- Frontend:
  - Adiciona service e schemas para biblioteca/showcase otaku.
  - Integra um gerenciador m?nimo de destaque em `/settings/integrations`.
  - Exibe estados de loading, erro, vazio, limite atingido e copy de privacidade.
- Testes:
  - Adiciona cobertura de rotas, service backend, service frontend e componente de curadoria.
  - Refor?a testes de rank inv?lido, limite, ownership, rank duplicado e payload seguro.

## Motiva??o
A importa??o inicial do MyAnimeList mant?m os itens privados por padr?o. Esta PR adiciona o passo expl?cito de opt-in para que o usu?rio escolha poucos itens destacados no perfil p?blico, sem publicar a watchlist completa, sem feed e sem nova sincroniza??o externa.

## Como validar
- Backend:
  - `cd backend`
  - `npm run test -- tests/unit/services/otaku-showcase.service.test.ts tests/integration/routes/otaku.routes.test.ts tests/integration/routes/profile.routes.test.ts`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Frontend:
  - `cd frontend`
  - `npm run test -- tests/unit/services/otaku.test.ts tests/unit/components/otaku-showcase-manager.test.tsx tests/unit/components/integrations-page-content.test.tsx tests/unit/components/otaku-showcase-card.test.tsx`
  - `npm run test:coverage`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`

## Riscos e impactos
- O novo contrato backend ? autenticado e n?o retorna `externalId`, metadata, payload bruto ou tokens.
- O limite de showcase foi fixado em 3 itens para alinhar com o resumo p?blico existente do perfil.
- Rank duplicado ? tratado de forma determin?stica: a posi??o escolhida fica com o item atualizado e qualquer destaque anterior naquela posi??o ? removido.
- `npm run test:coverage` completo no backend n?o foi conclusivo localmente porque suites de integra??o exigem Postgres em `localhost:5432`; os testes focados passaram.

## Evid?ncias
- Testes focados de backend: 3 arquivos passaram, 32 testes passaram.
- Testes focados de frontend: 4 arquivos passaram, 12 testes passaram.
- Frontend `npm run test:coverage`: 72 arquivos passaram, 271 testes passaram, cobertura global de linhas/statements em 82.66%.
- Backend `typecheck`, `lint` e `build` passaram; o lint manteve avisos preexistentes em `backend/src/config/rate-limit.ts`.
- Frontend `typecheck`, `lint` e `build` passaram.

## Checklist
- [x] Altera??o limitada ao objetivo da PR
- [x] Sem mudan?as desconexas
- [x] Impactos principais descritos
- [x] Valida??o documentada
- [x] Riscos identificados
