### PR TITLE
feat(communities): implementa arquivamento e slug único

### DIFF
--- a/backend/src/api/routes/communities.routes.ts
+++ b/backend/src/api/routes/communities.routes.ts
@@ -37,8 +37,10 @@ function sendCommunityServiceError(
   const statusByCode: Record<CommunityServiceError['code'], number> = {
     COMMUNITY_NOT_FOUND: 404,
     COMMUNITY_SLUG_CONFLICT: 409,
+    COMMUNITY_ARCHIVED: 409,
     COMMUNITY_ALREADY_JOINED: 409,
     COMMUNITY_OWNER_CANNOT_LEAVE: 403,
+    COMMUNITY_FORBIDDEN: 403,
     COMMUNITY_MEMBERSHIP_NOT_FOUND: 404,
   };
 
@@ -151,6 +153,33 @@ export async function communityRoutes(app: FastifyInstance): Promise<void> {
 
       try {
         const community = await communityService.leaveCommunity(params.data.slug, request.userId);
+
+        return reply.status(200).send({ community });
+      } catch (error) {
+        if (error instanceof CommunityServiceError) {
+          return sendCommunityServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.patch<{ Params: { slug: string } }>(
+    '/:slug/archive',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = slugParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const community = await communityService.archiveCommunity(params.data.slug, request.userId);
 
         return reply.status(200).send({ community });
       } catch (error) {

--- a/backend/src/core/repositories/community.repository.ts
+++ b/backend/src/core/repositories/community.repository.ts
@@ -151,6 +151,15 @@ export const communityRepository = {
     return community ? toSummary(community) : null;
   },
 
+  async slugExists(slug: string): Promise<boolean> {
+    const community = await prisma.community.findUnique({
+      where: { slug },
+      select: { id: true },
+    });
+
+    return Boolean(community);
+  },
+
   async findBySlug(slug: string): Promise<CommunitySummary | null> {
     const community = await prisma.community.findUnique({
       where: { slug },
@@ -158,6 +167,18 @@ export const communityRepository = {
     });
 
     return community ? toSummary(community) : null;
+  },
+
+  async archive(communityId: string): Promise<CommunitySummary> {
+    const community = await prisma.community.update({
+      where: { id: communityId },
+      data: {
+        status: CommunityStatus.ARCHIVED,
+      },
+      select: communitySelect,
+    });
+
+    return toSummary(community);
   },
 
   async findMembershipRole(

--- a/backend/src/core/services/community.service.ts
+++ b/backend/src/core/services/community.service.ts
@@ -1,4 +1,4 @@
-import { CommunityMemberRole } from '@prisma/client';
+import { CommunityMemberRole, CommunityStatus } from '@prisma/client';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import {
   communityRepository,
@@ -9,8 +9,10 @@ import {
 export type CommunityServiceErrorCode =
   | 'COMMUNITY_NOT_FOUND'
   | 'COMMUNITY_SLUG_CONFLICT'
+  | 'COMMUNITY_ARCHIVED'
   | 'COMMUNITY_ALREADY_JOINED'
   | 'COMMUNITY_OWNER_CANNOT_LEAVE'
+  | 'COMMUNITY_FORBIDDEN'
   | 'COMMUNITY_MEMBERSHIP_NOT_FOUND';
 
 export class CommunityServiceError extends Error {
@@ -36,13 +38,39 @@ function normalizeSlug(input: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, 64);
+    .slice(0, 64)
+    .replace(/-+$/g, '');
 
   return normalized.length > 0 ? normalized : 'community';
 }
 
 function isUniqueConstraintError(error: unknown): boolean {
   return error instanceof PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
+function buildSlugCandidate(baseSlug: string, offset: number): string {
+  if (offset === 0) {
+    return baseSlug;
+  }
+
+  const suffix = `-${offset + 1}`;
+  return `${baseSlug.slice(0, 64 - suffix.length).replace(/-+$/g, '')}${suffix}`;
+}
+
+async function resolveAvailableSlug(baseSlug: string): Promise<string> {
+  for (let offset = 0; offset < 20; offset += 1) {
+    const candidate = buildSlugCandidate(baseSlug, offset);
+    const exists = await communityRepository.slugExists(candidate);
+
+    if (!exists) {
+      return candidate;
+    }
+  }
+
+  throw new CommunityServiceError(
+    'COMMUNITY_SLUG_CONFLICT',
+    'Não foi possível gerar um slug único para esta comunidade.',
+  );
 }
 
 async function withViewerRole(
@@ -78,7 +106,7 @@ export const communityService = {
     slug: string,
     viewerUserId?: string | null,
   ): Promise<CommunityDetail> {
-    const community = await communityRepository.findPublicActiveBySlug(slug);
+    const community = await communityRepository.findBySlug(slug);
 
     if (!community) {
       throw new CommunityServiceError(
@@ -91,50 +119,51 @@ export const communityService = {
   },
 
   async createPublicCommunity(input: CreateCommunityServiceInput): Promise<CommunityDetail> {
-    const slug = normalizeSlug(input.name);
+    const baseSlug = normalizeSlug(input.name);
     const description = input.description?.trim();
-    const existingCommunity = await communityRepository.findBySlug(slug);
 
-    if (existingCommunity) {
-      throw new CommunityServiceError(
-        'COMMUNITY_SLUG_CONFLICT',
-        'Já existe uma comunidade com esse nome.',
-      );
-    }
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const slug = await resolveAvailableSlug(baseSlug);
 
-    let community: CommunitySummary;
+      try {
+        const community = await communityRepository.create({
+          ownerUserId: input.ownerUserId,
+          slug,
+          name: input.name,
+          description: description && description.length > 0 ? description : null,
+        });
 
-    try {
-      community = await communityRepository.create({
-        ownerUserId: input.ownerUserId,
-        slug,
-        name: input.name,
-        description: description && description.length > 0 ? description : null,
-      });
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        throw new CommunityServiceError(
-          'COMMUNITY_SLUG_CONFLICT',
-          'Já existe uma comunidade com esse nome.',
-        );
+        return {
+          ...community,
+          viewerMembershipRole: CommunityMemberRole.OWNER,
+        };
+      } catch (error) {
+        if (!isUniqueConstraintError(error)) {
+          throw error;
+        }
       }
-
-      throw error;
     }
 
-    return {
-      ...community,
-      viewerMembershipRole: CommunityMemberRole.OWNER,
-    };
+    throw new CommunityServiceError(
+      'COMMUNITY_SLUG_CONFLICT',
+      'Não foi possível gerar um slug único para esta comunidade.',
+    );
   },
 
   async joinCommunity(slug: string, userId: string): Promise<CommunityDetail> {
-    const community = await communityRepository.findPublicActiveBySlug(slug);
+    const community = await communityRepository.findBySlug(slug);
 
     if (!community) {
       throw new CommunityServiceError(
         'COMMUNITY_NOT_FOUND',
         'Comunidade pública não encontrada.',
+      );
+    }
+
+    if (community.status === CommunityStatus.ARCHIVED) {
+      throw new CommunityServiceError(
+        'COMMUNITY_ARCHIVED',
+        'Comunidade arquivada não aceita novos membros.',
       );
     }
 
@@ -159,7 +188,7 @@ export const communityService = {
 
       throw error;
     }
-    const updatedCommunity = await communityRepository.findPublicActiveBySlug(slug);
+    const updatedCommunity = await communityRepository.findBySlug(slug);
 
     if (!updatedCommunity) {
       throw new CommunityServiceError(
@@ -175,7 +204,7 @@ export const communityService = {
   },
 
   async leaveCommunity(slug: string, userId: string): Promise<CommunityDetail> {
-    const community = await communityRepository.findPublicActiveBySlug(slug);
+    const community = await communityRepository.findBySlug(slug);
 
     if (!community) {
       throw new CommunityServiceError(
@@ -209,7 +238,7 @@ export const communityService = {
       );
     }
 
-    const updatedCommunity = await communityRepository.findPublicActiveBySlug(slug);
+    const updatedCommunity = await communityRepository.findBySlug(slug);
 
     if (!updatedCommunity) {
       throw new CommunityServiceError(
@@ -221,6 +250,40 @@ export const communityService = {
     return {
       ...updatedCommunity,
       viewerMembershipRole: null,
+    };
+  },
+
+  async archiveCommunity(slug: string, userId: string): Promise<CommunityDetail> {
+    const community = await communityRepository.findBySlug(slug);
+
+    if (!community) {
+      throw new CommunityServiceError(
+        'COMMUNITY_NOT_FOUND',
+        'Comunidade pública não encontrada.',
+      );
+    }
+
+    const existingRole = await communityRepository.findMembershipRole(community.id, userId);
+
+    if (existingRole !== CommunityMemberRole.OWNER) {
+      throw new CommunityServiceError(
+        'COMMUNITY_FORBIDDEN',
+        'Apenas o owner pode arquivar esta comunidade.',
+      );
+    }
+
+    if (community.status === CommunityStatus.ARCHIVED) {
+      return {
+        ...community,
+        viewerMembershipRole: CommunityMemberRole.OWNER,
+      };
+    }
+
+    const archivedCommunity = await communityRepository.archive(community.id);
+
+    return {
+      ...archivedCommunity,
+      viewerMembershipRole: CommunityMemberRole.OWNER,
     };
   },
 };

--- a/backend/tests/integration/routes/communities.routes.test.ts
+++ b/backend/tests/integration/routes/communities.routes.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/core/services/community.service', async (importOriginal) => {
       createPublicCommunity: vi.fn(),
       joinCommunity: vi.fn(),
       leaveCommunity: vi.fn(),
+      archiveCommunity: vi.fn(),
     },
   };
 });
@@ -89,6 +90,29 @@ describe('Communities Routes', () => {
     await app.close();
   });
 
+  it('retorna detalhe direto de comunidade arquivada', async () => {
+    vi.mocked(communityService.getPublicCommunity).mockResolvedValue({
+      ...mockCommunity,
+      status: CommunityStatus.ARCHIVED,
+      viewerMembershipRole: null,
+    });
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/communities/guilda-dos-speedrunners',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      community: {
+        slug: 'guilda-dos-speedrunners',
+        status: CommunityStatus.ARCHIVED,
+      },
+    });
+    await app.close();
+  });
+
   it('cria comunidade pública autenticada', async () => {
     vi.mocked(communityService.createPublicCommunity).mockResolvedValue({
       ...mockCommunity,
@@ -136,6 +160,33 @@ describe('Communities Routes', () => {
     });
 
     expect(response.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it('cria comunidade publica com slug unico gerado pelo service', async () => {
+    vi.mocked(communityService.createPublicCommunity).mockResolvedValue({
+      ...mockCommunity,
+      slug: 'guilda-dos-speedrunners-2',
+      viewerMembershipRole: CommunityMemberRole.OWNER,
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        name: 'Guilda dos Speedrunners',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      community: {
+        slug: 'guilda-dos-speedrunners-2',
+      },
+    });
     await app.close();
   });
 
@@ -198,6 +249,74 @@ describe('Communities Routes', () => {
       'guilda-dos-speedrunners',
       'member-id-1',
     );
+    await app.close();
+  });
+
+  it('permite owner arquivar comunidade', async () => {
+    vi.mocked(communityService.archiveCommunity).mockResolvedValue({
+      ...mockCommunity,
+      status: CommunityStatus.ARCHIVED,
+      viewerMembershipRole: CommunityMemberRole.OWNER,
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/communities/guilda-dos-speedrunners/archive',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityService.archiveCommunity).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'owner-id-1',
+    );
+    expect(response.json()).toMatchObject({
+      community: {
+        status: CommunityStatus.ARCHIVED,
+      },
+    });
+    await app.close();
+  });
+
+  it('bloqueia arquivamento por membro comum', async () => {
+    vi.mocked(communityService.archiveCommunity).mockRejectedValue(
+      new CommunityServiceError(
+        'COMMUNITY_FORBIDDEN',
+        'Apenas o owner pode arquivar esta comunidade.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/communities/guilda-dos-speedrunners/archive',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('bloqueia join em comunidade arquivada com erro de dominio', async () => {
+    vi.mocked(communityService.joinCommunity).mockRejectedValue(
+      new CommunityServiceError(
+        'COMMUNITY_ARCHIVED',
+        'Comunidade arquivada não aceita novos membros.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/join',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(409);
     await app.close();
   });
 });

--- a/backend/tests/unit/services/community.service.test.ts
+++ b/backend/tests/unit/services/community.service.test.ts
@@ -9,10 +9,12 @@ vi.mock('@/core/repositories/community.repository', () => ({
     create: vi.fn(),
     findPublicActive: vi.fn(),
     findPublicActiveBySlug: vi.fn(),
+    slugExists: vi.fn(),
     findBySlug: vi.fn(),
     findMembershipRole: vi.fn(),
     addMember: vi.fn(),
     removeMember: vi.fn(),
+    archive: vi.fn(),
   },
 }));
 
@@ -53,8 +55,25 @@ describe('communityService', () => {
     );
   });
 
+  it('usa fallback seguro quando nome não gera slug válido', () => {
+    expect(communityService.normalizeSlug('!!!')).toBe('community');
+  });
+
+  it('remove hífen final após truncar slug longo', () => {
+    expect(communityService.normalizeSlug(`${'a'.repeat(63)} Guilda`)).toBe('a'.repeat(63));
+  });
+
+  it('lista apenas comunidades públicas ativas pelo repository dedicado', async () => {
+    vi.mocked(communityRepository.findPublicActive).mockResolvedValue([baseCommunity]);
+
+    const result = await communityService.listPublicCommunities();
+
+    expect(communityRepository.findPublicActive).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([baseCommunity]);
+  });
+
   it('cria comunidade pública com membership OWNER para o criador', async () => {
-    vi.mocked(communityRepository.findBySlug).mockResolvedValue(null);
+    vi.mocked(communityRepository.slugExists).mockResolvedValue(false);
     vi.mocked(communityRepository.create).mockResolvedValue(baseCommunity);
 
     const result = await communityService.createPublicCommunity({
@@ -72,37 +91,51 @@ describe('communityService', () => {
     expect(result.viewerMembershipRole).toBe(CommunityMemberRole.OWNER);
   });
 
-  it('bloqueia criação com slug já existente', async () => {
-    vi.mocked(communityRepository.findBySlug).mockResolvedValue(baseCommunity);
-
-    await expect(
-      communityService.createPublicCommunity({
-        ownerUserId: 'owner-id-1',
-        name: 'Guilda dos Speedrunners',
-      }),
-    ).rejects.toMatchObject({
-      code: 'COMMUNITY_SLUG_CONFLICT',
+  it('gera slug unico previsivel quando nomes equivalentes colidem', async () => {
+    vi.mocked(communityRepository.slugExists)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    vi.mocked(communityRepository.create).mockResolvedValue({
+      ...baseCommunity,
+      slug: 'guilda-dos-speedrunners-2',
     });
+
+    const result = await communityService.createPublicCommunity({
+      ownerUserId: 'owner-id-1',
+      name: 'Guilda dos Speedrunners',
+    });
+
+    expect(communityRepository.create).toHaveBeenCalledWith(expect.objectContaining({
+      slug: 'guilda-dos-speedrunners-2',
+    }));
+    expect(result.slug).toBe('guilda-dos-speedrunners-2');
   });
 
-  it('traduz corrida de slug único na criação para conflito de domínio', async () => {
-    vi.mocked(communityRepository.findBySlug).mockResolvedValue(null);
-    vi.mocked(communityRepository.create).mockRejectedValue(
-      createUniqueConstraintError(['slug']),
-    );
+  it('retenta criacao quando corrida concorrente ocupa slug candidato', async () => {
+    vi.mocked(communityRepository.slugExists)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    vi.mocked(communityRepository.create)
+      .mockRejectedValueOnce(createUniqueConstraintError(['slug']))
+      .mockResolvedValueOnce({
+        ...baseCommunity,
+        slug: 'guilda-dos-speedrunners-2',
+      });
 
-    await expect(
-      communityService.createPublicCommunity({
-        ownerUserId: 'owner-id-1',
-        name: 'Guilda dos Speedrunners',
-      }),
-    ).rejects.toMatchObject({
-      code: 'COMMUNITY_SLUG_CONFLICT',
+    const result = await communityService.createPublicCommunity({
+      ownerUserId: 'owner-id-1',
+      name: 'Guilda dos Speedrunners',
     });
+
+    expect(communityRepository.create).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      slug: 'guilda-dos-speedrunners-2',
+    }));
+    expect(result.slug).toBe('guilda-dos-speedrunners-2');
   });
 
   it('retorna papel do viewer ao buscar comunidade pública autenticada', async () => {
-    vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(baseCommunity);
     vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
 
     const result = await communityService.getPublicCommunity(
@@ -114,7 +147,7 @@ describe('communityService', () => {
   });
 
   it('permite entrar em comunidade pública quando usuário ainda não é membro', async () => {
-    vi.mocked(communityRepository.findPublicActiveBySlug)
+    vi.mocked(communityRepository.findBySlug)
       .mockResolvedValueOnce(baseCommunity)
       .mockResolvedValueOnce({ ...baseCommunity, memberCount: 2 });
     vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(null);
@@ -134,7 +167,7 @@ describe('communityService', () => {
   });
 
   it('traduz corrida de membership único ao entrar para conflito de domínio', async () => {
-    vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(baseCommunity);
     vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(null);
     vi.mocked(communityRepository.addMember).mockRejectedValue(
       createUniqueConstraintError(['communityId', 'userId']),
@@ -148,7 +181,7 @@ describe('communityService', () => {
   });
 
   it('impede owner de sair pelo fluxo simples de membership', async () => {
-    vi.mocked(communityRepository.findPublicActiveBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(baseCommunity);
     vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
 
     await expect(
@@ -156,5 +189,89 @@ describe('communityService', () => {
     ).rejects.toMatchObject({
       code: 'COMMUNITY_OWNER_CANNOT_LEAVE',
     });
+  });
+
+  it('bloqueia entrada em comunidade arquivada', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue({
+      ...baseCommunity,
+      status: CommunityStatus.ARCHIVED,
+    });
+
+    await expect(
+      communityService.joinCommunity('guilda-dos-speedrunners', 'member-id-1'),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_ARCHIVED',
+    });
+    expect(communityRepository.addMember).not.toHaveBeenCalled();
+  });
+
+  it('permite membro sair de comunidade arquivada sem reabrir a comunidade', async () => {
+    vi.mocked(communityRepository.findBySlug)
+      .mockResolvedValueOnce({
+        ...baseCommunity,
+        status: CommunityStatus.ARCHIVED,
+      })
+      .mockResolvedValueOnce({
+        ...baseCommunity,
+        status: CommunityStatus.ARCHIVED,
+        memberCount: 1,
+      });
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+    vi.mocked(communityRepository.removeMember).mockResolvedValue(1);
+
+    const result = await communityService.leaveCommunity(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+
+    expect(result.status).toBe(CommunityStatus.ARCHIVED);
+    expect(result.viewerMembershipRole).toBeNull();
+  });
+
+  it('permite owner arquivar comunidade ativa', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+    vi.mocked(communityRepository.archive).mockResolvedValue({
+      ...baseCommunity,
+      status: CommunityStatus.ARCHIVED,
+    });
+
+    const result = await communityService.archiveCommunity(
+      'guilda-dos-speedrunners',
+      'owner-id-1',
+    );
+
+    expect(communityRepository.archive).toHaveBeenCalledWith('community-id-1');
+    expect(result.status).toBe(CommunityStatus.ARCHIVED);
+    expect(result.viewerMembershipRole).toBe(CommunityMemberRole.OWNER);
+  });
+
+  it('bloqueia arquivamento por membro comum', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(baseCommunity);
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+
+    await expect(
+      communityService.archiveCommunity('guilda-dos-speedrunners', 'member-id-1'),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_FORBIDDEN',
+    });
+    expect(communityRepository.archive).not.toHaveBeenCalled();
+  });
+
+  it('mantém arquivamento idempotente quando comunidade já está arquivada', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue({
+      ...baseCommunity,
+      status: CommunityStatus.ARCHIVED,
+    });
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+
+    const result = await communityService.archiveCommunity(
+      'guilda-dos-speedrunners',
+      'owner-id-1',
+    );
+
+    expect(communityRepository.archive).not.toHaveBeenCalled();
+    expect(result.status).toBe(CommunityStatus.ARCHIVED);
+    expect(result.viewerMembershipRole).toBe(CommunityMemberRole.OWNER);
   });
 });

--- a/frontend/src/components/communities/communities-page-content.tsx
+++ b/frontend/src/components/communities/communities-page-content.tsx
@@ -53,6 +53,9 @@ export function CommunitiesPageContent() {
 
   const isAuthenticated = status === 'authenticated';
   const canSubmit = isAuthenticated && name.trim().length >= 3 && !createCommunityMutation.isPending;
+  const visibleCommunities = communitiesQuery.data?.filter(
+    (community) => community.status === 'ACTIVE',
+  );
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -72,6 +75,7 @@ export function CommunitiesPageContent() {
       <SectionHeading
         eyebrow="Comunidades"
         title="Guildas públicas para pertencer sem virar chat"
+        level="h1"
         description="O primeiro slice mantém descoberta simples, identidade básica e membership mínimo. Eventos, chat e governança pesada ficam fora deste recorte."
       />
 
@@ -121,7 +125,7 @@ export function CommunitiesPageContent() {
             <p className="text-sm text-secondary" role={formMessage ? 'alert' : undefined}>
               {formMessage ??
                 (isAuthenticated
-                  ? 'O slug é derivado do nome e precisa ser único.'
+                  ? 'O slug é derivado do nome e recebe sufixo automático quando necessário.'
                   : 'Entre na sessão para criar uma comunidade pública.')}
             </p>
             <Button type="submit" disabled={!canSubmit}>
@@ -145,7 +149,7 @@ export function CommunitiesPageContent() {
         </Card>
       ) : null}
 
-      {communitiesQuery.data?.length === 0 ? (
+      {visibleCommunities?.length === 0 ? (
         <Card>
           <p className="text-sm leading-6 text-secondary">
             Ainda não há comunidades públicas. Crie a primeira para validar o fluxo básico
@@ -154,9 +158,9 @@ export function CommunitiesPageContent() {
         </Card>
       ) : null}
 
-      {communitiesQuery.data && communitiesQuery.data.length > 0 ? (
+      {visibleCommunities && visibleCommunities.length > 0 ? (
         <div className="grid gap-5 lg:grid-cols-2">
-          {communitiesQuery.data.map((community) => (
+          {visibleCommunities.map((community) => (
             <CommunityCard key={community.id} community={community} />
           ))}
         </div>

--- a/frontend/src/components/communities/community-page-content.tsx
+++ b/frontend/src/components/communities/community-page-content.tsx
@@ -8,6 +8,7 @@ import { Card } from '@/components/ui/card';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { useAuth } from '@/hooks/use-auth';
 import {
+  archiveCommunity,
   CommunitiesRequestError,
   fetchCommunityBySlug,
   joinCommunity,
@@ -54,6 +55,16 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
     },
   });
 
+  const archiveMutation = useMutation({
+    mutationFn: () => archiveCommunity(slug),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['communities'] }),
+        queryClient.invalidateQueries({ queryKey: ['communities', slug] }),
+      ]);
+    },
+  });
+
   if (communityQuery.isLoading) {
     return (
       <Card>
@@ -83,14 +94,16 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
   const ownerLabel = community.owner.displayName ?? community.owner.username;
   const isOwner = community.viewerMembershipRole === 'OWNER';
   const isMember = community.viewerMembershipRole === 'MEMBER';
-  const actionIsPending = joinMutation.isPending || leaveMutation.isPending;
-  const mutationError = joinMutation.error ?? leaveMutation.error;
+  const isArchived = community.status === 'ARCHIVED';
+  const actionIsPending = joinMutation.isPending || leaveMutation.isPending || archiveMutation.isPending;
+  const mutationError = joinMutation.error ?? leaveMutation.error ?? archiveMutation.error;
 
   return (
     <div className="flex flex-col gap-section">
       <SectionHeading
         eyebrow="Comunidade pública"
         title={community.name}
+        level="h1"
         description={
           community.description ??
           'Espaço público para reunir jogadores em torno de um interesse compartilhado.'
@@ -111,6 +124,7 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
             <div className="flex flex-wrap items-center gap-2">
               <Badge tone="success">{community.memberCount} membros</Badge>
               <Badge tone="neutral">Pública</Badge>
+              {isArchived ? <Badge tone="warning">Arquivada</Badge> : null}
               {community.viewerMembershipRole ? (
                 <Badge tone="accent">{community.viewerMembershipRole}</Badge>
               ) : null}
@@ -119,13 +133,32 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
               Owner: <span className="text-primary">{ownerLabel}</span>
             </p>
             <p className="mt-2 text-sm leading-6 text-secondary">
-              Este slice valida leitura pública e membership simples. Eventos, chat e
-              governança avançada ainda não fazem parte desta comunidade.
+              {isArchived
+                ? 'Esta comunidade foi arquivada. O histórico segue acessível por URL direta, mas novas participações e ações de eventos ficam bloqueadas.'
+                : 'Este slice valida leitura pública e membership simples. Eventos, chat e governança avançada ainda não fazem parte desta comunidade.'}
             </p>
           </div>
 
           <div className="flex min-w-48 flex-col gap-2">
-            {!isAuthenticated ? (
+            {isArchived && isMember ? (
+              <>
+                <p className="text-sm leading-6 text-secondary">
+                  Comunidade arquivada. Você ainda pode sair sem reativar a comunidade.
+                </p>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={actionIsPending}
+                  onClick={() => leaveMutation.mutate()}
+                >
+                  Sair da comunidade arquivada
+                </Button>
+              </>
+            ) : isArchived ? (
+              <p className="text-sm leading-6 text-secondary">
+                Comunidade arquivada. Ações de participação estão indisponíveis.
+              </p>
+            ) : !isAuthenticated ? (
               <p className="text-sm leading-6 text-secondary">
                 Entre na sessão para participar desta comunidade.
               </p>
@@ -151,6 +184,16 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
                 Participar
               </Button>
             )}
+            {isOwner && !isArchived ? (
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={actionIsPending}
+                onClick={() => archiveMutation.mutate()}
+              >
+                Arquivar comunidade
+              </Button>
+            ) : null}
           </div>
         </div>
 

--- a/frontend/src/services/communities.ts
+++ b/frontend/src/services/communities.ts
@@ -133,3 +133,19 @@ export async function leaveCommunity(slug: string): Promise<Community> {
 
   return communityResponseSchema.parse(payload).community;
 }
+
+export async function archiveCommunity(slug: string): Promise<Community> {
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}/archive`, {
+    method: 'PATCH',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel arquivar esta comunidade.'),
+    );
+  }
+
+  return communityResponseSchema.parse(payload).community;
+}

--- a/frontend/tests/unit/components/communities-page-content.test.tsx
+++ b/frontend/tests/unit/components/communities-page-content.test.tsx
@@ -84,6 +84,24 @@ describe('CommunitiesPageContent', () => {
     expect(screen.getByText(/owner: owner/i)).toBeInTheDocument();
   });
 
+  it('does not render archived communities in public discovery', async () => {
+    mockedFetchCommunities.mockResolvedValue([
+      community,
+      {
+        ...community,
+        id: 'community-id-2',
+        slug: 'guilda-arquivada',
+        name: 'Guilda Arquivada',
+        status: 'ARCHIVED',
+      },
+    ]);
+
+    renderCommunitiesPage();
+
+    expect(await screen.findByText('Guilda dos Speedrunners')).toBeInTheDocument();
+    expect(screen.queryByText('Guilda Arquivada')).not.toBeInTheDocument();
+  });
+
   it('creates a community and navigates to its public page', async () => {
     mockedFetchCommunities.mockResolvedValue([]);
     mockedCreateCommunity.mockResolvedValue(community);

--- a/frontend/tests/unit/components/community-page-content.test.tsx
+++ b/frontend/tests/unit/components/community-page-content.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CommunityPageContent } from '@/components/communities/community-page-content';
 import { useAuth } from '@/hooks/use-auth';
 import {
+  archiveCommunity,
   fetchCommunityBySlug,
   joinCommunity,
   leaveCommunity,
@@ -18,12 +19,14 @@ vi.mock('@/services/communities', () => ({
   fetchCommunityBySlug: vi.fn(),
   joinCommunity: vi.fn(),
   leaveCommunity: vi.fn(),
+  archiveCommunity: vi.fn(),
 }));
 
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedFetchCommunityBySlug = vi.mocked(fetchCommunityBySlug);
 const mockedJoinCommunity = vi.mocked(joinCommunity);
 const mockedLeaveCommunity = vi.mocked(leaveCommunity);
+const mockedArchiveCommunity = vi.mocked(archiveCommunity);
 
 const community = {
   id: 'community-id-1',
@@ -65,6 +68,7 @@ describe('CommunityPageContent', () => {
     mockedFetchCommunityBySlug.mockReset();
     mockedJoinCommunity.mockReset();
     mockedLeaveCommunity.mockReset();
+    mockedArchiveCommunity.mockReset();
     mockedUseAuth.mockReturnValue({
       user: { id: 'user-id-1', username: 'clutchplayer', email: 'player@clutch.gg' },
       status: 'authenticated',
@@ -115,5 +119,72 @@ describe('CommunityPageContent', () => {
     await waitFor(() => {
       expect(mockedLeaveCommunity).toHaveBeenCalledWith('guilda-dos-speedrunners');
     });
+  });
+
+  it('shows archived state without join CTA on direct access', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      status: 'ARCHIVED',
+    });
+
+    renderCommunityPage();
+
+    expect(await screen.findByText('Arquivada')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /participar/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/ações de participação estão indisponíveis/i)).toBeInTheDocument();
+  });
+
+  it('lets owner archive an active community', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'OWNER',
+    });
+    mockedArchiveCommunity.mockResolvedValue({
+      ...community,
+      status: 'ARCHIVED',
+      viewerMembershipRole: 'OWNER',
+    });
+
+    renderCommunityPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /arquivar comunidade/i }));
+
+    await waitFor(() => {
+      expect(mockedArchiveCommunity).toHaveBeenCalledWith('guilda-dos-speedrunners');
+    });
+  });
+
+  it('does not show archive action to regular members', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'MEMBER',
+    });
+
+    renderCommunityPage();
+
+    await screen.findByRole('button', { name: /sair da comunidade/i });
+    expect(screen.queryByRole('button', { name: /arquivar comunidade/i })).not.toBeInTheDocument();
+  });
+
+  it('lets member leave archived community without join action', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      status: 'ARCHIVED',
+      viewerMembershipRole: 'MEMBER',
+    });
+    mockedLeaveCommunity.mockResolvedValue({
+      ...community,
+      status: 'ARCHIVED',
+      viewerMembershipRole: null,
+    });
+
+    renderCommunityPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /sair da comunidade arquivada/i }));
+
+    await waitFor(() => {
+      expect(mockedLeaveCommunity).toHaveBeenCalledWith('guilda-dos-speedrunners');
+    });
+    expect(screen.queryByRole('button', { name: /^participar$/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/services/communities.test.ts
+++ b/frontend/tests/unit/services/communities.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiRequest } from '@/lib/api';
 import {
   createCommunity,
+  archiveCommunity,
   fetchCommunities,
   fetchCommunityBySlug,
   joinCommunity,
@@ -130,6 +131,28 @@ describe('communities service', () => {
       '/communities/guilda-dos-speedrunners/membership',
       {
         method: 'DELETE',
+      },
+    );
+  });
+
+  it('archives a community by slug', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({ community: { ...communityPayload, status: 'ARCHIVED' } }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await archiveCommunity('guilda-dos-speedrunners');
+
+    expect(response.status).toBe('ARCHIVED');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/archive',
+      {
+        method: 'PATCH',
       },
     );
   });


### PR DESCRIPTION
## Resumo
Implementa o ciclo de vida mínimo de comunidades públicas para a #278, com geração de slug único previsível e arquivamento por owner. A mudança mantém comunidades arquivadas acessíveis por URL direta, remove essas comunidades da descoberta pública e bloqueia ações indevidas no estado arquivado.

Closes #278

## O que foi alterado
- Backend:
  - Geração de slug com fallback seguro, truncamento estável e sufixo previsível quando o slug base já existe.
  - Retry limitado para colisão concorrente de slug, evitando 500 em conflito esperado.
  - Endpoint autenticado para owner arquivar comunidade.
  - Arquivamento idempotente quando a comunidade já está arquivada.
  - Detalhe por slug passa a retornar comunidade arquivada para acesso direto.
  - Join é bloqueado em comunidade arquivada; leave de membro permanece permitido.
  - Listagem pública continua restrita a comunidades `ACTIVE`.
- Frontend:
  - Listagem pública filtra comunidades arquivadas defensivamente.
  - Detalhe de comunidade exibe estado arquivado e remove CTAs incompatíveis.
  - Owner vê ação mínima de arquivamento em comunidade ativa.
  - Páginas de comunidades usam heading principal descritivo.
  - Service frontend adiciona chamada de arquivamento.
- Testes:
  - Cobertura de slug único, fallback de slug, colisão concorrente, arquivamento idempotente, permissões, listagem pública, detalhe arquivado e UI arquivada.

## Motivação
O MVP de comunidades precisava de hardening operacional para evitar colisões de slug e permitir encerrar uma comunidade pública sem apagar dados. O arquivamento também evita que usuários continuem entrando ou interagindo com comunidades que não devem mais aceitar novas ações.

## Como validar
- Backend:
  - `cd backend && npm run test -- tests/unit/services/community.service.test.ts tests/integration/routes/communities.routes.test.ts`
  - `cd backend && npm run typecheck`
  - `cd backend && npm run lint`
  - `cd backend && npm run build`
- Frontend:
  - `cd frontend && npm run test -- tests/unit/services/communities.test.ts tests/unit/components/communities-page-content.test.tsx tests/unit/components/community-page-content.test.tsx`
  - `cd frontend && npm run test:coverage`
  - `cd frontend && npm run typecheck`
  - `cd frontend && npm run lint`
  - `cd frontend && npm run build`

## Riscos e impactos
- Slugs duplicados passam a receber sufixos como `guilda`, `guilda-2`, `guilda-3`; consumidores que assumiam erro de conflito precisam considerar o novo comportamento.
- Comunidades arquivadas permanecem acessíveis por URL direta, mas saem da descoberta pública.
- Leave foi mantido permitido para membros em comunidades arquivadas, para que o usuário possa remover sua própria associação sem reabrir a comunidade.
- O código atual do repositório não contém modelos ou rotas de eventos comunitários/RSVP; por isso, bloqueios específicos de evento/RSVP não foram implementados nesta PR e devem ser reavaliados quando essa superfície existir no backend.
- `npm run test:coverage` do backend não concluiu localmente porque suites de integração dependem de PostgreSQL em `localhost:5432` e o ambiente local também emitiu timeouts/erros de Redis offline em suites não relacionadas. Os testes focados de backend passaram.

## Evidências
- Testes focados de backend: 2 arquivos, 28 testes passando.
- Testes focados de frontend: 3 arquivos, 16 testes passando.
- Frontend coverage: 72 arquivos, 277 testes passando, lines/statements 82.71%.
- Backend typecheck, lint e build passaram; lint manteve avisos existentes em `backend/src/config/rate-limit.ts`.
- Frontend typecheck, lint e build passaram.

## Checklist
- [ ] Alteração limitada ao objetivo da PR
- [ ] Sem mudanças desconexas
- [ ] Impactos principais descritos
- [ ] Validação documentada
- [ ] Riscos identificados