### PR TITLE
feat(communities): reentrega eventos comunitários mínimos

### DIFF
--- a/backend/prisma/migrations/20260501010000_add_community_events/migration.sql
+++ b/backend/prisma/migrations/20260501010000_add_community_events/migration.sql
@@ -1,0 +1,36 @@
+CREATE TYPE "CommunityEventStatus" AS ENUM ('PUBLISHED', 'CANCELLED');
+CREATE TYPE "CommunityEventRsvpStatus" AS ENUM ('GOING', 'INTERESTED', 'NOT_GOING');
+
+CREATE TABLE "community_events" (
+    "id" TEXT NOT NULL,
+    "communityId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "status" "CommunityEventStatus" NOT NULL DEFAULT 'PUBLISHED',
+    "createdByUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "community_events_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "community_event_rsvps" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" "CommunityEventRsvpStatus" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "community_event_rsvps_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "community_events_communityId_status_startsAt_idx" ON "community_events"("communityId", "status", "startsAt");
+CREATE INDEX "community_event_rsvps_userId_idx" ON "community_event_rsvps"("userId");
+CREATE UNIQUE INDEX "community_event_rsvps_eventId_userId_key" ON "community_event_rsvps"("eventId", "userId");
+
+ALTER TABLE "community_events" ADD CONSTRAINT "community_events_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "communities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_events" ADD CONSTRAINT "community_events_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_event_rsvps" ADD CONSTRAINT "community_event_rsvps_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "community_events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "community_event_rsvps" ADD CONSTRAINT "community_event_rsvps_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -111,6 +111,17 @@ enum CommunityMemberRole {
   MEMBER
 }
 
+enum CommunityEventStatus {
+  PUBLISHED
+  CANCELLED
+}
+
+enum CommunityEventRsvpStatus {
+  GOING
+  INTERESTED
+  NOT_GOING
+}
+
 // ── User ─────────────────────────────────────────────────────
 
 model User {
@@ -122,25 +133,27 @@ model User {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  profile              Profile?
-  stats                UserStats?
-  presence             UserPresence?
-  platformIntegrations PlatformIntegration[]
-  gameLibrary          UserGameLibrary[]
-  posts                Post[]
-  comments             Comment[]
-  interactions         Interaction[]
-  notifications        Notification[]        @relation("NotificationRecipient")
-  actorNotifications   Notification[]        @relation("NotificationActor")
-  sentFriendRequests   FriendRequest[]       @relation("FriendRequestSender")
-  receivedFriendRequests FriendRequest[]     @relation("FriendRequestReceiver")
-  friendships          Friendship[]          @relation("FriendshipUser")
-  friendOf             Friendship[]          @relation("FriendshipFriend")
-  sentGameInvites      GameInvite[]          @relation("GameInviteSender")
-  receivedGameInvites  GameInvite[]          @relation("GameInviteReceiver")
-  mediaEntries         UserMediaEntry[]
-  ownedCommunities     Community[]           @relation("CommunityOwner")
-  communityMemberships CommunityMember[]
+  profile                Profile?
+  stats                  UserStats?
+  presence               UserPresence?
+  platformIntegrations   PlatformIntegration[]
+  gameLibrary            UserGameLibrary[]
+  posts                  Post[]
+  comments               Comment[]
+  interactions           Interaction[]
+  notifications          Notification[]        @relation("NotificationRecipient")
+  actorNotifications     Notification[]        @relation("NotificationActor")
+  sentFriendRequests     FriendRequest[]       @relation("FriendRequestSender")
+  receivedFriendRequests FriendRequest[]       @relation("FriendRequestReceiver")
+  friendships            Friendship[]          @relation("FriendshipUser")
+  friendOf               Friendship[]          @relation("FriendshipFriend")
+  sentGameInvites        GameInvite[]          @relation("GameInviteSender")
+  receivedGameInvites    GameInvite[]          @relation("GameInviteReceiver")
+  mediaEntries           UserMediaEntry[]
+  ownedCommunities       Community[]           @relation("CommunityOwner")
+  communityMemberships   CommunityMember[]
+  createdCommunityEvents CommunityEvent[]      @relation("CommunityEventCreator")
+  communityEventRsvps    CommunityEventRsvp[]
 
   @@map("users")
 }
@@ -200,21 +213,21 @@ model UserPresence {
 // ── PlatformIntegration ──────────────────────────────────────
 
 model PlatformIntegration {
-  id             String                            @id @default(uuid())
-  userId         String
-  platform       Platform
-  externalId     String
-  connectionType PlatformIntegrationConnectionType @default(CONNECTED_ACCOUNT)
-  status         PlatformIntegrationStatus         @default(CONNECTED)
-  dataSource     PlatformIntegrationDataSource     @default(OFFICIAL)
-  accessToken    String?
-  refreshToken   String?
-  metadata       Json?
-  isActive       Boolean                           @default(true)
-  publicProfileVisible Boolean                     @default(false)
-  lastSyncAt     DateTime?
-  createdAt      DateTime                          @default(now())
-  updatedAt      DateTime                          @updatedAt
+  id                   String                            @id @default(uuid())
+  userId               String
+  platform             Platform
+  externalId           String
+  connectionType       PlatformIntegrationConnectionType @default(CONNECTED_ACCOUNT)
+  status               PlatformIntegrationStatus         @default(CONNECTED)
+  dataSource           PlatformIntegrationDataSource     @default(OFFICIAL)
+  accessToken          String?
+  refreshToken         String?
+  metadata             Json?
+  isActive             Boolean                           @default(true)
+  publicProfileVisible Boolean                           @default(false)
+  lastSyncAt           DateTime?
+  createdAt            DateTime                          @default(now())
+  updatedAt            DateTime                          @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -226,7 +239,7 @@ model PlatformIntegration {
 // ── UserGameLibrary ──────────────────────────────────────────
 
 model UserGameLibrary {
-  id           String   @id @default(uuid())
+  id           String    @id @default(uuid())
   userId       String
   gameId       String
   gameName     String
@@ -243,14 +256,14 @@ model UserGameLibrary {
 }
 
 model MediaTitle {
-  id             String           @id @default(uuid())
+  id             String    @id @default(uuid())
   kind           MediaKind
   canonicalTitle String
   coverUrl       String?
   externalSource Platform?
   externalId     String?
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @updatedAt
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
   userEntries UserMediaEntry[]
 
@@ -292,6 +305,7 @@ model Community {
 
   owner   User              @relation("CommunityOwner", fields: [ownerUserId], references: [id], onDelete: Cascade)
   members CommunityMember[]
+  events  CommunityEvent[]
 
   @@index([status, visibility, createdAt])
   @@map("communities")
@@ -312,17 +326,52 @@ model CommunityMember {
   @@map("community_members")
 }
 
+model CommunityEvent {
+  id              String               @id @default(uuid())
+  communityId     String
+  title           String
+  description     String?
+  startsAt        DateTime
+  status          CommunityEventStatus @default(PUBLISHED)
+  createdByUserId String
+  createdAt       DateTime             @default(now())
+  updatedAt       DateTime             @updatedAt
+
+  community Community            @relation(fields: [communityId], references: [id], onDelete: Cascade)
+  createdBy User                 @relation("CommunityEventCreator", fields: [createdByUserId], references: [id], onDelete: Cascade)
+  rsvps     CommunityEventRsvp[]
+
+  @@index([communityId, status, startsAt])
+  @@map("community_events")
+}
+
+model CommunityEventRsvp {
+  id        String                   @id @default(uuid())
+  eventId   String
+  userId    String
+  status    CommunityEventRsvpStatus
+  createdAt DateTime                 @default(now())
+  updatedAt DateTime                 @updatedAt
+
+  event CommunityEvent @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  user  User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([eventId, userId])
+  @@index([userId])
+  @@map("community_event_rsvps")
+}
+
 // ── Post ─────────────────────────────────────────────────────
 
 model Post {
-  id          String    @id @default(uuid())
+  id          String   @id @default(uuid())
   userId      String
   contentText String?
   mediaUrl    String?
-  type        PostType  @default(TEXT)
+  type        PostType @default(TEXT)
   gameContext Json?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
   user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   comments     Comment[]
@@ -341,10 +390,10 @@ model Comment {
   content   String
   createdAt DateTime @default(now())
 
-  post     Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
-  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  parent   Comment?  @relation("CommentReplies", fields: [parentId], references: [id])
-  replies  Comment[] @relation("CommentReplies")
+  post    Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user    User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  parent  Comment?  @relation("CommentReplies", fields: [parentId], references: [id])
+  replies Comment[] @relation("CommentReplies")
 
   @@map("comments")
 }

--- a/backend/src/api/routes/communities.routes.ts
+++ b/backend/src/api/routes/communities.routes.ts
@@ -5,6 +5,10 @@ import {
   communityService,
   CommunityServiceError,
 } from '../../core/services/community.service';
+import {
+  communityEventService,
+  CommunityEventServiceError,
+} from '../../core/services/community-event.service';
 
 const slugParamsSchema = z.object({
   slug: z.string().trim().min(1).max(80),
@@ -13,6 +17,21 @@ const slugParamsSchema = z.object({
 const createCommunitySchema = z.object({
   name: z.string().trim().min(3).max(80),
   description: z.string().trim().max(240).optional(),
+});
+
+const eventParamsSchema = z.object({
+  slug: z.string().trim().min(1).max(80),
+  eventId: z.string().uuid(),
+});
+
+const createCommunityEventSchema = z.object({
+  title: z.string().trim().min(3).max(100),
+  description: z.string().trim().max(280).optional(),
+  startsAt: z.coerce.date(),
+});
+
+const rsvpSchema = z.object({
+  status: z.enum(['GOING', 'INTERESTED', 'NOT_GOING']),
 });
 
 function resolveOptionalViewerUserId(request: FastifyRequest): string | null {
@@ -47,12 +66,191 @@ function sendCommunityServiceError(
   return reply.status(statusByCode[error.code]).send({ message: error.message });
 }
 
+function sendCommunityEventServiceError(
+  error: CommunityEventServiceError,
+  reply: FastifyReply,
+): FastifyReply {
+  const statusByCode: Record<CommunityEventServiceError['code'], number> = {
+    COMMUNITY_NOT_FOUND: 404,
+    COMMUNITY_ARCHIVED: 409,
+    COMMUNITY_EVENT_NOT_FOUND: 404,
+    COMMUNITY_EVENT_FORBIDDEN: 403,
+    COMMUNITY_EVENT_INVALID_START: 400,
+    COMMUNITY_EVENT_CANCELLED: 409,
+    COMMUNITY_MEMBERSHIP_REQUIRED: 403,
+  };
+
+  return reply.status(statusByCode[error.code]).send({ message: error.message });
+}
+
 export async function communityRoutes(app: FastifyInstance): Promise<void> {
   app.get('/', async () => {
     const communities = await communityService.listPublicCommunities();
 
     return { communities };
   });
+
+  app.get<{ Params: { slug: string } }>('/:slug/events', async (request, reply) => {
+    const params = slugParamsSchema.safeParse(request.params);
+
+    if (!params.success) {
+      return reply.status(400).send({
+        message: 'Parâmetros inválidos.',
+        errors: params.error.flatten(),
+      });
+    }
+
+    try {
+      const events = await communityEventService.listEvents(
+        params.data.slug,
+        resolveOptionalViewerUserId(request),
+      );
+
+      return { events };
+    } catch (error) {
+      if (error instanceof CommunityEventServiceError) {
+        return sendCommunityEventServiceError(error, reply);
+      }
+
+      throw error;
+    }
+  });
+
+  app.post<{ Params: { slug: string } }>(
+    '/:slug/events',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = slugParamsSchema.safeParse(request.params);
+      const body = createCommunityEventSchema.safeParse(request.body);
+
+      if (!params.success || !body.success) {
+        return reply.status(400).send({
+          message: 'Dados inválidos.',
+          errors: {
+            params: params.success ? undefined : params.error.flatten(),
+            body: body.success ? undefined : body.error.flatten(),
+          },
+        });
+      }
+
+      try {
+        const event = await communityEventService.createEvent(
+          params.data.slug,
+          request.userId,
+          {
+            title: body.data.title,
+            description: body.data.description ?? null,
+            startsAt: body.data.startsAt,
+          },
+        );
+
+        return reply.status(201).send({ event });
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.get<{ Params: { slug: string; eventId: string } }>(
+    '/:slug/events/:eventId',
+    async (request, reply) => {
+      const params = eventParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const event = await communityEventService.getEvent(
+          params.data.slug,
+          params.data.eventId,
+          resolveOptionalViewerUserId(request),
+        );
+
+        return { event };
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.put<{ Params: { slug: string; eventId: string } }>(
+    '/:slug/events/:eventId/rsvp',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = eventParamsSchema.safeParse(request.params);
+      const body = rsvpSchema.safeParse(request.body);
+
+      if (!params.success || !body.success) {
+        return reply.status(400).send({
+          message: 'Dados inválidos.',
+          errors: {
+            params: params.success ? undefined : params.error.flatten(),
+            body: body.success ? undefined : body.error.flatten(),
+          },
+        });
+      }
+
+      try {
+        const event = await communityEventService.setRsvp(
+          params.data.slug,
+          params.data.eventId,
+          request.userId,
+          body.data.status,
+        );
+
+        return reply.status(200).send({ event });
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.patch<{ Params: { slug: string; eventId: string } }>(
+    '/:slug/events/:eventId/cancel',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = eventParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const event = await communityEventService.cancelEvent(
+          params.data.slug,
+          params.data.eventId,
+          request.userId,
+        );
+
+        return reply.status(200).send({ event });
+      } catch (error) {
+        if (error instanceof CommunityEventServiceError) {
+          return sendCommunityEventServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
 
   app.post(
     '/',

--- a/backend/src/core/repositories/community-event.repository.ts
+++ b/backend/src/core/repositories/community-event.repository.ts
@@ -1,0 +1,210 @@
+import {
+  CommunityEventRsvpStatus,
+  CommunityEventStatus,
+  type Prisma,
+} from '@prisma/client';
+import { prisma } from '../../infra/database/client';
+
+const communityEventSelect = {
+  id: true,
+  communityId: true,
+  title: true,
+  description: true,
+  startsAt: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+  createdBy: {
+    select: {
+      id: true,
+      username: true,
+      profile: {
+        select: {
+          displayName: true,
+        },
+      },
+    },
+  },
+  rsvps: {
+    select: {
+      userId: true,
+      status: true,
+    },
+  },
+} satisfies Prisma.CommunityEventSelect;
+
+type CommunityEventRecord = Prisma.CommunityEventGetPayload<{
+  select: typeof communityEventSelect;
+}>;
+
+export type CommunityEventCreatorSummary = {
+  id: string;
+  username: string;
+  displayName: string | null;
+};
+
+export type CommunityEventRsvpCounts = {
+  going: number;
+  interested: number;
+  notGoing: number;
+};
+
+export type CommunityEventSummary = {
+  id: string;
+  communityId: string;
+  title: string;
+  description: string | null;
+  startsAt: Date;
+  status: CommunityEventStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: CommunityEventCreatorSummary;
+  viewerRsvp: CommunityEventRsvpStatus | null;
+  rsvpCounts: CommunityEventRsvpCounts;
+};
+
+export type CreateCommunityEventInput = {
+  communityId: string;
+  title: string;
+  description?: string | null;
+  startsAt: Date;
+  createdByUserId: string;
+};
+
+function toSummary(
+  record: CommunityEventRecord,
+  viewerUserId?: string | null,
+): CommunityEventSummary {
+  const rsvpCounts: CommunityEventRsvpCounts = {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  };
+  let viewerRsvp: CommunityEventRsvpStatus | null = null;
+
+  for (const rsvp of record.rsvps) {
+    if (rsvp.status === CommunityEventRsvpStatus.GOING) {
+      rsvpCounts.going += 1;
+    }
+
+    if (rsvp.status === CommunityEventRsvpStatus.INTERESTED) {
+      rsvpCounts.interested += 1;
+    }
+
+    if (rsvp.status === CommunityEventRsvpStatus.NOT_GOING) {
+      rsvpCounts.notGoing += 1;
+    }
+
+    if (viewerUserId && rsvp.userId === viewerUserId) {
+      viewerRsvp = rsvp.status;
+    }
+  }
+
+  return {
+    id: record.id,
+    communityId: record.communityId,
+    title: record.title,
+    description: record.description,
+    startsAt: record.startsAt,
+    status: record.status,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    createdBy: {
+      id: record.createdBy.id,
+      username: record.createdBy.username,
+      displayName: record.createdBy.profile?.displayName ?? null,
+    },
+    viewerRsvp,
+    rsvpCounts,
+  };
+}
+
+export const communityEventRepository = {
+  async create(input: CreateCommunityEventInput): Promise<CommunityEventSummary> {
+    const event = await prisma.communityEvent.create({
+      data: {
+        communityId: input.communityId,
+        title: input.title,
+        description: input.description ?? null,
+        startsAt: input.startsAt,
+        status: CommunityEventStatus.PUBLISHED,
+        createdByUserId: input.createdByUserId,
+      },
+      select: communityEventSelect,
+    });
+
+    return toSummary(event, input.createdByUserId);
+  },
+
+  async findByCommunityId(
+    communityId: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary[]> {
+    const events = await prisma.communityEvent.findMany({
+      where: { communityId },
+      orderBy: [
+        { startsAt: 'asc' },
+        { createdAt: 'desc' },
+      ],
+      select: communityEventSelect,
+    });
+
+    return events.map((event) => toSummary(event, viewerUserId));
+  },
+
+  async findById(
+    communityId: string,
+    eventId: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary | null> {
+    const event = await prisma.communityEvent.findFirst({
+      where: {
+        id: eventId,
+        communityId,
+      },
+      select: communityEventSelect,
+    });
+
+    return event ? toSummary(event, viewerUserId) : null;
+  },
+
+  async upsertRsvp(
+    eventId: string,
+    userId: string,
+    status: CommunityEventRsvpStatus,
+  ): Promise<void> {
+    await prisma.communityEventRsvp.upsert({
+      where: {
+        eventId_userId: {
+          eventId,
+          userId,
+        },
+      },
+      create: {
+        eventId,
+        userId,
+        status,
+      },
+      update: { status },
+    });
+  },
+
+  async cancelEvent(communityId: string, eventId: string): Promise<CommunityEventSummary | null> {
+    const result = await prisma.communityEvent.updateMany({
+      where: {
+        id: eventId,
+        communityId,
+        status: CommunityEventStatus.PUBLISHED,
+      },
+      data: {
+        status: CommunityEventStatus.CANCELLED,
+      },
+    });
+
+    if (result.count === 0) {
+      return null;
+    }
+
+    return this.findById(communityId, eventId);
+  },
+};

--- a/backend/src/core/services/community-event.service.ts
+++ b/backend/src/core/services/community-event.service.ts
@@ -1,0 +1,219 @@
+import {
+  CommunityEventRsvpStatus,
+  CommunityEventStatus,
+  CommunityMemberRole,
+  CommunityStatus,
+} from '@prisma/client';
+import {
+  communityEventRepository,
+  type CommunityEventSummary,
+} from '../repositories/community-event.repository';
+import { communityRepository, type CommunitySummary } from '../repositories/community.repository';
+
+export type CommunityEventServiceErrorCode =
+  | 'COMMUNITY_NOT_FOUND'
+  | 'COMMUNITY_ARCHIVED'
+  | 'COMMUNITY_EVENT_NOT_FOUND'
+  | 'COMMUNITY_EVENT_FORBIDDEN'
+  | 'COMMUNITY_EVENT_INVALID_START'
+  | 'COMMUNITY_EVENT_CANCELLED'
+  | 'COMMUNITY_MEMBERSHIP_REQUIRED';
+
+export class CommunityEventServiceError extends Error {
+  readonly code: CommunityEventServiceErrorCode;
+
+  constructor(code: CommunityEventServiceErrorCode, message: string) {
+    super(message);
+    this.name = 'CommunityEventServiceError';
+    this.code = code;
+  }
+}
+
+export type CreateCommunityEventServiceInput = {
+  title: string;
+  description?: string | null;
+  startsAt: Date;
+};
+
+async function findCommunity(slug: string): Promise<CommunitySummary> {
+  const community = await communityRepository.findBySlug(slug);
+
+  if (!community) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_NOT_FOUND',
+      'Comunidade pública não encontrada.',
+    );
+  }
+
+  return community;
+}
+
+function assertCommunityActive(community: CommunitySummary): void {
+  if (community.status === CommunityStatus.ARCHIVED) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_ARCHIVED',
+      'Comunidade arquivada não aceita novas ações de eventos.',
+    );
+  }
+}
+
+async function requireOwner(communityId: string, userId: string): Promise<void> {
+  const role = await communityRepository.findMembershipRole(communityId, userId);
+
+  if (role !== CommunityMemberRole.OWNER) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_EVENT_FORBIDDEN',
+      'Apenas o owner pode gerenciar eventos desta comunidade.',
+    );
+  }
+}
+
+async function requireMember(communityId: string, userId: string): Promise<void> {
+  const role = await communityRepository.findMembershipRole(communityId, userId);
+
+  if (!role) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_MEMBERSHIP_REQUIRED',
+      'Apenas membros podem responder RSVP nesta comunidade.',
+    );
+  }
+}
+
+function assertFutureStart(startsAt: Date): void {
+  if (startsAt.getTime() <= Date.now()) {
+    throw new CommunityEventServiceError(
+      'COMMUNITY_EVENT_INVALID_START',
+      'O evento precisa começar no futuro.',
+    );
+  }
+}
+
+export const communityEventService = {
+  async listEvents(
+    slug: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary[]> {
+    const community = await findCommunity(slug);
+
+    return communityEventRepository.findByCommunityId(community.id, viewerUserId);
+  },
+
+  async getEvent(
+    slug: string,
+    eventId: string,
+    viewerUserId?: string | null,
+  ): Promise<CommunityEventSummary> {
+    const community = await findCommunity(slug);
+    const event = await communityEventRepository.findById(
+      community.id,
+      eventId,
+      viewerUserId,
+    );
+
+    if (!event) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    return event;
+  },
+
+  async createEvent(
+    slug: string,
+    userId: string,
+    input: CreateCommunityEventServiceInput,
+  ): Promise<CommunityEventSummary> {
+    const community = await findCommunity(slug);
+    assertCommunityActive(community);
+    await requireOwner(community.id, userId);
+    assertFutureStart(input.startsAt);
+
+    const description = input.description?.trim();
+
+    return communityEventRepository.create({
+      communityId: community.id,
+      title: input.title.trim(),
+      description: description && description.length > 0 ? description : null,
+      startsAt: input.startsAt,
+      createdByUserId: userId,
+    });
+  },
+
+  async setRsvp(
+    slug: string,
+    eventId: string,
+    userId: string,
+    status: CommunityEventRsvpStatus,
+  ): Promise<CommunityEventSummary> {
+    const community = await findCommunity(slug);
+    assertCommunityActive(community);
+    await requireMember(community.id, userId);
+
+    const event = await communityEventRepository.findById(community.id, eventId, userId);
+
+    if (!event) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    if (event.status === CommunityEventStatus.CANCELLED) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_CANCELLED',
+        'Evento cancelado não aceita RSVP.',
+      );
+    }
+
+    await communityEventRepository.upsertRsvp(event.id, userId, status);
+    const updatedEvent = await communityEventRepository.findById(community.id, eventId, userId);
+
+    if (!updatedEvent) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    return updatedEvent;
+  },
+
+  async cancelEvent(
+    slug: string,
+    eventId: string,
+    userId: string,
+  ): Promise<CommunityEventSummary> {
+    const community = await findCommunity(slug);
+    assertCommunityActive(community);
+    await requireOwner(community.id, userId);
+
+    const existingEvent = await communityEventRepository.findById(community.id, eventId, userId);
+
+    if (!existingEvent) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    if (existingEvent.status === CommunityEventStatus.CANCELLED) {
+      return existingEvent;
+    }
+
+    const cancelledEvent = await communityEventRepository.cancelEvent(community.id, eventId);
+
+    if (!cancelledEvent) {
+      throw new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      );
+    }
+
+    return {
+      ...cancelledEvent,
+      viewerRsvp: existingEvent.viewerRsvp,
+    };
+  },
+};

--- a/backend/tests/integration/routes/communities.routes.test.ts
+++ b/backend/tests/integration/routes/communities.routes.test.ts
@@ -1,10 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { CommunityMemberRole, CommunityStatus, CommunityVisibility } from '@prisma/client';
+import {
+  CommunityEventRsvpStatus,
+  CommunityEventStatus,
+  CommunityMemberRole,
+  CommunityStatus,
+  CommunityVisibility,
+} from '@prisma/client';
 import { buildApp, generateTestToken } from '../../helpers/build-app';
 import {
   communityService,
   CommunityServiceError,
 } from '@/core/services/community.service';
+import {
+  communityEventService,
+  CommunityEventServiceError,
+} from '@/core/services/community-event.service';
 
 vi.mock('@/core/services/community.service', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/core/services/community.service')>();
@@ -18,6 +28,21 @@ vi.mock('@/core/services/community.service', async (importOriginal) => {
       joinCommunity: vi.fn(),
       leaveCommunity: vi.fn(),
       archiveCommunity: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/core/services/community-event.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/services/community-event.service')>();
+
+  return {
+    ...actual,
+    communityEventService: {
+      listEvents: vi.fn(),
+      getEvent: vi.fn(),
+      createEvent: vi.fn(),
+      setRsvp: vi.fn(),
+      cancelEvent: vi.fn(),
     },
   };
 });
@@ -43,6 +68,28 @@ const mockCommunity = {
   createdAt: new Date('2026-04-25T10:00:00.000Z'),
   updatedAt: new Date('2026-04-25T10:00:00.000Z'),
   viewerMembershipRole: null,
+};
+
+const mockEvent = {
+  id: '11111111-1111-4111-8111-111111111111',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: new Date('2099-05-01T23:00:00.000Z'),
+  status: CommunityEventStatus.PUBLISHED,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
 };
 
 describe('Communities Routes', () => {
@@ -317,6 +364,324 @@ describe('Communities Routes', () => {
     });
 
     expect(response.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it('lista eventos da comunidade', async () => {
+    vi.mocked(communityEventService.listEvents).mockResolvedValue([mockEvent]);
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'GET',
+      url: '/communities/guilda-dos-speedrunners/events',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityEventService.listEvents).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+    expect(response.json()).toMatchObject({
+      events: [
+        {
+          id: mockEvent.id,
+          title: 'Noite de ranked',
+          status: CommunityEventStatus.PUBLISHED,
+        },
+      ],
+    });
+    await app.close();
+  });
+
+  it('permite owner criar evento em comunidade ativa', async () => {
+    vi.mocked(communityEventService.createEvent).mockResolvedValue(mockEvent);
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/events',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        title: 'Noite de ranked',
+        description: 'Fila fechada para subir elo.',
+        startsAt: '2099-05-01T23:00:00.000Z',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(communityEventService.createEvent).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      'owner-id-1',
+      {
+        title: 'Noite de ranked',
+        description: 'Fila fechada para subir elo.',
+        startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      },
+    );
+    await app.close();
+  });
+
+  it('bloqueia criação de evento em comunidade arquivada', async () => {
+    vi.mocked(communityEventService.createEvent).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_ARCHIVED',
+        'Comunidade arquivada não aceita novas ações de eventos.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/events',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        title: 'Noite de ranked',
+        startsAt: '2099-05-01T23:00:00.000Z',
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it('bloqueia criação de evento sem autenticação', async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/events',
+      payload: {
+        title: 'Noite de ranked',
+        startsAt: '2099-05-01T23:00:00.000Z',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(communityEventService.createEvent).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('bloqueia criação de evento por não-owner', async () => {
+    vi.mocked(communityEventService.createEvent).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_EVENT_FORBIDDEN',
+        'Apenas o owner pode gerenciar eventos desta comunidade.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/communities/guilda-dos-speedrunners/events',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        title: 'Noite de ranked',
+        startsAt: '2099-05-01T23:00:00.000Z',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('permite RSVP em evento de comunidade ativa', async () => {
+    vi.mocked(communityEventService.setRsvp).mockResolvedValue({
+      ...mockEvent,
+      viewerRsvp: CommunityEventRsvpStatus.GOING,
+      rsvpCounts: { going: 1, interested: 0, notGoing: 0 },
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/rsvp`,
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        status: CommunityEventRsvpStatus.GOING,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityEventService.setRsvp).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      mockEvent.id,
+      'member-id-1',
+      CommunityEventRsvpStatus.GOING,
+    );
+    expect(response.json()).toMatchObject({
+      event: {
+        viewerRsvp: CommunityEventRsvpStatus.GOING,
+      },
+    });
+    await app.close();
+  });
+
+  it('bloqueia RSVP em comunidade arquivada', async () => {
+    vi.mocked(communityEventService.setRsvp).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_ARCHIVED',
+        'Comunidade arquivada não aceita novas ações de eventos.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/rsvp`,
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        status: CommunityEventRsvpStatus.GOING,
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it('bloqueia RSVP sem autenticação', async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/rsvp`,
+      payload: {
+        status: CommunityEventRsvpStatus.GOING,
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(communityEventService.setRsvp).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('rejeita status inválido de RSVP', async () => {
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/rsvp`,
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        status: 'MAYBE',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(communityEventService.setRsvp).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('bloqueia RSVP por não-membro', async () => {
+    vi.mocked(communityEventService.setRsvp).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_MEMBERSHIP_REQUIRED',
+        'Apenas membros podem responder RSVP nesta comunidade.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'outsider-id-1');
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/rsvp`,
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        status: CommunityEventRsvpStatus.GOING,
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('permite owner cancelar evento', async () => {
+    vi.mocked(communityEventService.cancelEvent).mockResolvedValue({
+      ...mockEvent,
+      status: CommunityEventStatus.CANCELLED,
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/cancel`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(communityEventService.cancelEvent).toHaveBeenCalledWith(
+      'guilda-dos-speedrunners',
+      mockEvent.id,
+      'owner-id-1',
+    );
+    expect(response.json()).toMatchObject({
+      event: {
+        status: CommunityEventStatus.CANCELLED,
+      },
+    });
+    await app.close();
+  });
+
+  it('impede não-owner de cancelar evento', async () => {
+    vi.mocked(communityEventService.cancelEvent).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_EVENT_FORBIDDEN',
+        'Apenas o owner pode gerenciar eventos desta comunidade.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'member-id-1');
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/cancel`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(403);
+    await app.close();
+  });
+
+  it('bloqueia cancelamento em comunidade arquivada', async () => {
+    vi.mocked(communityEventService.cancelEvent).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_ARCHIVED',
+        'Comunidade arquivada não aceita novas ações de eventos.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'owner-id-1');
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}/cancel`,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it('retorna erro seguro para evento inexistente', async () => {
+    vi.mocked(communityEventService.getEvent).mockRejectedValue(
+      new CommunityEventServiceError(
+        'COMMUNITY_EVENT_NOT_FOUND',
+        'Evento comunitário não encontrado.',
+      ),
+    );
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: `/communities/guilda-dos-speedrunners/events/${mockEvent.id}`,
+    });
+
+    expect(response.statusCode).toBe(404);
     await app.close();
   });
 });

--- a/backend/tests/unit/repositories/community-event.repository.test.ts
+++ b/backend/tests/unit/repositories/community-event.repository.test.ts
@@ -1,0 +1,57 @@
+import { CommunityEventRsvpStatus } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { communityEventRepository } from '@/core/repositories/community-event.repository';
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    communityEvent: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    communityEventRsvp: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/infra/database/client';
+
+describe('communityEventRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('usa upsert por eventId e userId para atualizar RSVP sem duplicar', async () => {
+    vi.mocked(prisma.communityEventRsvp.upsert).mockResolvedValue({
+      id: 'rsvp-id-1',
+      eventId: 'event-id-1',
+      userId: 'user-id-1',
+      status: CommunityEventRsvpStatus.INTERESTED,
+      createdAt: new Date('2026-05-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-05-01T10:00:00.000Z'),
+    });
+
+    await communityEventRepository.upsertRsvp(
+      'event-id-1',
+      'user-id-1',
+      CommunityEventRsvpStatus.INTERESTED,
+    );
+
+    expect(prisma.communityEventRsvp.upsert).toHaveBeenCalledWith({
+      where: {
+        eventId_userId: {
+          eventId: 'event-id-1',
+          userId: 'user-id-1',
+        },
+      },
+      create: {
+        eventId: 'event-id-1',
+        userId: 'user-id-1',
+        status: CommunityEventRsvpStatus.INTERESTED,
+      },
+      update: { status: CommunityEventRsvpStatus.INTERESTED },
+    });
+  });
+});

--- a/backend/tests/unit/services/community-event.service.test.ts
+++ b/backend/tests/unit/services/community-event.service.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CommunityEventRsvpStatus,
+  CommunityEventStatus,
+  CommunityMemberRole,
+  CommunityStatus,
+  CommunityVisibility,
+} from '@prisma/client';
+import { communityEventService } from '@/core/services/community-event.service';
+import { communityRepository, type CommunitySummary } from '@/core/repositories/community.repository';
+import {
+  communityEventRepository,
+  type CommunityEventSummary,
+} from '@/core/repositories/community-event.repository';
+
+vi.mock('@/core/repositories/community.repository', () => ({
+  communityRepository: {
+    findBySlug: vi.fn(),
+    findMembershipRole: vi.fn(),
+  },
+}));
+
+vi.mock('@/core/repositories/community-event.repository', () => ({
+  communityEventRepository: {
+    create: vi.fn(),
+    findByCommunityId: vi.fn(),
+    findById: vi.fn(),
+    upsertRsvp: vi.fn(),
+    cancelEvent: vi.fn(),
+  },
+}));
+
+const community: CommunitySummary = {
+  id: 'community-id-1',
+  slug: 'guilda-dos-speedrunners',
+  name: 'Guilda dos Speedrunners',
+  description: 'Runs, PBs e desafios semanais.',
+  visibility: CommunityVisibility.PUBLIC,
+  status: CommunityStatus.ACTIVE,
+  owner: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+    avatarUrl: null,
+  },
+  memberCount: 12,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+};
+
+const event: CommunityEventSummary = {
+  id: 'event-id-1',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: new Date('2099-05-01T23:00:00.000Z'),
+  status: CommunityEventStatus.PUBLISHED,
+  createdAt: new Date('2026-04-25T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-25T10:00:00.000Z'),
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
+};
+
+describe('communityEventService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue(community);
+  });
+
+  it('lista eventos da comunidade preservando RSVP do viewer', async () => {
+    vi.mocked(communityEventRepository.findByCommunityId).mockResolvedValue([event]);
+
+    const result = await communityEventService.listEvents(
+      'guilda-dos-speedrunners',
+      'member-id-1',
+    );
+
+    expect(communityEventRepository.findByCommunityId).toHaveBeenCalledWith(
+      'community-id-1',
+      'member-id-1',
+    );
+    expect(result).toEqual([event]);
+  });
+
+  it('permite owner criar evento publicado com data futura', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+    vi.mocked(communityEventRepository.create).mockResolvedValue(event);
+
+    const result = await communityEventService.createEvent(
+      'guilda-dos-speedrunners',
+      'owner-id-1',
+      {
+        title: 'Noite de ranked',
+        description: 'Fila fechada para subir elo.',
+        startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      },
+    );
+
+    expect(communityEventRepository.create).toHaveBeenCalledWith({
+      communityId: 'community-id-1',
+      title: 'Noite de ranked',
+      description: 'Fila fechada para subir elo.',
+      startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      createdByUserId: 'owner-id-1',
+    });
+    expect(result.status).toBe(CommunityEventStatus.PUBLISHED);
+  });
+
+  it('bloqueia criação em comunidade arquivada', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue({
+      ...community,
+      status: CommunityStatus.ARCHIVED,
+    });
+
+    await expect(
+      communityEventService.createEvent('guilda-dos-speedrunners', 'owner-id-1', {
+        title: 'Noite de ranked',
+        startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_ARCHIVED',
+    });
+    expect(communityRepository.findMembershipRole).not.toHaveBeenCalled();
+    expect(communityEventRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('bloqueia criação por membro não-owner', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+
+    await expect(
+      communityEventService.createEvent('guilda-dos-speedrunners', 'member-id-1', {
+        title: 'Noite de ranked',
+        startsAt: new Date('2099-05-01T23:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_FORBIDDEN',
+    });
+  });
+
+  it('bloqueia criação com data no passado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+
+    await expect(
+      communityEventService.createEvent('guilda-dos-speedrunners', 'owner-id-1', {
+        title: 'Noite de ranked',
+        startsAt: new Date('2020-05-01T23:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_INVALID_START',
+    });
+  });
+
+  it('permite membro responder RSVP em evento publicado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+    vi.mocked(communityEventRepository.findById)
+      .mockResolvedValueOnce(event)
+      .mockResolvedValueOnce({
+        ...event,
+        viewerRsvp: CommunityEventRsvpStatus.GOING,
+        rsvpCounts: { going: 1, interested: 0, notGoing: 0 },
+      });
+    vi.mocked(communityEventRepository.upsertRsvp).mockResolvedValue(undefined);
+
+    const result = await communityEventService.setRsvp(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'member-id-1',
+      CommunityEventRsvpStatus.GOING,
+    );
+
+    expect(communityEventRepository.upsertRsvp).toHaveBeenCalledWith(
+      'event-id-1',
+      'member-id-1',
+      CommunityEventRsvpStatus.GOING,
+    );
+    expect(result.viewerRsvp).toBe(CommunityEventRsvpStatus.GOING);
+  });
+
+  it('bloqueia RSVP em comunidade arquivada', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue({
+      ...community,
+      status: CommunityStatus.ARCHIVED,
+    });
+
+    await expect(
+      communityEventService.setRsvp(
+        'guilda-dos-speedrunners',
+        'event-id-1',
+        'member-id-1',
+        CommunityEventRsvpStatus.GOING,
+      ),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_ARCHIVED',
+    });
+    expect(communityEventRepository.upsertRsvp).not.toHaveBeenCalled();
+  });
+
+  it('bloqueia RSVP para usuário que não é membro', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(null);
+
+    await expect(
+      communityEventService.setRsvp(
+        'guilda-dos-speedrunners',
+        'event-id-1',
+        'outsider-id-1',
+        CommunityEventRsvpStatus.GOING,
+      ),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_MEMBERSHIP_REQUIRED',
+    });
+  });
+
+  it('bloqueia RSVP em evento cancelado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+    vi.mocked(communityEventRepository.findById).mockResolvedValue({
+      ...event,
+      status: CommunityEventStatus.CANCELLED,
+    });
+
+    await expect(
+      communityEventService.setRsvp(
+        'guilda-dos-speedrunners',
+        'event-id-1',
+        'member-id-1',
+        CommunityEventRsvpStatus.GOING,
+      ),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_CANCELLED',
+    });
+  });
+
+  it('permite owner cancelar evento publicado', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+    vi.mocked(communityEventRepository.findById).mockResolvedValue(event);
+    vi.mocked(communityEventRepository.cancelEvent).mockResolvedValue({
+      ...event,
+      status: CommunityEventStatus.CANCELLED,
+    });
+
+    const result = await communityEventService.cancelEvent(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'owner-id-1',
+    );
+
+    expect(communityEventRepository.cancelEvent).toHaveBeenCalledWith(
+      'community-id-1',
+      'event-id-1',
+    );
+    expect(result.status).toBe(CommunityEventStatus.CANCELLED);
+  });
+
+  it('bloqueia cancelamento por não-owner', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.MEMBER);
+
+    await expect(
+      communityEventService.cancelEvent('guilda-dos-speedrunners', 'event-id-1', 'member-id-1'),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_FORBIDDEN',
+    });
+  });
+
+  it('bloqueia cancelamento em comunidade arquivada', async () => {
+    vi.mocked(communityRepository.findBySlug).mockResolvedValue({
+      ...community,
+      status: CommunityStatus.ARCHIVED,
+    });
+
+    await expect(
+      communityEventService.cancelEvent('guilda-dos-speedrunners', 'event-id-1', 'owner-id-1'),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_ARCHIVED',
+    });
+    expect(communityRepository.findMembershipRole).not.toHaveBeenCalled();
+    expect(communityEventRepository.cancelEvent).not.toHaveBeenCalled();
+  });
+
+  it('retorna erro seguro quando evento não existe', async () => {
+    vi.mocked(communityRepository.findMembershipRole).mockResolvedValue(CommunityMemberRole.OWNER);
+    vi.mocked(communityEventRepository.findById).mockResolvedValue(null);
+
+    await expect(
+      communityEventService.cancelEvent('guilda-dos-speedrunners', 'event-id-1', 'owner-id-1'),
+    ).rejects.toMatchObject({
+      code: 'COMMUNITY_EVENT_NOT_FOUND',
+    });
+  });
+});

--- a/frontend/src/components/communities/community-events-panel.tsx
+++ b/frontend/src/components/communities/community-events-panel.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeading } from '@/components/ui/section-heading';
+import type { CommunityEventRsvpStatus, CommunityRole } from '@/schemas/communities';
+import {
+  cancelCommunityEvent,
+  CommunitiesRequestError,
+  createCommunityEvent,
+  fetchCommunityEvents,
+  setCommunityEventRsvp,
+} from '@/services/communities';
+
+type CommunityEventsPanelProps = {
+  slug: string;
+  isArchived: boolean;
+  isAuthenticated: boolean;
+  viewerMembershipRole: CommunityRole | null;
+};
+
+const rsvpOptions: Array<{ status: CommunityEventRsvpStatus; label: string }> = [
+  { status: 'GOING', label: 'Vou' },
+  { status: 'INTERESTED', label: 'Tenho interesse' },
+  { status: 'NOT_GOING', label: 'Não vou' },
+];
+
+function resolveErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof CommunitiesRequestError) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+function formatUtcDateTime(value: string): string {
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+export function CommunityEventsPanel({
+  slug,
+  isArchived,
+  isAuthenticated,
+  viewerMembershipRole,
+}: CommunityEventsPanelProps) {
+  const queryClient = useQueryClient();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [startsAt, setStartsAt] = useState('');
+  const [formMessage, setFormMessage] = useState<string | null>(null);
+  const isOwner = viewerMembershipRole === 'OWNER';
+  const isMember = viewerMembershipRole === 'OWNER' || viewerMembershipRole === 'MEMBER';
+
+  const eventsQuery = useQuery({
+    queryKey: ['communities', slug, 'events'],
+    queryFn: () => fetchCommunityEvents(slug),
+  });
+
+  const invalidateEvents = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['communities', slug, 'events'] });
+  };
+
+  const createEventMutation = useMutation({
+    mutationFn: () =>
+      createCommunityEvent(slug, {
+        title,
+        description: description.trim() || undefined,
+        startsAt: new Date(startsAt).toISOString(),
+      }),
+    onSuccess: async () => {
+      setTitle('');
+      setDescription('');
+      setStartsAt('');
+      setFormMessage(null);
+      await invalidateEvents();
+    },
+    onError: (error) => {
+      setFormMessage(resolveErrorMessage(error, 'Não foi possível criar o evento.'));
+    },
+  });
+
+  const rsvpMutation = useMutation({
+    mutationFn: ({
+      eventId,
+      status,
+    }: {
+      eventId: string;
+      status: CommunityEventRsvpStatus;
+    }) => setCommunityEventRsvp(slug, eventId, status),
+    onSuccess: invalidateEvents,
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (eventId: string) => cancelCommunityEvent(slug, eventId),
+    onSuccess: invalidateEvents,
+  });
+
+  const canCreate =
+    !isArchived &&
+    isOwner &&
+    title.trim().length >= 3 &&
+    startsAt.length > 0 &&
+    !createEventMutation.isPending;
+  const actionError = rsvpMutation.error ?? cancelMutation.error;
+
+  function handleCreateEvent(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canCreate) {
+      return;
+    }
+
+    createEventMutation.mutate();
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeading
+        eyebrow="Eventos"
+        title="Agenda comunitária mínima"
+        description={
+          isArchived
+            ? 'Esta comunidade está arquivada. Eventos existentes continuam visíveis, mas criação e RSVP estão bloqueados.'
+            : 'Eventos ficam dentro da comunidade, com RSVP simples. Sem calendário, recorrência, chat ou reminders neste slice.'
+        }
+        level="h2"
+      />
+
+      {isOwner && !isArchived ? (
+        <Card>
+          <form className="flex flex-col gap-4" onSubmit={handleCreateEvent}>
+            <div>
+              <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+                Criar evento
+              </p>
+              <p className="mt-2 text-sm leading-6 text-secondary">
+                Owner cria eventos publicados diretamente. A moderação avançada fica fora.
+              </p>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+                Título
+                <input
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  minLength={3}
+                  maxLength={100}
+                  placeholder="Noite de ranked"
+                  className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                  disabled={createEventMutation.isPending}
+                />
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+                Início
+                <input
+                  type="datetime-local"
+                  value={startsAt}
+                  onChange={(event) => setStartsAt(event.target.value)}
+                  className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                  disabled={createEventMutation.isPending}
+                />
+              </label>
+            </div>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+              Descrição curta
+              <input
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                maxLength={280}
+                placeholder="Fila fechada para subir elo."
+                className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+                disabled={createEventMutation.isPending}
+              />
+            </label>
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm text-secondary" role={formMessage ? 'alert' : undefined}>
+                {formMessage ?? 'O horário é enviado como instante UTC para o backend.'}
+              </p>
+              <Button type="submit" disabled={!canCreate}>
+                Criar evento
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : null}
+
+      {isArchived ? (
+        <Card>
+          <p className="text-sm leading-6 text-secondary">
+            Comunidade arquivada. Eventos seguem em modo leitura, sem criação, RSVP ou
+            cancelamento pela interface.
+          </p>
+        </Card>
+      ) : null}
+
+      {eventsQuery.isLoading ? (
+        <Card>
+          <p className="text-sm text-secondary">Carregando eventos da comunidade...</p>
+        </Card>
+      ) : null}
+
+      {eventsQuery.isError ? (
+        <Card>
+          <p className="text-sm text-secondary" role="alert">
+            Não foi possível carregar os eventos desta comunidade.
+          </p>
+        </Card>
+      ) : null}
+
+      {eventsQuery.data?.length === 0 ? (
+        <Card>
+          <p className="text-sm leading-6 text-secondary">
+            Ainda não há eventos publicados nesta comunidade. Quando o owner criar o
+            primeiro, ele aparecerá aqui.
+          </p>
+        </Card>
+      ) : null}
+
+      {eventsQuery.data && eventsQuery.data.length > 0 ? (
+        <div className="grid gap-4">
+          {eventsQuery.data.map((event) => {
+            const isCancelled = event.status === 'CANCELLED';
+
+            return (
+              <Card key={event.id} className="flex flex-col gap-4">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge tone={isCancelled ? 'warning' : 'success'}>
+                        {isCancelled ? 'Cancelado' : 'Publicado'}
+                      </Badge>
+                      {event.viewerRsvp ? <Badge tone="accent">{event.viewerRsvp}</Badge> : null}
+                    </div>
+                    <h3 className="mt-3 font-display text-2xl font-semibold text-primary">
+                      {event.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-secondary">
+                      {event.description ?? 'Evento sem descrição adicional.'}
+                    </p>
+                  </div>
+
+                  <div className="text-right text-sm text-secondary">
+                    <p className="font-medium text-primary">{formatUtcDateTime(event.startsAt)}</p>
+                    <p className="mt-1">UTC</p>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.24em] text-secondary">
+                  <span>{event.rsvpCounts.going} vou</span>
+                  <span>{event.rsvpCounts.interested} interesse</span>
+                  <span>{event.rsvpCounts.notGoing} não vou</span>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+                  <p className="text-sm text-secondary">
+                    Criado por {event.createdBy.displayName ?? event.createdBy.username}
+                  </p>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {isAuthenticated && isMember && !isArchived && !isCancelled
+                      ? rsvpOptions.map((option) => (
+                          <Button
+                            key={option.status}
+                            type="button"
+                            size="sm"
+                            variant={event.viewerRsvp === option.status ? 'primary' : 'secondary'}
+                            disabled={rsvpMutation.isPending}
+                            onClick={() =>
+                              rsvpMutation.mutate({ eventId: event.id, status: option.status })
+                            }
+                          >
+                            {option.label}
+                          </Button>
+                        ))
+                      : null}
+
+                    {isOwner && !isArchived && !isCancelled ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        disabled={cancelMutation.isPending}
+                        onClick={() => cancelMutation.mutate(event.id)}
+                      >
+                        Cancelar evento
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {actionError ? (
+        <p className="text-sm text-status-afk" role="alert">
+          {resolveErrorMessage(actionError, 'Não foi possível atualizar o evento.')}
+        </p>
+      ) : null}
+
+      {!isAuthenticated && !isArchived ? (
+        <p className="text-sm text-secondary">
+          Entre na sessão para responder RSVP nos eventos da comunidade.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/communities/community-page-content.tsx
+++ b/frontend/src/components/communities/community-page-content.tsx
@@ -14,6 +14,7 @@ import {
   joinCommunity,
   leaveCommunity,
 } from '@/services/communities';
+import { CommunityEventsPanel } from './community-events-panel';
 
 type CommunityPageContentProps = {
   slug: string;
@@ -203,6 +204,13 @@ export function CommunityPageContent({ slug }: CommunityPageContentProps) {
           </p>
         ) : null}
       </Card>
+
+      <CommunityEventsPanel
+        slug={slug}
+        isArchived={isArchived}
+        isAuthenticated={isAuthenticated}
+        viewerMembershipRole={community.viewerMembershipRole ?? null}
+      />
     </div>
   );
 }

--- a/frontend/src/schemas/communities.ts
+++ b/frontend/src/schemas/communities.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 export const communityRoleSchema = z.enum(['OWNER', 'MEMBER']);
 export const communityVisibilitySchema = z.enum(['PUBLIC']);
 export const communityStatusSchema = z.enum(['ACTIVE', 'ARCHIVED']);
+export const communityEventStatusSchema = z.enum(['PUBLISHED', 'CANCELLED']);
+export const communityEventRsvpStatusSchema = z.enum(['GOING', 'INTERESTED', 'NOT_GOING']);
 
 export const communityOwnerSchema = z.object({
   id: z.string(),
@@ -33,13 +35,56 @@ export const communityResponseSchema = z.object({
   community: communitySchema,
 });
 
+export const communityEventCreatorSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+});
+
+export const communityEventSchema = z.object({
+  id: z.string(),
+  communityId: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  startsAt: z.string(),
+  status: communityEventStatusSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  createdBy: communityEventCreatorSchema,
+  viewerRsvp: communityEventRsvpStatusSchema.nullable(),
+  rsvpCounts: z.object({
+    going: z.number().int().nonnegative(),
+    interested: z.number().int().nonnegative(),
+    notGoing: z.number().int().nonnegative(),
+  }),
+});
+
+export const communityEventsResponseSchema = z.object({
+  events: z.array(communityEventSchema),
+});
+
+export const communityEventResponseSchema = z.object({
+  event: communityEventSchema,
+});
+
 export const createCommunityRequestSchema = z.object({
   name: z.string().trim().min(3).max(80),
   description: z.string().trim().max(240).optional(),
 });
 
+export const createCommunityEventRequestSchema = z.object({
+  title: z.string().trim().min(3).max(100),
+  description: z.string().trim().max(280).optional(),
+  startsAt: z.string().datetime(),
+});
+
 export type CommunityRole = z.infer<typeof communityRoleSchema>;
+export type CommunityEventRsvpStatus = z.infer<typeof communityEventRsvpStatusSchema>;
 export type Community = z.infer<typeof communitySchema>;
+export type CommunityEvent = z.infer<typeof communityEventSchema>;
 export type CommunitiesResponse = z.infer<typeof communitiesResponseSchema>;
 export type CommunityResponse = z.infer<typeof communityResponseSchema>;
+export type CommunityEventsResponse = z.infer<typeof communityEventsResponseSchema>;
+export type CommunityEventResponse = z.infer<typeof communityEventResponseSchema>;
 export type CreateCommunityValues = z.infer<typeof createCommunityRequestSchema>;
+export type CreateCommunityEventValues = z.infer<typeof createCommunityEventRequestSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -10,11 +10,17 @@ export {
 } from './auth';
 export {
   communitiesResponseSchema,
+  communityEventResponseSchema,
+  communityEventRsvpStatusSchema,
+  communityEventsResponseSchema,
+  communityEventSchema,
+  communityEventStatusSchema,
   communityResponseSchema,
   communityRoleSchema,
   communitySchema,
   communityStatusSchema,
   communityVisibilitySchema,
+  createCommunityEventRequestSchema,
   createCommunityRequestSchema,
 } from './communities';
 export {

--- a/frontend/src/services/communities.ts
+++ b/frontend/src/services/communities.ts
@@ -1,9 +1,15 @@
 import { apiRequest } from '@/lib/api';
 import {
   communitiesResponseSchema,
+  communityEventResponseSchema,
+  communityEventsResponseSchema,
   communityResponseSchema,
+  createCommunityEventRequestSchema,
   createCommunityRequestSchema,
   type Community,
+  type CommunityEvent,
+  type CommunityEventRsvpStatus,
+  type CreateCommunityEventValues,
   type CreateCommunityValues,
 } from '@/schemas/communities';
 
@@ -148,4 +154,91 @@ export async function archiveCommunity(slug: string): Promise<Community> {
   }
 
   return communityResponseSchema.parse(payload).community;
+}
+
+export async function fetchCommunityEvents(slug: string): Promise<CommunityEvent[]> {
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}/events`, {
+    method: 'GET',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar os eventos desta comunidade.'),
+    );
+  }
+
+  return communityEventsResponseSchema.parse(payload).events;
+}
+
+export async function createCommunityEvent(
+  slug: string,
+  input: CreateCommunityEventValues,
+): Promise<CommunityEvent> {
+  const payload = createCommunityEventRequestSchema.parse(input);
+  const response = await apiRequest(`/communities/${encodeURIComponent(slug)}/events`, {
+    method: 'POST',
+    body: {
+      title: payload.title.trim(),
+      description: payload.description?.trim() || undefined,
+      startsAt: payload.startsAt,
+    },
+  });
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel criar o evento.'),
+    );
+  }
+
+  return communityEventResponseSchema.parse(responsePayload).event;
+}
+
+export async function setCommunityEventRsvp(
+  slug: string,
+  eventId: string,
+  status: CommunityEventRsvpStatus,
+): Promise<CommunityEvent> {
+  const response = await apiRequest(
+    `/communities/${encodeURIComponent(slug)}/events/${encodeURIComponent(eventId)}/rsvp`,
+    {
+      method: 'PUT',
+      body: { status },
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel responder RSVP.'),
+    );
+  }
+
+  return communityEventResponseSchema.parse(payload).event;
+}
+
+export async function cancelCommunityEvent(
+  slug: string,
+  eventId: string,
+): Promise<CommunityEvent> {
+  const response = await apiRequest(
+    `/communities/${encodeURIComponent(slug)}/events/${encodeURIComponent(eventId)}/cancel`,
+    {
+      method: 'PATCH',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new CommunitiesRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel cancelar o evento.'),
+    );
+  }
+
+  return communityEventResponseSchema.parse(payload).event;
 }

--- a/frontend/tests/unit/components/community-page-content.test.tsx
+++ b/frontend/tests/unit/components/community-page-content.test.tsx
@@ -6,9 +6,13 @@ import { CommunityPageContent } from '@/components/communities/community-page-co
 import { useAuth } from '@/hooks/use-auth';
 import {
   archiveCommunity,
+  cancelCommunityEvent,
+  createCommunityEvent,
   fetchCommunityBySlug,
+  fetchCommunityEvents,
   joinCommunity,
   leaveCommunity,
+  setCommunityEventRsvp,
 } from '@/services/communities';
 
 vi.mock('@/hooks/use-auth', () => ({
@@ -17,16 +21,24 @@ vi.mock('@/hooks/use-auth', () => ({
 
 vi.mock('@/services/communities', () => ({
   fetchCommunityBySlug: vi.fn(),
+  fetchCommunityEvents: vi.fn(),
   joinCommunity: vi.fn(),
   leaveCommunity: vi.fn(),
   archiveCommunity: vi.fn(),
+  createCommunityEvent: vi.fn(),
+  setCommunityEventRsvp: vi.fn(),
+  cancelCommunityEvent: vi.fn(),
 }));
 
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedFetchCommunityBySlug = vi.mocked(fetchCommunityBySlug);
+const mockedFetchCommunityEvents = vi.mocked(fetchCommunityEvents);
 const mockedJoinCommunity = vi.mocked(joinCommunity);
 const mockedLeaveCommunity = vi.mocked(leaveCommunity);
 const mockedArchiveCommunity = vi.mocked(archiveCommunity);
+const mockedCreateCommunityEvent = vi.mocked(createCommunityEvent);
+const mockedSetCommunityEventRsvp = vi.mocked(setCommunityEventRsvp);
+const mockedCancelCommunityEvent = vi.mocked(cancelCommunityEvent);
 
 const community = {
   id: 'community-id-1',
@@ -45,6 +57,28 @@ const community = {
   createdAt: '2026-04-25T10:00:00.000Z',
   updatedAt: '2026-04-25T10:00:00.000Z',
   viewerMembershipRole: null,
+};
+
+const communityEvent = {
+  id: 'event-id-1',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: '2099-05-01T23:00:00.000Z',
+  status: 'PUBLISHED' as const,
+  createdAt: '2026-04-25T10:00:00.000Z',
+  updatedAt: '2026-04-25T10:00:00.000Z',
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
 };
 
 function renderCommunityPage() {
@@ -69,6 +103,11 @@ describe('CommunityPageContent', () => {
     mockedJoinCommunity.mockReset();
     mockedLeaveCommunity.mockReset();
     mockedArchiveCommunity.mockReset();
+    mockedFetchCommunityEvents.mockReset();
+    mockedCreateCommunityEvent.mockReset();
+    mockedSetCommunityEventRsvp.mockReset();
+    mockedCancelCommunityEvent.mockReset();
+    mockedFetchCommunityEvents.mockResolvedValue([]);
     mockedUseAuth.mockReturnValue({
       user: { id: 'user-id-1', username: 'clutchplayer', email: 'player@clutch.gg' },
       status: 'authenticated',
@@ -186,5 +225,113 @@ describe('CommunityPageContent', () => {
       expect(mockedLeaveCommunity).toHaveBeenCalledWith('guilda-dos-speedrunners');
     });
     expect(screen.queryByRole('button', { name: /^participar$/i })).not.toBeInTheDocument();
+  });
+
+  it('renders community events on the public community page', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'MEMBER',
+    });
+    mockedFetchCommunityEvents.mockResolvedValue([communityEvent]);
+
+    renderCommunityPage();
+
+    expect(await screen.findByRole('heading', { name: 'Agenda comunitária mínima' }))
+      .toBeInTheDocument();
+    expect(await screen.findByText('Noite de ranked')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Vou' })).toBeInTheDocument();
+  });
+
+  it('renders empty state when community has no events', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue(community);
+    mockedFetchCommunityEvents.mockResolvedValue([]);
+
+    renderCommunityPage();
+
+    expect(await screen.findByText(/ainda não há eventos publicados/i)).toBeInTheDocument();
+  });
+
+  it('lets owner create a community event', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'OWNER',
+    });
+    mockedFetchCommunityEvents.mockResolvedValue([]);
+    mockedCreateCommunityEvent.mockResolvedValue(communityEvent);
+
+    renderCommunityPage();
+
+    fireEvent.change(await screen.findByLabelText(/^título$/i), {
+      target: { value: 'Noite de ranked' },
+    });
+    fireEvent.change(screen.getByLabelText(/^início$/i), {
+      target: { value: '2099-05-01T23:00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^criar evento$/i }));
+
+    await waitFor(() => {
+      expect(mockedCreateCommunityEvent).toHaveBeenCalledWith(
+        'guilda-dos-speedrunners',
+        expect.objectContaining({
+          title: 'Noite de ranked',
+        }),
+      );
+    });
+  });
+
+  it('lets member RSVP when community is active', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      viewerMembershipRole: 'MEMBER',
+    });
+    mockedFetchCommunityEvents.mockResolvedValue([communityEvent]);
+    mockedSetCommunityEventRsvp.mockResolvedValue({
+      ...communityEvent,
+      viewerRsvp: 'GOING',
+    });
+
+    renderCommunityPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Vou' }));
+
+    await waitFor(() => {
+      expect(mockedSetCommunityEventRsvp).toHaveBeenCalledWith(
+        'guilda-dos-speedrunners',
+        'event-id-1',
+        'GOING',
+      );
+    });
+  });
+
+  it('hides event actions when community is archived', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue({
+      ...community,
+      status: 'ARCHIVED',
+      viewerMembershipRole: 'OWNER',
+    });
+    mockedFetchCommunityEvents.mockResolvedValue([communityEvent]);
+
+    renderCommunityPage();
+
+    expect(await screen.findByText('Noite de ranked')).toBeInTheDocument();
+    expect(screen.getByText(/eventos seguem em modo leitura/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^criar evento$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Vou' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /cancelar evento/i })).not.toBeInTheDocument();
+  });
+
+  it('renders cancelled events with status', async () => {
+    mockedFetchCommunityBySlug.mockResolvedValue(community);
+    mockedFetchCommunityEvents.mockResolvedValue([
+      {
+        ...communityEvent,
+        status: 'CANCELLED',
+      },
+    ]);
+
+    renderCommunityPage();
+
+    expect(await screen.findByText('Cancelado')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Vou' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/services/communities.test.ts
+++ b/frontend/tests/unit/services/communities.test.ts
@@ -3,10 +3,14 @@ import { apiRequest } from '@/lib/api';
 import {
   createCommunity,
   archiveCommunity,
+  cancelCommunityEvent,
   fetchCommunities,
   fetchCommunityBySlug,
+  fetchCommunityEvents,
   joinCommunity,
   leaveCommunity,
+  createCommunityEvent,
+  setCommunityEventRsvp,
 } from '@/services/communities';
 
 vi.mock('@/lib/api', () => ({
@@ -32,6 +36,28 @@ const communityPayload = {
   createdAt: '2026-04-25T10:00:00.000Z',
   updatedAt: '2026-04-25T10:00:00.000Z',
   viewerMembershipRole: null,
+};
+
+const communityEventPayload = {
+  id: 'event-id-1',
+  communityId: 'community-id-1',
+  title: 'Noite de ranked',
+  description: 'Fila fechada para subir elo.',
+  startsAt: '2099-05-01T23:00:00.000Z',
+  status: 'PUBLISHED',
+  createdAt: '2026-04-25T10:00:00.000Z',
+  updatedAt: '2026-04-25T10:00:00.000Z',
+  createdBy: {
+    id: 'owner-id-1',
+    username: 'owner',
+    displayName: 'Owner',
+  },
+  viewerRsvp: null,
+  rsvpCounts: {
+    going: 0,
+    interested: 0,
+    notGoing: 0,
+  },
 };
 
 describe('communities service', () => {
@@ -151,6 +177,103 @@ describe('communities service', () => {
     expect(response.status).toBe('ARCHIVED');
     expect(mockedApiRequest).toHaveBeenCalledWith(
       '/communities/guilda-dos-speedrunners/archive',
+      {
+        method: 'PATCH',
+      },
+    );
+  });
+
+  it('lists community events by slug', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ events: [communityEventPayload] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await fetchCommunityEvents('guilda-dos-speedrunners');
+
+    expect(response).toHaveLength(1);
+    expect(response[0]?.title).toBe('Noite de ranked');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events',
+      {
+        method: 'GET',
+      },
+    );
+  });
+
+  it('creates a community event with the real contract', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ event: communityEventPayload }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await createCommunityEvent('guilda-dos-speedrunners', {
+      title: 'Noite de ranked',
+      description: 'Fila fechada para subir elo.',
+      startsAt: '2099-05-01T23:00:00.000Z',
+    });
+
+    expect(response.status).toBe('PUBLISHED');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events',
+      {
+        method: 'POST',
+        body: {
+          title: 'Noite de ranked',
+          description: 'Fila fechada para subir elo.',
+          startsAt: '2099-05-01T23:00:00.000Z',
+        },
+      },
+    );
+  });
+
+  it('sets RSVP for a community event', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({ event: { ...communityEventPayload, viewerRsvp: 'GOING' } }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await setCommunityEventRsvp(
+      'guilda-dos-speedrunners',
+      'event-id-1',
+      'GOING',
+    );
+
+    expect(response.viewerRsvp).toBe('GOING');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events/event-id-1/rsvp',
+      {
+        method: 'PUT',
+        body: { status: 'GOING' },
+      },
+    );
+  });
+
+  it('cancels a community event', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({ event: { ...communityEventPayload, status: 'CANCELLED' } }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await cancelCommunityEvent('guilda-dos-speedrunners', 'event-id-1');
+
+    expect(response.status).toBe('CANCELLED');
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/communities/guilda-dos-speedrunners/events/event-id-1/cancel',
       {
         method: 'PATCH',
       },


### PR DESCRIPTION
﻿## Resumo
Reentrega o slice funcional mínimo de eventos comunitários diretamente sobre `develop`, corrigindo a lacuna em que a PR anterior de #268 foi mergeada em uma branch de feature e não chegou à linha principal. A mudança adiciona criação, listagem, RSVP e cancelamento de eventos por comunidade, respeitando o arquivamento entregue em #278.

Closes #268

## O que foi alterado
- Backend:
  - adiciona os modelos `CommunityEvent` e `CommunityEventRsvp`, com enums de status e migration dedicada;
  - adiciona repository e service de eventos comunitários;
  - expõe rotas mínimas em `/communities/:slug/events`, `/communities/:slug/events/:eventId/rsvp` e `/communities/:slug/events/:eventId/cancel`;
  - bloqueia criação, RSVP e cancelamento quando a comunidade está arquivada;
  - restringe criação/cancelamento ao owner e RSVP a membros.
- Frontend:
  - adiciona o painel mínimo de eventos na página pública da comunidade;
  - renderiza lista, empty state, estado cancelado e modo somente leitura para comunidade arquivada;
  - permite criação por owner e RSVP por membro quando permitido.
- Testes:
  - adiciona cobertura unitária do service de eventos;
  - amplia testes de rotas de comunidades;
  - amplia testes de service frontend e da página de comunidade.

## Motivação
A issue #268 estava fechada, mas o commit da PR #269 não é ancestral de `origin/develop` e os modelos/rotas reais de eventos não existiam na linha principal. Esta PR reabre a entrega de forma limpa sobre `develop`, adaptando o slice ao estado atual do produto após #278.

## Como validar
- Backend:
  - `cd backend`
  - `npm run test -- tests/unit/services/community-event.service.test.ts tests/unit/repositories/community-event.repository.test.ts tests/integration/routes/communities.routes.test.ts`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
- Frontend:
  - `cd frontend`
  - `npm run test -- tests/unit/services/communities.test.ts tests/unit/components/community-page-content.test.tsx`
  - `npm run test:coverage`
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`

## Riscos e impactos
- Inclui migration Prisma com novas tabelas e enums para eventos comunitários.
- Datas de eventos são tratadas em UTC no contrato atual; calendário complexo, recorrência e reminders ficam fora do escopo.
- `npm run test:coverage` do backend não completou localmente por credenciais inválidas de Postgres em `localhost` e timeouts associados a Redis indisponível; os testes focados da área passaram isoladamente.
- Eventos/RSVP agora existem na linha principal e respeitam comunidades arquivadas; após merge, #214 pode ser reavaliada para fechamento.

## Evidências
- Backend focado: 3 arquivos, 40 testes passando.
- Frontend focado: 2 arquivos, 23 testes passando.
- Frontend coverage: 72 arquivos, 287 testes passando, linhas/statements 82,85%.
- Backend typecheck, lint e build passaram; lint mantém 3 warnings preexistentes em `backend/src/config/rate-limit.ts`.
- Frontend typecheck, lint e build passaram.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados


