### PR TITLE
feat(arena): implementar desafios semanais assíncronos

### DIFF
--- a/backend/prisma/migrations/20260501153000_add_arena_weekly_challenges/migration.sql
+++ b/backend/prisma/migrations/20260501153000_add_arena_weekly_challenges/migration.sql
@@ -1,0 +1,57 @@
+CREATE TYPE "ArenaChallengeStatus" AS ENUM ('DRAFT', 'ACTIVE', 'CLOSED', 'ARCHIVED');
+CREATE TYPE "ArenaProofType" AS ENUM ('GAME_SESSION', 'ACHIEVEMENT', 'COMMUNITY_EVENT_RSVP');
+
+CREATE TABLE "arena_challenges" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "status" "ArenaChallengeStatus" NOT NULL DEFAULT 'ACTIVE',
+    "ruleType" "ArenaProofType" NOT NULL,
+    "scoreValue" INTEGER NOT NULL DEFAULT 10,
+    "maxSubmissionsPerUser" INTEGER NOT NULL DEFAULT 3,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "arena_challenges_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "arena_participations" (
+    "id" TEXT NOT NULL,
+    "challengeId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "arena_participations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "arena_submissions" (
+    "id" TEXT NOT NULL,
+    "challengeId" TEXT NOT NULL,
+    "participationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "proofType" "ArenaProofType" NOT NULL,
+    "proofId" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "submittedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "arena_submissions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "arena_challenges_slug_key" ON "arena_challenges"("slug");
+CREATE INDEX "arena_challenges_status_startsAt_endsAt_idx" ON "arena_challenges"("status", "startsAt", "endsAt");
+
+CREATE UNIQUE INDEX "arena_participations_challengeId_userId_key" ON "arena_participations"("challengeId", "userId");
+CREATE INDEX "arena_participations_userId_idx" ON "arena_participations"("userId");
+
+CREATE UNIQUE INDEX "arena_submissions_challengeId_proofType_proofId_key" ON "arena_submissions"("challengeId", "proofType", "proofId");
+CREATE INDEX "arena_submissions_challengeId_userId_idx" ON "arena_submissions"("challengeId", "userId");
+CREATE INDEX "arena_submissions_userId_idx" ON "arena_submissions"("userId");
+
+ALTER TABLE "arena_participations" ADD CONSTRAINT "arena_participations_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "arena_challenges"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "arena_participations" ADD CONSTRAINT "arena_participations_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "arena_submissions" ADD CONSTRAINT "arena_submissions_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "arena_challenges"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "arena_submissions" ADD CONSTRAINT "arena_submissions_participationId_fkey" FOREIGN KEY ("participationId") REFERENCES "arena_participations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "arena_submissions" ADD CONSTRAINT "arena_submissions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260501153000_add_arena_weekly_challenges/migration.sql
+++ b/backend/prisma/migrations/20260501153000_add_arena_weekly_challenges/migration.sql
@@ -50,6 +50,11 @@ CREATE UNIQUE INDEX "arena_submissions_challengeId_proofType_proofId_key" ON "ar
 CREATE INDEX "arena_submissions_challengeId_userId_idx" ON "arena_submissions"("challengeId", "userId");
 CREATE INDEX "arena_submissions_userId_idx" ON "arena_submissions"("userId");
 
+ALTER TABLE "arena_challenges" ADD CONSTRAINT "arena_challenges_valid_window_check" CHECK ("endsAt" > "startsAt");
+ALTER TABLE "arena_challenges" ADD CONSTRAINT "arena_challenges_scoreValue_positive_check" CHECK ("scoreValue" > 0);
+ALTER TABLE "arena_challenges" ADD CONSTRAINT "arena_challenges_maxSubmissionsPerUser_positive_check" CHECK ("maxSubmissionsPerUser" > 0);
+ALTER TABLE "arena_submissions" ADD CONSTRAINT "arena_submissions_score_positive_check" CHECK ("score" > 0);
+
 ALTER TABLE "arena_participations" ADD CONSTRAINT "arena_participations_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "arena_challenges"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE "arena_participations" ADD CONSTRAINT "arena_participations_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE "arena_submissions" ADD CONSTRAINT "arena_submissions_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "arena_challenges"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -122,6 +122,19 @@ enum CommunityEventRsvpStatus {
   NOT_GOING
 }
 
+enum ArenaChallengeStatus {
+  DRAFT
+  ACTIVE
+  CLOSED
+  ARCHIVED
+}
+
+enum ArenaProofType {
+  GAME_SESSION
+  ACHIEVEMENT
+  COMMUNITY_EVENT_RSVP
+}
+
 // ── User ─────────────────────────────────────────────────────
 
 model User {
@@ -154,6 +167,8 @@ model User {
   communityMemberships   CommunityMember[]
   createdCommunityEvents CommunityEvent[]      @relation("CommunityEventCreator")
   communityEventRsvps    CommunityEventRsvp[]
+  arenaParticipations     ArenaParticipation[]
+  arenaSubmissions        ArenaSubmission[]
 
   @@map("users")
 }
@@ -359,6 +374,64 @@ model CommunityEventRsvp {
   @@unique([eventId, userId])
   @@index([userId])
   @@map("community_event_rsvps")
+}
+
+// ── Arena ───────────────────────────────────────────────────
+
+model ArenaChallenge {
+  id                    String               @id @default(uuid())
+  slug                  String               @unique
+  title                 String
+  description           String
+  startsAt              DateTime
+  endsAt                DateTime
+  status                ArenaChallengeStatus @default(ACTIVE)
+  ruleType              ArenaProofType
+  scoreValue            Int                  @default(10)
+  maxSubmissionsPerUser Int                  @default(3)
+  createdAt             DateTime             @default(now())
+  updatedAt             DateTime             @updatedAt
+
+  participations ArenaParticipation[]
+  submissions    ArenaSubmission[]
+
+  @@index([status, startsAt, endsAt])
+  @@map("arena_challenges")
+}
+
+model ArenaParticipation {
+  id          String   @id @default(uuid())
+  challengeId String
+  userId      String
+  joinedAt    DateTime @default(now())
+
+  challenge   ArenaChallenge   @relation(fields: [challengeId], references: [id], onDelete: Cascade)
+  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  submissions ArenaSubmission[]
+
+  @@unique([challengeId, userId])
+  @@index([userId])
+  @@map("arena_participations")
+}
+
+model ArenaSubmission {
+  id              String         @id @default(uuid())
+  challengeId     String
+  participationId String
+  userId          String
+  proofType       ArenaProofType
+  proofId         String
+  score           Int
+  submittedAt     DateTime       @default(now())
+
+  challenge     ArenaChallenge     @relation(fields: [challengeId], references: [id], onDelete: Cascade)
+  participation ArenaParticipation @relation(fields: [participationId], references: [id], onDelete: Cascade)
+  user          User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([challengeId, proofType, proofId])
+  @@index([challengeId, userId])
+  @@index([userId])
+  @@map("arena_submissions")
 }
 
 // ── Post ─────────────────────────────────────────────────────

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -7,6 +7,8 @@ import type {
 import { fileURLToPath } from 'node:url';
 
 const {
+  ArenaChallengeStatus,
+  ArenaProofType,
   InteractionType,
   MediaConsumptionStatus,
   MediaKind,
@@ -19,6 +21,8 @@ const {
 } = prismaClientPackage;
 
 type InteractionType = (typeof InteractionType)[keyof typeof InteractionType];
+type ArenaChallengeStatus = (typeof ArenaChallengeStatus)[keyof typeof ArenaChallengeStatus];
+type ArenaProofType = (typeof ArenaProofType)[keyof typeof ArenaProofType];
 type MediaConsumptionStatus = (typeof MediaConsumptionStatus)[keyof typeof MediaConsumptionStatus];
 type MediaKind = (typeof MediaKind)[keyof typeof MediaKind];
 type NotificationType = (typeof NotificationType)[keyof typeof NotificationType];
@@ -81,6 +85,10 @@ export const SEEDED_ENTITY_IDS = {
     'h2222222-2222-4222-8222-222222222222',
     'h3333333-3333-4333-8333-333333333333',
     'h4444444-4444-4444-8444-444444444444',
+  ],
+  arenaChallenges: [
+    'i1111111-1111-4111-8111-111111111111',
+    'i2222222-2222-4222-8222-222222222222',
   ],
 } as const;
 
@@ -196,6 +204,17 @@ type SeedUserMediaEntryConfig = {
   mediaTitleId: string;
   status: MediaConsumptionStatus;
   showcaseRank: number | null;
+};
+
+type SeedArenaChallengeConfig = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  status: ArenaChallengeStatus;
+  ruleType: ArenaProofType;
+  scoreValue: number;
+  maxSubmissionsPerUser: number;
 };
 
 function toNullableJsonInput(value: Prisma.JsonObject | null): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
@@ -625,6 +644,40 @@ const seedUserMediaEntries: SeedUserMediaEntryConfig[] = [
   },
 ];
 
+const seedArenaChallenges: SeedArenaChallengeConfig[] = [
+  {
+    id: 'i1111111-1111-4111-8111-111111111111',
+    slug: 'semana-da-game-session',
+    title: 'Semana da Game Session',
+    description: 'Entre no desafio e envie posts GAME_SESSION da semana para pontuar no ranking local.',
+    status: ArenaChallengeStatus.ACTIVE,
+    ruleType: ArenaProofType.GAME_SESSION,
+    scoreValue: 10,
+    maxSubmissionsPerUser: 3,
+  },
+  {
+    id: 'i2222222-2222-4222-8222-222222222222',
+    slug: 'conquistas-da-semana',
+    title: 'Conquistas da Semana',
+    description: 'Submeta posts ACHIEVEMENT da semana para validar o primeiro loop competitivo assíncrono.',
+    status: ArenaChallengeStatus.ACTIVE,
+    ruleType: ArenaProofType.ACHIEVEMENT,
+    scoreValue: 15,
+    maxSubmissionsPerUser: 3,
+  },
+];
+
+function resolveSeedArenaWindow(referenceDate = new Date()): { startsAt: Date; endsAt: Date } {
+  const startsAt = new Date(referenceDate);
+  startsAt.setUTCHours(0, 0, 0, 0);
+  startsAt.setUTCDate(startsAt.getUTCDate() - 1);
+
+  const endsAt = new Date(startsAt);
+  endsAt.setUTCDate(startsAt.getUTCDate() + 7);
+
+  return { startsAt, endsAt };
+}
+
 function seedUsersPlaceholder(): readonly string[] {
   return [
     DEMO_ACCOUNT.email,
@@ -727,6 +780,37 @@ function getUserId(userIdsByEmail: Map<string, string>, email: string): string {
 }
 
 async function upsertSeedRelations(client: PrismaClient, userIdsByEmail: Map<string, string>): Promise<void> {
+  const arenaWindow = resolveSeedArenaWindow();
+
+  for (const challenge of seedArenaChallenges) {
+    await client.arenaChallenge.upsert({
+      where: { id: challenge.id },
+      update: {
+        slug: challenge.slug,
+        title: challenge.title,
+        description: challenge.description,
+        startsAt: arenaWindow.startsAt,
+        endsAt: arenaWindow.endsAt,
+        status: challenge.status,
+        ruleType: challenge.ruleType,
+        scoreValue: challenge.scoreValue,
+        maxSubmissionsPerUser: challenge.maxSubmissionsPerUser,
+      },
+      create: {
+        id: challenge.id,
+        slug: challenge.slug,
+        title: challenge.title,
+        description: challenge.description,
+        startsAt: arenaWindow.startsAt,
+        endsAt: arenaWindow.endsAt,
+        status: challenge.status,
+        ruleType: challenge.ruleType,
+        scoreValue: challenge.scoreValue,
+        maxSubmissionsPerUser: challenge.maxSubmissionsPerUser,
+      },
+    });
+  }
+
   for (const mediaTitle of seedMediaTitles) {
     await client.mediaTitle.upsert({
       where: { id: mediaTitle.id },

--- a/backend/src/api/routes/arena.routes.ts
+++ b/backend/src/api/routes/arena.routes.ts
@@ -1,0 +1,183 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { extractBearerToken, type VerifiedJwtPayload } from '../../config/jwt';
+import {
+  arenaService,
+  ArenaServiceError,
+} from '../../core/services/arena.service';
+
+const slugParamsSchema = z.object({
+  slug: z.string().trim().min(1).max(120),
+});
+
+const challengeIdParamsSchema = z.object({
+  challengeId: z.string().trim().min(1),
+});
+
+const submitProofSchema = z.object({
+  proofType: z.enum(['GAME_SESSION', 'ACHIEVEMENT']),
+  proofId: z.string().trim().min(1),
+});
+
+function resolveOptionalViewerUserId(request: FastifyRequest): string | null {
+  const token = extractBearerToken(request.headers.authorization);
+
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const payload = request.server.verifyAccessToken(token) as VerifiedJwtPayload;
+    return payload.id;
+  } catch {
+    return null;
+  }
+}
+
+function sendArenaServiceError(
+  error: ArenaServiceError,
+  reply: FastifyReply,
+): FastifyReply {
+  const statusByCode: Record<ArenaServiceError['code'], number> = {
+    ARENA_CHALLENGE_NOT_FOUND: 404,
+    ARENA_CHALLENGE_NOT_ACTIVE: 409,
+    ARENA_CHALLENGE_NOT_STARTED: 409,
+    ARENA_CHALLENGE_ENDED: 409,
+    ARENA_PARTICIPATION_REQUIRED: 403,
+    ARENA_PROOF_NOT_FOUND: 404,
+    ARENA_PROOF_FORBIDDEN: 403,
+    ARENA_PROOF_TYPE_UNSUPPORTED: 400,
+    ARENA_PROOF_OUTSIDE_WINDOW: 400,
+    ARENA_PROOF_DUPLICATE: 409,
+    ARENA_SUBMISSION_CAP_REACHED: 409,
+  };
+
+  return reply.status(statusByCode[error.code]).send({ message: error.message });
+}
+
+export async function arenaRoutes(app: FastifyInstance): Promise<void> {
+  app.get('/challenges', async (request) => {
+    const challenges = await arenaService.listActiveChallenges(
+      resolveOptionalViewerUserId(request),
+    );
+
+    return { challenges };
+  });
+
+  app.get<{ Params: { slug: string } }>('/challenges/:slug', async (request, reply) => {
+    const params = slugParamsSchema.safeParse(request.params);
+
+    if (!params.success) {
+      return reply.status(400).send({
+        message: 'Parâmetros inválidos.',
+        errors: params.error.flatten(),
+      });
+    }
+
+    try {
+      const challenge = await arenaService.getChallenge(
+        params.data.slug,
+        resolveOptionalViewerUserId(request),
+      );
+
+      return { challenge };
+    } catch (error) {
+      if (error instanceof ArenaServiceError) {
+        return sendArenaServiceError(error, reply);
+      }
+
+      throw error;
+    }
+  });
+
+  app.post<{ Params: { challengeId: string } }>(
+    '/challenges/:challengeId/join',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = challengeIdParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const challenge = await arenaService.joinChallenge(
+          params.data.challengeId,
+          request.userId,
+        );
+
+        return reply.status(200).send({ challenge });
+      } catch (error) {
+        if (error instanceof ArenaServiceError) {
+          return sendArenaServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.post<{ Params: { challengeId: string } }>(
+    '/challenges/:challengeId/submissions',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const params = challengeIdParamsSchema.safeParse(request.params);
+      const body = submitProofSchema.safeParse(request.body);
+
+      if (!params.success || !body.success) {
+        return reply.status(400).send({
+          message: 'Dados inválidos.',
+          errors: {
+            params: params.success ? undefined : params.error.flatten(),
+            body: body.success ? undefined : body.error.flatten(),
+          },
+        });
+      }
+
+      try {
+        const submission = await arenaService.submitProof(
+          params.data.challengeId,
+          request.userId,
+          body.data,
+        );
+
+        return reply.status(201).send({ submission });
+      } catch (error) {
+        if (error instanceof ArenaServiceError) {
+          return sendArenaServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+
+  app.get<{ Params: { challengeId: string } }>(
+    '/challenges/:challengeId/leaderboard',
+    async (request, reply) => {
+      const params = challengeIdParamsSchema.safeParse(request.params);
+
+      if (!params.success) {
+        return reply.status(400).send({
+          message: 'Parâmetros inválidos.',
+          errors: params.error.flatten(),
+        });
+      }
+
+      try {
+        const leaderboard = await arenaService.listLeaderboard(params.data.challengeId);
+
+        return { leaderboard };
+      } catch (error) {
+        if (error instanceof ArenaServiceError) {
+          return sendArenaServiceError(error, reply);
+        }
+
+        throw error;
+      }
+    },
+  );
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import { notificationRoutes } from './api/routes/notifications.routes';
 import { uploadRoutes } from './api/routes/uploads.routes';
 import { communityRoutes } from './api/routes/communities.routes';
 import { otakuRoutes } from './api/routes/otaku.routes';
+import { arenaRoutes } from './api/routes/arena.routes';
 import { authenticate } from './api/middlewares/authenticate';
 import {
   runReadinessChecks,
@@ -197,6 +198,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await app.register(uploadRoutes, { prefix: '/uploads' });
   await app.register(communityRoutes, { prefix: '/communities' });
   await app.register(otakuRoutes, { prefix: '/otaku' });
+  await app.register(arenaRoutes, { prefix: '/arena' });
 
   await app.ready();
 

--- a/backend/src/core/repositories/arena.repository.ts
+++ b/backend/src/core/repositories/arena.repository.ts
@@ -2,7 +2,7 @@ import {
   ArenaChallengeStatus,
   ArenaProofType,
   PostType,
-  type Prisma,
+  Prisma,
 } from '@prisma/client';
 import { prisma } from '../../infra/database/client';
 
@@ -90,6 +90,13 @@ export type ArenaLeaderboardEntry = {
   submissionsCount: number;
   lastSubmissionAt: Date;
 };
+
+export class ArenaSubmissionCapReachedError extends Error {
+  constructor() {
+    super('Arena submission cap reached.');
+    this.name = 'ArenaSubmissionCapReachedError';
+  }
+}
 
 function toChallengeSummary(
   challenge: ArenaChallengeRecord,
@@ -235,16 +242,39 @@ export const arenaRepository = {
     });
   },
 
-  async createSubmission(input: {
+  async createSubmissionWithinCap(input: {
     challengeId: string;
     participationId: string;
     userId: string;
     proofType: ArenaProofType;
     proofId: string;
     score: number;
+    maxSubmissionsPerUser: number;
   }): Promise<ArenaSubmissionSummary> {
-    return prisma.arenaSubmission.create({
-      data: input,
+    return prisma.$transaction(async (tx) => {
+      const submissionsCount = await tx.arenaSubmission.count({
+        where: {
+          challengeId: input.challengeId,
+          userId: input.userId,
+        },
+      });
+
+      if (submissionsCount >= input.maxSubmissionsPerUser) {
+        throw new ArenaSubmissionCapReachedError();
+      }
+
+      return tx.arenaSubmission.create({
+        data: {
+          challengeId: input.challengeId,
+          participationId: input.participationId,
+          userId: input.userId,
+          proofType: input.proofType,
+          proofId: input.proofId,
+          score: input.score,
+        },
+      });
+    }, {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
     });
   },
 

--- a/backend/src/core/repositories/arena.repository.ts
+++ b/backend/src/core/repositories/arena.repository.ts
@@ -1,0 +1,314 @@
+import {
+  ArenaChallengeStatus,
+  ArenaProofType,
+  PostType,
+  type Prisma,
+} from '@prisma/client';
+import { prisma } from '../../infra/database/client';
+
+const arenaChallengeSelect = {
+  id: true,
+  slug: true,
+  title: true,
+  description: true,
+  startsAt: true,
+  endsAt: true,
+  status: true,
+  ruleType: true,
+  scoreValue: true,
+  maxSubmissionsPerUser: true,
+  createdAt: true,
+  updatedAt: true,
+  participations: {
+    select: {
+      userId: true,
+      joinedAt: true,
+    },
+  },
+  _count: {
+    select: {
+      participations: true,
+      submissions: true,
+    },
+  },
+} satisfies Prisma.ArenaChallengeSelect;
+
+type ArenaChallengeRecord = Prisma.ArenaChallengeGetPayload<{
+  select: typeof arenaChallengeSelect;
+}>;
+
+export type ArenaChallengeSummary = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  startsAt: Date;
+  endsAt: Date;
+  status: ArenaChallengeStatus;
+  ruleType: ArenaProofType;
+  scoreValue: number;
+  maxSubmissionsPerUser: number;
+  participantCount: number;
+  submissionCount: number;
+  viewerHasJoined: boolean;
+  viewerJoinedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ArenaParticipationRecord = {
+  id: string;
+  challengeId: string;
+  userId: string;
+  joinedAt: Date;
+};
+
+export type ArenaProofPost = {
+  id: string;
+  userId: string;
+  type: PostType;
+  createdAt: Date;
+  contentText: string | null;
+};
+
+export type ArenaSubmissionSummary = {
+  id: string;
+  challengeId: string;
+  userId: string;
+  proofType: ArenaProofType;
+  proofId: string;
+  score: number;
+  submittedAt: Date;
+};
+
+export type ArenaLeaderboardEntry = {
+  position: number;
+  userId: string;
+  username: string;
+  displayName: string | null;
+  score: number;
+  submissionsCount: number;
+  lastSubmissionAt: Date;
+};
+
+function toChallengeSummary(
+  challenge: ArenaChallengeRecord,
+  viewerUserId?: string | null,
+): ArenaChallengeSummary {
+  const viewerParticipation = viewerUserId
+    ? challenge.participations.find((participation) => participation.userId === viewerUserId)
+    : undefined;
+
+  return {
+    id: challenge.id,
+    slug: challenge.slug,
+    title: challenge.title,
+    description: challenge.description,
+    startsAt: challenge.startsAt,
+    endsAt: challenge.endsAt,
+    status: challenge.status,
+    ruleType: challenge.ruleType,
+    scoreValue: challenge.scoreValue,
+    maxSubmissionsPerUser: challenge.maxSubmissionsPerUser,
+    participantCount: challenge._count.participations,
+    submissionCount: challenge._count.submissions,
+    viewerHasJoined: Boolean(viewerParticipation),
+    viewerJoinedAt: viewerParticipation?.joinedAt ?? null,
+    createdAt: challenge.createdAt,
+    updatedAt: challenge.updatedAt,
+  };
+}
+
+export const arenaRepository = {
+  async listActiveChallenges(
+    now: Date,
+    viewerUserId?: string | null,
+  ): Promise<ArenaChallengeSummary[]> {
+    const challenges = await prisma.arenaChallenge.findMany({
+      where: {
+        status: ArenaChallengeStatus.ACTIVE,
+        startsAt: { lte: now },
+        endsAt: { gt: now },
+      },
+      orderBy: [
+        { endsAt: 'asc' },
+        { startsAt: 'asc' },
+      ],
+      select: arenaChallengeSelect,
+    });
+
+    return challenges.map((challenge) => toChallengeSummary(challenge, viewerUserId));
+  },
+
+  async findChallengeBySlug(
+    slug: string,
+    viewerUserId?: string | null,
+  ): Promise<ArenaChallengeSummary | null> {
+    const challenge = await prisma.arenaChallenge.findUnique({
+      where: { slug },
+      select: arenaChallengeSelect,
+    });
+
+    return challenge ? toChallengeSummary(challenge, viewerUserId) : null;
+  },
+
+  async findChallengeById(
+    challengeId: string,
+    viewerUserId?: string | null,
+  ): Promise<ArenaChallengeSummary | null> {
+    const challenge = await prisma.arenaChallenge.findUnique({
+      where: { id: challengeId },
+      select: arenaChallengeSelect,
+    });
+
+    return challenge ? toChallengeSummary(challenge, viewerUserId) : null;
+  },
+
+  async upsertParticipation(
+    challengeId: string,
+    userId: string,
+  ): Promise<ArenaParticipationRecord> {
+    return prisma.arenaParticipation.upsert({
+      where: {
+        challengeId_userId: {
+          challengeId,
+          userId,
+        },
+      },
+      create: {
+        challengeId,
+        userId,
+      },
+      update: {},
+    });
+  },
+
+  async findParticipation(
+    challengeId: string,
+    userId: string,
+  ): Promise<ArenaParticipationRecord | null> {
+    return prisma.arenaParticipation.findUnique({
+      where: {
+        challengeId_userId: {
+          challengeId,
+          userId,
+        },
+      },
+    });
+  },
+
+  async findProofPost(proofId: string): Promise<ArenaProofPost | null> {
+    return prisma.post.findUnique({
+      where: { id: proofId },
+      select: {
+        id: true,
+        userId: true,
+        type: true,
+        createdAt: true,
+        contentText: true,
+      },
+    });
+  },
+
+  async countUserSubmissions(challengeId: string, userId: string): Promise<number> {
+    return prisma.arenaSubmission.count({
+      where: {
+        challengeId,
+        userId,
+      },
+    });
+  },
+
+  async findSubmissionByProof(
+    challengeId: string,
+    proofType: ArenaProofType,
+    proofId: string,
+  ): Promise<ArenaSubmissionSummary | null> {
+    return prisma.arenaSubmission.findUnique({
+      where: {
+        challengeId_proofType_proofId: {
+          challengeId,
+          proofType,
+          proofId,
+        },
+      },
+    });
+  },
+
+  async createSubmission(input: {
+    challengeId: string;
+    participationId: string;
+    userId: string;
+    proofType: ArenaProofType;
+    proofId: string;
+    score: number;
+  }): Promise<ArenaSubmissionSummary> {
+    return prisma.arenaSubmission.create({
+      data: input,
+    });
+  },
+
+  async listLeaderboard(challengeId: string): Promise<ArenaLeaderboardEntry[]> {
+    const submissions = await prisma.arenaSubmission.findMany({
+      where: { challengeId },
+      select: {
+        userId: true,
+        score: true,
+        submittedAt: true,
+        user: {
+          select: {
+            username: true,
+            profile: {
+              select: {
+                displayName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const entriesByUserId = new Map<string, Omit<ArenaLeaderboardEntry, 'position'>>();
+
+    for (const submission of submissions) {
+      const existing = entriesByUserId.get(submission.userId);
+
+      if (!existing) {
+        entriesByUserId.set(submission.userId, {
+          userId: submission.userId,
+          username: submission.user.username,
+          displayName: submission.user.profile?.displayName ?? null,
+          score: submission.score,
+          submissionsCount: 1,
+          lastSubmissionAt: submission.submittedAt,
+        });
+        continue;
+      }
+
+      existing.score += submission.score;
+      existing.submissionsCount += 1;
+
+      if (submission.submittedAt > existing.lastSubmissionAt) {
+        existing.lastSubmissionAt = submission.submittedAt;
+      }
+    }
+
+    return Array.from(entriesByUserId.values())
+      .sort((left, right) => {
+        if (right.score !== left.score) {
+          return right.score - left.score;
+        }
+
+        const submittedAtDelta = left.lastSubmissionAt.getTime() - right.lastSubmissionAt.getTime();
+        if (submittedAtDelta !== 0) {
+          return submittedAtDelta;
+        }
+
+        return left.username.localeCompare(right.username);
+      })
+      .map((entry, index) => ({
+        ...entry,
+        position: index + 1,
+      }));
+  },
+};

--- a/backend/src/core/services/arena.service.ts
+++ b/backend/src/core/services/arena.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@prisma/client';
 import {
   arenaRepository,
+  ArenaSubmissionCapReachedError,
   type ArenaChallengeSummary,
   type ArenaLeaderboardEntry,
   type ArenaSubmissionSummary,
@@ -99,6 +100,10 @@ function assertProofBelongsToChallengeWindow(
 
 function isUniqueConstraintError(error: unknown): boolean {
   return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
+function isSerializableTransactionConflict(error: unknown): boolean {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
 }
 
 export const arenaService = {
@@ -220,28 +225,35 @@ export const arenaService = {
       );
     }
 
-    const submissionsCount = await arenaRepository.countUserSubmissions(challenge.id, userId);
-    if (submissionsCount >= challenge.maxSubmissionsPerUser) {
-      throw new ArenaServiceError(
-        'ARENA_SUBMISSION_CAP_REACHED',
-        'Você atingiu o limite de submissões deste desafio.',
-      );
-    }
-
     try {
-      return await arenaRepository.createSubmission({
+      return await arenaRepository.createSubmissionWithinCap({
         challengeId: challenge.id,
         participationId: participation.id,
         userId,
         proofType: input.proofType,
         proofId: input.proofId,
         score: challenge.scoreValue,
+        maxSubmissionsPerUser: challenge.maxSubmissionsPerUser,
       });
     } catch (error) {
+      if (error instanceof ArenaSubmissionCapReachedError) {
+        throw new ArenaServiceError(
+          'ARENA_SUBMISSION_CAP_REACHED',
+          'Você atingiu o limite de submissões deste desafio.',
+        );
+      }
+
       if (isUniqueConstraintError(error)) {
         throw new ArenaServiceError(
           'ARENA_PROOF_DUPLICATE',
           'Esta prova já foi usada neste desafio.',
+        );
+      }
+
+      if (isSerializableTransactionConflict(error)) {
+        throw new ArenaServiceError(
+          'ARENA_SUBMISSION_CAP_REACHED',
+          'Tente enviar novamente; outra submissão foi processada ao mesmo tempo.',
         );
       }
 

--- a/backend/src/core/services/arena.service.ts
+++ b/backend/src/core/services/arena.service.ts
@@ -1,0 +1,264 @@
+import {
+  ArenaChallengeStatus,
+  ArenaProofType,
+  PostType,
+  Prisma,
+} from '@prisma/client';
+import {
+  arenaRepository,
+  type ArenaChallengeSummary,
+  type ArenaLeaderboardEntry,
+  type ArenaSubmissionSummary,
+} from '../repositories/arena.repository';
+
+const POST_PROOF_TYPES = new Set<ArenaProofType>([
+  ArenaProofType.GAME_SESSION,
+  ArenaProofType.ACHIEVEMENT,
+]);
+
+export type ArenaServiceErrorCode =
+  | 'ARENA_CHALLENGE_NOT_FOUND'
+  | 'ARENA_CHALLENGE_NOT_ACTIVE'
+  | 'ARENA_CHALLENGE_NOT_STARTED'
+  | 'ARENA_CHALLENGE_ENDED'
+  | 'ARENA_PARTICIPATION_REQUIRED'
+  | 'ARENA_PROOF_NOT_FOUND'
+  | 'ARENA_PROOF_FORBIDDEN'
+  | 'ARENA_PROOF_TYPE_UNSUPPORTED'
+  | 'ARENA_PROOF_OUTSIDE_WINDOW'
+  | 'ARENA_PROOF_DUPLICATE'
+  | 'ARENA_SUBMISSION_CAP_REACHED';
+
+export class ArenaServiceError extends Error {
+  readonly code: ArenaServiceErrorCode;
+
+  constructor(code: ArenaServiceErrorCode, message: string) {
+    super(message);
+    this.name = 'ArenaServiceError';
+    this.code = code;
+  }
+}
+
+export type CreateArenaSubmissionInput = {
+  proofType: ArenaProofType;
+  proofId: string;
+};
+
+function assertChallengeAcceptsActions(
+  challenge: ArenaChallengeSummary,
+  now: Date,
+): void {
+  if (challenge.status !== ArenaChallengeStatus.ACTIVE) {
+    throw new ArenaServiceError(
+      'ARENA_CHALLENGE_NOT_ACTIVE',
+      'Este desafio Arena não está ativo.',
+    );
+  }
+
+  if (challenge.startsAt > now) {
+    throw new ArenaServiceError(
+      'ARENA_CHALLENGE_NOT_STARTED',
+      'Este desafio Arena ainda não começou.',
+    );
+  }
+
+  if (challenge.endsAt <= now) {
+    throw new ArenaServiceError(
+      'ARENA_CHALLENGE_ENDED',
+      'Este desafio Arena já encerrou.',
+    );
+  }
+}
+
+function toExpectedPostType(proofType: ArenaProofType): PostType {
+  if (proofType === ArenaProofType.GAME_SESSION) {
+    return PostType.GAME_SESSION;
+  }
+
+  if (proofType === ArenaProofType.ACHIEVEMENT) {
+    return PostType.ACHIEVEMENT;
+  }
+
+  throw new ArenaServiceError(
+    'ARENA_PROOF_TYPE_UNSUPPORTED',
+    'Este tipo de prova ainda não é aceito no MVP do Arena.',
+  );
+}
+
+function assertProofBelongsToChallengeWindow(
+  proofCreatedAt: Date,
+  challenge: ArenaChallengeSummary,
+): void {
+  if (proofCreatedAt < challenge.startsAt || proofCreatedAt > challenge.endsAt) {
+    throw new ArenaServiceError(
+      'ARENA_PROOF_OUTSIDE_WINDOW',
+      'A prova precisa estar dentro da janela do desafio.',
+    );
+  }
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
+export const arenaService = {
+  async listActiveChallenges(viewerUserId?: string | null): Promise<ArenaChallengeSummary[]> {
+    return arenaRepository.listActiveChallenges(new Date(), viewerUserId);
+  },
+
+  async getChallenge(
+    slug: string,
+    viewerUserId?: string | null,
+  ): Promise<ArenaChallengeSummary> {
+    const challenge = await arenaRepository.findChallengeBySlug(slug, viewerUserId);
+
+    if (!challenge) {
+      throw new ArenaServiceError(
+        'ARENA_CHALLENGE_NOT_FOUND',
+        'Desafio Arena não encontrado.',
+      );
+    }
+
+    return challenge;
+  },
+
+  async joinChallenge(
+    challengeId: string,
+    userId: string,
+  ): Promise<ArenaChallengeSummary> {
+    const now = new Date();
+    const challenge = await arenaRepository.findChallengeById(challengeId, userId);
+
+    if (!challenge) {
+      throw new ArenaServiceError(
+        'ARENA_CHALLENGE_NOT_FOUND',
+        'Desafio Arena não encontrado.',
+      );
+    }
+
+    assertChallengeAcceptsActions(challenge, now);
+    await arenaRepository.upsertParticipation(challenge.id, userId);
+
+    const updatedChallenge = await arenaRepository.findChallengeById(challengeId, userId);
+    if (!updatedChallenge) {
+      throw new ArenaServiceError(
+        'ARENA_CHALLENGE_NOT_FOUND',
+        'Desafio Arena não encontrado.',
+      );
+    }
+
+    return updatedChallenge;
+  },
+
+  async submitProof(
+    challengeId: string,
+    userId: string,
+    input: CreateArenaSubmissionInput,
+  ): Promise<ArenaSubmissionSummary> {
+    const now = new Date();
+    const challenge = await arenaRepository.findChallengeById(challengeId, userId);
+
+    if (!challenge) {
+      throw new ArenaServiceError(
+        'ARENA_CHALLENGE_NOT_FOUND',
+        'Desafio Arena não encontrado.',
+      );
+    }
+
+    assertChallengeAcceptsActions(challenge, now);
+
+    if (!POST_PROOF_TYPES.has(input.proofType) || input.proofType !== challenge.ruleType) {
+      throw new ArenaServiceError(
+        'ARENA_PROOF_TYPE_UNSUPPORTED',
+        'Este desafio não aceita esse tipo de prova.',
+      );
+    }
+
+    const participation = await arenaRepository.findParticipation(challenge.id, userId);
+    if (!participation) {
+      throw new ArenaServiceError(
+        'ARENA_PARTICIPATION_REQUIRED',
+        'Entre no desafio antes de submeter uma prova.',
+      );
+    }
+
+    const proofPost = await arenaRepository.findProofPost(input.proofId);
+    if (!proofPost) {
+      throw new ArenaServiceError(
+        'ARENA_PROOF_NOT_FOUND',
+        'Prova elegível não encontrada.',
+      );
+    }
+
+    if (proofPost.userId !== userId) {
+      throw new ArenaServiceError(
+        'ARENA_PROOF_FORBIDDEN',
+        'Você só pode submeter provas da sua própria atividade.',
+      );
+    }
+
+    const expectedPostType = toExpectedPostType(input.proofType);
+    if (proofPost.type !== expectedPostType) {
+      throw new ArenaServiceError(
+        'ARENA_PROOF_TYPE_UNSUPPORTED',
+        'Presence, reactions, comments e posts comuns não contam como prova Arena.',
+      );
+    }
+
+    assertProofBelongsToChallengeWindow(proofPost.createdAt, challenge);
+
+    const existingSubmission = await arenaRepository.findSubmissionByProof(
+      challenge.id,
+      input.proofType,
+      input.proofId,
+    );
+
+    if (existingSubmission) {
+      throw new ArenaServiceError(
+        'ARENA_PROOF_DUPLICATE',
+        'Esta prova já foi usada neste desafio.',
+      );
+    }
+
+    const submissionsCount = await arenaRepository.countUserSubmissions(challenge.id, userId);
+    if (submissionsCount >= challenge.maxSubmissionsPerUser) {
+      throw new ArenaServiceError(
+        'ARENA_SUBMISSION_CAP_REACHED',
+        'Você atingiu o limite de submissões deste desafio.',
+      );
+    }
+
+    try {
+      return await arenaRepository.createSubmission({
+        challengeId: challenge.id,
+        participationId: participation.id,
+        userId,
+        proofType: input.proofType,
+        proofId: input.proofId,
+        score: challenge.scoreValue,
+      });
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new ArenaServiceError(
+          'ARENA_PROOF_DUPLICATE',
+          'Esta prova já foi usada neste desafio.',
+        );
+      }
+
+      throw error;
+    }
+  },
+
+  async listLeaderboard(challengeId: string): Promise<ArenaLeaderboardEntry[]> {
+    const challenge = await arenaRepository.findChallengeById(challengeId);
+
+    if (!challenge) {
+      throw new ArenaServiceError(
+        'ARENA_CHALLENGE_NOT_FOUND',
+        'Desafio Arena não encontrado.',
+      );
+    }
+
+    return arenaRepository.listLeaderboard(challenge.id);
+  },
+};

--- a/backend/tests/integration/routes/arena.routes.test.ts
+++ b/backend/tests/integration/routes/arena.routes.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ArenaChallengeStatus,
+  ArenaProofType,
+} from '@prisma/client';
+import { buildApp, generateTestToken } from '../../helpers/build-app';
+import {
+  arenaService,
+  ArenaServiceError,
+} from '@/core/services/arena.service';
+
+vi.mock('@/core/services/arena.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/services/arena.service')>();
+
+  return {
+    ...actual,
+    arenaService: {
+      listActiveChallenges: vi.fn(),
+      getChallenge: vi.fn(),
+      joinChallenge: vi.fn(),
+      submitProof: vi.fn(),
+      listLeaderboard: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/infra/integrations/steam/steam.service', () => ({ steamService: {} }));
+vi.mock('@/infra/integrations/igdb/igdb.service', () => ({ igdbService: {} }));
+vi.mock('@/infra/integrations/epic/epic.service', () => ({ epicService: {} }));
+
+const challenge = {
+  id: 'challenge-id-1',
+  slug: 'semana-da-game-session',
+  title: 'Semana da Game Session',
+  description: 'Envie GAME_SESSION da semana.',
+  startsAt: new Date('2026-05-01T00:00:00.000Z'),
+  endsAt: new Date('2026-05-08T00:00:00.000Z'),
+  status: ArenaChallengeStatus.ACTIVE,
+  ruleType: ArenaProofType.GAME_SESSION,
+  scoreValue: 10,
+  maxSubmissionsPerUser: 3,
+  participantCount: 1,
+  submissionCount: 0,
+  viewerHasJoined: false,
+  viewerJoinedAt: null,
+  createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+};
+
+describe('Arena Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lista desafios ativos', async () => {
+    vi.mocked(arenaService.listActiveChallenges).mockResolvedValue([challenge]);
+
+    const app = await buildApp();
+    const response = await app.inject({ method: 'GET', url: '/arena/challenges' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      challenges: [
+        {
+          slug: 'semana-da-game-session',
+          scoreValue: 10,
+          maxSubmissionsPerUser: 3,
+        },
+      ],
+    });
+    await app.close();
+  });
+
+  it('retorna detalhe do desafio por slug', async () => {
+    vi.mocked(arenaService.getChallenge).mockResolvedValue(challenge);
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/arena/challenges/semana-da-game-session',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(arenaService.getChallenge).toHaveBeenCalledWith(
+      'semana-da-game-session',
+      null,
+    );
+    await app.close();
+  });
+
+  it('entra em desafio autenticado', async () => {
+    vi.mocked(arenaService.joinChallenge).mockResolvedValue({
+      ...challenge,
+      viewerHasJoined: true,
+      viewerJoinedAt: new Date('2026-05-01T10:00:00.000Z'),
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'user-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/arena/challenges/challenge-id-1/join',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(arenaService.joinChallenge).toHaveBeenCalledWith(
+      'challenge-id-1',
+      'user-id-1',
+    );
+    await app.close();
+  });
+
+  it('bloqueia entrada sem autenticacao', async () => {
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'POST',
+      url: '/arena/challenges/challenge-id-1/join',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(arenaService.joinChallenge).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('submete prova valida', async () => {
+    vi.mocked(arenaService.submitProof).mockResolvedValue({
+      id: 'submission-id-1',
+      challengeId: 'challenge-id-1',
+      userId: 'user-id-1',
+      proofType: ArenaProofType.GAME_SESSION,
+      proofId: 'post-id-1',
+      score: 10,
+      submittedAt: new Date('2026-05-01T12:00:00.000Z'),
+    });
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'user-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/arena/challenges/challenge-id-1/submissions',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        proofType: 'GAME_SESSION',
+        proofId: 'post-id-1',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toMatchObject({
+      submission: {
+        proofType: 'GAME_SESSION',
+        proofId: 'post-id-1',
+        score: 10,
+      },
+    });
+    await app.close();
+  });
+
+  it('rejeita proofType invalido antes do service', async () => {
+    const app = await buildApp();
+    const token = generateTestToken(app, 'user-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/arena/challenges/challenge-id-1/submissions',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        proofType: 'COMMENT',
+        proofId: 'comment-id-1',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(arenaService.submitProof).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('mapeia erro de dominio sem virar 500', async () => {
+    vi.mocked(arenaService.submitProof).mockRejectedValue(
+      new ArenaServiceError(
+        'ARENA_PROOF_DUPLICATE',
+        'Esta prova já foi usada neste desafio.',
+      ),
+    );
+
+    const app = await buildApp();
+    const token = generateTestToken(app, 'user-id-1');
+    const response = await app.inject({
+      method: 'POST',
+      url: '/arena/challenges/challenge-id-1/submissions',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        proofType: 'GAME_SESSION',
+        proofId: 'post-id-1',
+      },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({
+      message: 'Esta prova já foi usada neste desafio.',
+    });
+    await app.close();
+  });
+
+  it('retorna ranking local do desafio', async () => {
+    vi.mocked(arenaService.listLeaderboard).mockResolvedValue([
+      {
+        position: 1,
+        userId: 'user-id-1',
+        username: 'clutchplayer',
+        displayName: 'Clutch Player',
+        score: 20,
+        submissionsCount: 2,
+        lastSubmissionAt: new Date('2026-05-01T12:00:00.000Z'),
+      },
+    ]);
+
+    const app = await buildApp();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/arena/challenges/challenge-id-1/leaderboard',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      leaderboard: [
+        {
+          position: 1,
+          username: 'clutchplayer',
+          score: 20,
+        },
+      ],
+    });
+    await app.close();
+  });
+});

--- a/backend/tests/integration/routes/arena.routes.test.ts
+++ b/backend/tests/integration/routes/arena.routes.test.ts
@@ -143,6 +143,7 @@ describe('Arena Routes', () => {
       payload: {
         proofType: 'GAME_SESSION',
         proofId: 'post-id-1',
+        score: 9999,
       },
     });
 
@@ -154,6 +155,14 @@ describe('Arena Routes', () => {
         score: 10,
       },
     });
+    expect(arenaService.submitProof).toHaveBeenCalledWith(
+      'challenge-id-1',
+      'user-id-1',
+      {
+        proofType: 'GAME_SESSION',
+        proofId: 'post-id-1',
+      },
+    );
     await app.close();
   });
 

--- a/backend/tests/unit/repositories/arena.repository.test.ts
+++ b/backend/tests/unit/repositories/arena.repository.test.ts
@@ -8,6 +8,7 @@ import { arenaRepository } from '@/core/repositories/arena.repository';
 
 vi.mock('@/infra/database/client', () => ({
   prisma: {
+    $transaction: vi.fn(),
     arenaChallenge: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
@@ -58,6 +59,7 @@ const challengeRecord = {
 describe('arenaRepository', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback) => callback(prisma));
   });
 
   it('lista desafios ativos e marca participacao do viewer', async () => {
@@ -155,5 +157,44 @@ describe('arenaRepository', () => {
         submissionsCount: 1,
       }),
     ]);
+  });
+
+  it('cria submissao dentro de transacao serializavel respeitando cap', async () => {
+    vi.mocked(prisma.arenaSubmission.count).mockResolvedValue(2);
+    vi.mocked(prisma.arenaSubmission.create).mockResolvedValue({
+      id: 'submission-id-1',
+      challengeId: 'challenge-id-1',
+      participationId: 'participation-id-1',
+      userId: 'user-id-1',
+      proofType: ArenaProofType.GAME_SESSION,
+      proofId: 'post-id-1',
+      score: 10,
+      submittedAt: new Date('2026-05-02T12:00:00.000Z'),
+    } as never);
+
+    const result = await arenaRepository.createSubmissionWithinCap({
+      challengeId: 'challenge-id-1',
+      participationId: 'participation-id-1',
+      userId: 'user-id-1',
+      proofType: ArenaProofType.GAME_SESSION,
+      proofId: 'post-id-1',
+      score: 10,
+      maxSubmissionsPerUser: 3,
+    });
+
+    expect(result.id).toBe('submission-id-1');
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: 'Serializable',
+    });
+    expect(prisma.arenaSubmission.create).toHaveBeenCalledWith({
+      data: {
+        challengeId: 'challenge-id-1',
+        participationId: 'participation-id-1',
+        userId: 'user-id-1',
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+        score: 10,
+      },
+    });
   });
 });

--- a/backend/tests/unit/repositories/arena.repository.test.ts
+++ b/backend/tests/unit/repositories/arena.repository.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ArenaChallengeStatus,
+  ArenaProofType,
+  PostType,
+} from '@prisma/client';
+import { arenaRepository } from '@/core/repositories/arena.repository';
+
+vi.mock('@/infra/database/client', () => ({
+  prisma: {
+    arenaChallenge: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    arenaParticipation: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    arenaSubmission: {
+      count: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+    post: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/infra/database/client';
+
+const challengeRecord = {
+  id: 'challenge-id-1',
+  slug: 'semana-da-game-session',
+  title: 'Semana da Game Session',
+  description: 'Envie GAME_SESSION da semana.',
+  startsAt: new Date('2026-05-01T00:00:00.000Z'),
+  endsAt: new Date('2026-05-08T00:00:00.000Z'),
+  status: ArenaChallengeStatus.ACTIVE,
+  ruleType: ArenaProofType.GAME_SESSION,
+  scoreValue: 10,
+  maxSubmissionsPerUser: 3,
+  createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+  participations: [
+    {
+      userId: 'user-id-1',
+      joinedAt: new Date('2026-05-01T01:00:00.000Z'),
+    },
+  ],
+  _count: {
+    participations: 1,
+    submissions: 0,
+  },
+};
+
+describe('arenaRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lista desafios ativos e marca participacao do viewer', async () => {
+    vi.mocked(prisma.arenaChallenge.findMany).mockResolvedValue([challengeRecord]);
+
+    const result = await arenaRepository.listActiveChallenges(
+      new Date('2026-05-02T00:00:00.000Z'),
+      'user-id-1',
+    );
+
+    expect(result[0]).toMatchObject({
+      slug: 'semana-da-game-session',
+      participantCount: 1,
+      viewerHasJoined: true,
+    });
+    expect(prisma.arenaChallenge.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          status: ArenaChallengeStatus.ACTIVE,
+          startsAt: { lte: new Date('2026-05-02T00:00:00.000Z') },
+          endsAt: { gt: new Date('2026-05-02T00:00:00.000Z') },
+        },
+      }),
+    );
+  });
+
+  it('busca post de prova por id sem reactions ou comments', async () => {
+    vi.mocked(prisma.post.findUnique).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'user-id-1',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2026-05-02T10:00:00.000Z'),
+      contentText: 'Ranked com squad fechado.',
+    } as never);
+
+    const result = await arenaRepository.findProofPost('post-id-1');
+
+    expect(result?.type).toBe(PostType.GAME_SESSION);
+    expect(prisma.post.findUnique).toHaveBeenCalledWith({
+      where: { id: 'post-id-1' },
+      select: {
+        id: true,
+        userId: true,
+        type: true,
+        createdAt: true,
+        contentText: true,
+      },
+    });
+  });
+
+  it('ordena ranking local por score, data e username', async () => {
+    vi.mocked(prisma.arenaSubmission.findMany).mockResolvedValue([
+      {
+        userId: 'user-id-2',
+        score: 10,
+        submittedAt: new Date('2026-05-02T12:00:00.000Z'),
+        user: {
+          username: 'bravo',
+          profile: { displayName: 'Bravo' },
+        },
+      },
+      {
+        userId: 'user-id-1',
+        score: 10,
+        submittedAt: new Date('2026-05-02T10:00:00.000Z'),
+        user: {
+          username: 'alpha',
+          profile: { displayName: 'Alpha' },
+        },
+      },
+      {
+        userId: 'user-id-2',
+        score: 10,
+        submittedAt: new Date('2026-05-02T13:00:00.000Z'),
+        user: {
+          username: 'bravo',
+          profile: { displayName: 'Bravo' },
+        },
+      },
+    ] as never);
+
+    const result = await arenaRepository.listLeaderboard('challenge-id-1');
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        position: 1,
+        userId: 'user-id-2',
+        score: 20,
+        submissionsCount: 2,
+      }),
+      expect.objectContaining({
+        position: 2,
+        userId: 'user-id-1',
+        score: 10,
+        submissionsCount: 1,
+      }),
+    ]);
+  });
+});

--- a/backend/tests/unit/services/arena.service.test.ts
+++ b/backend/tests/unit/services/arena.service.test.ts
@@ -3,15 +3,23 @@ import {
   ArenaChallengeStatus,
   ArenaProofType,
   PostType,
+  Prisma,
 } from '@prisma/client';
 import { arenaService } from '@/core/services/arena.service';
 import {
   arenaRepository,
+  ArenaSubmissionCapReachedError,
   type ArenaChallengeSummary,
   type ArenaSubmissionSummary,
 } from '@/core/repositories/arena.repository';
 
 vi.mock('@/core/repositories/arena.repository', () => ({
+  ArenaSubmissionCapReachedError: class ArenaSubmissionCapReachedError extends Error {
+    constructor() {
+      super('Arena submission cap reached.');
+      this.name = 'ArenaSubmissionCapReachedError';
+    }
+  },
   arenaRepository: {
     listActiveChallenges: vi.fn(),
     findChallengeBySlug: vi.fn(),
@@ -21,7 +29,7 @@ vi.mock('@/core/repositories/arena.repository', () => ({
     findProofPost: vi.fn(),
     countUserSubmissions: vi.fn(),
     findSubmissionByProof: vi.fn(),
-    createSubmission: vi.fn(),
+    createSubmissionWithinCap: vi.fn(),
     listLeaderboard: vi.fn(),
   },
 }));
@@ -112,6 +120,35 @@ describe('arenaService', () => {
     expect(arenaRepository.upsertParticipation).not.toHaveBeenCalled();
   });
 
+  it('bloqueia entrada em desafio futuro', async () => {
+    vi.mocked(arenaRepository.findChallengeById).mockResolvedValue({
+      ...activeChallenge,
+      startsAt: new Date('2099-01-01T00:00:00.000Z'),
+      endsAt: new Date('2099-01-08T00:00:00.000Z'),
+    });
+
+    await expect(
+      arenaService.joinChallenge(activeChallenge.id, 'user-id-1'),
+    ).rejects.toMatchObject({
+      code: 'ARENA_CHALLENGE_NOT_STARTED',
+    });
+    expect(arenaRepository.upsertParticipation).not.toHaveBeenCalled();
+  });
+
+  it('bloqueia entrada em desafio inativo', async () => {
+    vi.mocked(arenaRepository.findChallengeById).mockResolvedValue({
+      ...activeChallenge,
+      status: ArenaChallengeStatus.DRAFT,
+    });
+
+    await expect(
+      arenaService.joinChallenge(activeChallenge.id, 'user-id-1'),
+    ).rejects.toMatchObject({
+      code: 'ARENA_CHALLENGE_NOT_ACTIVE',
+    });
+    expect(arenaRepository.upsertParticipation).not.toHaveBeenCalled();
+  });
+
   it('submete prova GAME_SESSION valida e calcula score fixo', async () => {
     vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
       id: 'participation-id-1',
@@ -127,8 +164,7 @@ describe('arenaService', () => {
       contentText: 'Ranked com squad fechado.',
     });
     vi.mocked(arenaRepository.findSubmissionByProof).mockResolvedValue(null);
-    vi.mocked(arenaRepository.countUserSubmissions).mockResolvedValue(0);
-    vi.mocked(arenaRepository.createSubmission).mockResolvedValue(submission);
+    vi.mocked(arenaRepository.createSubmissionWithinCap).mockResolvedValue(submission);
 
     const result = await arenaService.submitProof(activeChallenge.id, 'user-id-1', {
       proofType: ArenaProofType.GAME_SESSION,
@@ -136,13 +172,14 @@ describe('arenaService', () => {
     });
 
     expect(result.score).toBe(10);
-    expect(arenaRepository.createSubmission).toHaveBeenCalledWith({
+    expect(arenaRepository.createSubmissionWithinCap).toHaveBeenCalledWith({
       challengeId: activeChallenge.id,
       participationId: 'participation-id-1',
       userId: 'user-id-1',
       proofType: ArenaProofType.GAME_SESSION,
       proofId: 'post-id-1',
       score: 10,
+      maxSubmissionsPerUser: 3,
     });
   });
 
@@ -235,6 +272,38 @@ describe('arenaService', () => {
     });
   });
 
+  it('mapeia unique constraint concorrente de prova duplicada para erro de dominio', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date(),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'user-id-1',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2026-05-01T11:00:00.000Z'),
+      contentText: null,
+    });
+    vi.mocked(arenaRepository.findSubmissionByProof).mockResolvedValue(null);
+    vi.mocked(arenaRepository.createSubmissionWithinCap).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: 'test',
+      }),
+    );
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_PROOF_DUPLICATE',
+    });
+  });
+
   it('bloqueia submissao acima do cap do desafio', async () => {
     vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
       id: 'participation-id-1',
@@ -250,12 +319,46 @@ describe('arenaService', () => {
       contentText: null,
     });
     vi.mocked(arenaRepository.findSubmissionByProof).mockResolvedValue(null);
-    vi.mocked(arenaRepository.countUserSubmissions).mockResolvedValue(3);
+    vi.mocked(arenaRepository.createSubmissionWithinCap).mockRejectedValue(
+      new ArenaSubmissionCapReachedError(),
+    );
 
     await expect(
       arenaService.submitProof(activeChallenge.id, 'user-id-1', {
         proofType: ArenaProofType.GAME_SESSION,
         proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_SUBMISSION_CAP_REACHED',
+    });
+  });
+
+  it('mapeia conflito serializavel de cap concorrente para erro de dominio', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date(),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-2',
+      userId: 'user-id-1',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2026-05-01T11:00:00.000Z'),
+      contentText: null,
+    });
+    vi.mocked(arenaRepository.findSubmissionByProof).mockResolvedValue(null);
+    vi.mocked(arenaRepository.createSubmissionWithinCap).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Transaction conflict', {
+        code: 'P2034',
+        clientVersion: 'test',
+      }),
+    );
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-2',
       }),
     ).rejects.toMatchObject({
       code: 'ARENA_SUBMISSION_CAP_REACHED',

--- a/backend/tests/unit/services/arena.service.test.ts
+++ b/backend/tests/unit/services/arena.service.test.ts
@@ -1,0 +1,308 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ArenaChallengeStatus,
+  ArenaProofType,
+  PostType,
+} from '@prisma/client';
+import { arenaService } from '@/core/services/arena.service';
+import {
+  arenaRepository,
+  type ArenaChallengeSummary,
+  type ArenaSubmissionSummary,
+} from '@/core/repositories/arena.repository';
+
+vi.mock('@/core/repositories/arena.repository', () => ({
+  arenaRepository: {
+    listActiveChallenges: vi.fn(),
+    findChallengeBySlug: vi.fn(),
+    findChallengeById: vi.fn(),
+    upsertParticipation: vi.fn(),
+    findParticipation: vi.fn(),
+    findProofPost: vi.fn(),
+    countUserSubmissions: vi.fn(),
+    findSubmissionByProof: vi.fn(),
+    createSubmission: vi.fn(),
+    listLeaderboard: vi.fn(),
+  },
+}));
+
+const activeChallenge: ArenaChallengeSummary = {
+  id: 'challenge-id-1',
+  slug: 'semana-da-game-session',
+  title: 'Semana da Game Session',
+  description: 'Envie GAME_SESSION da semana.',
+  startsAt: new Date('2020-01-01T00:00:00.000Z'),
+  endsAt: new Date('2099-01-01T00:00:00.000Z'),
+  status: ArenaChallengeStatus.ACTIVE,
+  ruleType: ArenaProofType.GAME_SESSION,
+  scoreValue: 10,
+  maxSubmissionsPerUser: 3,
+  participantCount: 0,
+  submissionCount: 0,
+  viewerHasJoined: false,
+  viewerJoinedAt: null,
+  createdAt: new Date('2026-05-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-05-01T10:00:00.000Z'),
+};
+
+const submission: ArenaSubmissionSummary = {
+  id: 'submission-id-1',
+  challengeId: activeChallenge.id,
+  userId: 'user-id-1',
+  proofType: ArenaProofType.GAME_SESSION,
+  proofId: 'post-id-1',
+  score: 10,
+  submittedAt: new Date('2026-05-01T11:00:00.000Z'),
+};
+
+describe('arenaService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(arenaRepository.findChallengeById).mockResolvedValue(activeChallenge);
+  });
+
+  it('lista desafios ativos com contexto do viewer', async () => {
+    vi.mocked(arenaRepository.listActiveChallenges).mockResolvedValue([activeChallenge]);
+
+    const result = await arenaService.listActiveChallenges('user-id-1');
+
+    expect(result).toEqual([activeChallenge]);
+    expect(arenaRepository.listActiveChallenges).toHaveBeenCalledWith(
+      expect.any(Date),
+      'user-id-1',
+    );
+  });
+
+  it('permite entrar em desafio ativo de forma idempotente', async () => {
+    vi.mocked(arenaRepository.upsertParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date('2026-05-01T10:30:00.000Z'),
+    });
+    vi.mocked(arenaRepository.findChallengeById)
+      .mockResolvedValueOnce(activeChallenge)
+      .mockResolvedValueOnce({
+        ...activeChallenge,
+        participantCount: 1,
+        viewerHasJoined: true,
+        viewerJoinedAt: new Date('2026-05-01T10:30:00.000Z'),
+      });
+
+    const result = await arenaService.joinChallenge(activeChallenge.id, 'user-id-1');
+
+    expect(arenaRepository.upsertParticipation).toHaveBeenCalledWith(
+      activeChallenge.id,
+      'user-id-1',
+    );
+    expect(result.viewerHasJoined).toBe(true);
+  });
+
+  it('bloqueia entrada em desafio encerrado', async () => {
+    vi.mocked(arenaRepository.findChallengeById).mockResolvedValue({
+      ...activeChallenge,
+      endsAt: new Date('2020-01-02T00:00:00.000Z'),
+    });
+
+    await expect(
+      arenaService.joinChallenge(activeChallenge.id, 'user-id-1'),
+    ).rejects.toMatchObject({
+      code: 'ARENA_CHALLENGE_ENDED',
+    });
+    expect(arenaRepository.upsertParticipation).not.toHaveBeenCalled();
+  });
+
+  it('submete prova GAME_SESSION valida e calcula score fixo', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date('2026-05-01T10:30:00.000Z'),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'user-id-1',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2026-05-01T11:00:00.000Z'),
+      contentText: 'Ranked com squad fechado.',
+    });
+    vi.mocked(arenaRepository.findSubmissionByProof).mockResolvedValue(null);
+    vi.mocked(arenaRepository.countUserSubmissions).mockResolvedValue(0);
+    vi.mocked(arenaRepository.createSubmission).mockResolvedValue(submission);
+
+    const result = await arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+      proofType: ArenaProofType.GAME_SESSION,
+      proofId: 'post-id-1',
+    });
+
+    expect(result.score).toBe(10);
+    expect(arenaRepository.createSubmission).toHaveBeenCalledWith({
+      challengeId: activeChallenge.id,
+      participationId: 'participation-id-1',
+      userId: 'user-id-1',
+      proofType: ArenaProofType.GAME_SESSION,
+      proofId: 'post-id-1',
+      score: 10,
+    });
+  });
+
+  it('bloqueia submissao sem participacao voluntaria', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue(null);
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_PARTICIPATION_REQUIRED',
+    });
+  });
+
+  it('bloqueia prova de outro usuario', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date(),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'other-user-id',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2026-05-01T11:00:00.000Z'),
+      contentText: null,
+    });
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_PROOF_FORBIDDEN',
+    });
+  });
+
+  it('bloqueia posts comuns, reactions, comments e presence como prova', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date(),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'user-id-1',
+      type: PostType.TEXT,
+      createdAt: new Date('2026-05-01T11:00:00.000Z'),
+      contentText: 'comentario social nao pontua',
+    });
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_PROOF_TYPE_UNSUPPORTED',
+    });
+  });
+
+  it('bloqueia prova duplicada no mesmo desafio', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date(),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'user-id-1',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2026-05-01T11:00:00.000Z'),
+      contentText: null,
+    });
+    vi.mocked(arenaRepository.findSubmissionByProof).mockResolvedValue(submission);
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_PROOF_DUPLICATE',
+    });
+  });
+
+  it('bloqueia submissao acima do cap do desafio', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date(),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'user-id-1',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2026-05-01T11:00:00.000Z'),
+      contentText: null,
+    });
+    vi.mocked(arenaRepository.findSubmissionByProof).mockResolvedValue(null);
+    vi.mocked(arenaRepository.countUserSubmissions).mockResolvedValue(3);
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_SUBMISSION_CAP_REACHED',
+    });
+  });
+
+  it('bloqueia prova fora da janela do desafio', async () => {
+    vi.mocked(arenaRepository.findParticipation).mockResolvedValue({
+      id: 'participation-id-1',
+      challengeId: activeChallenge.id,
+      userId: 'user-id-1',
+      joinedAt: new Date(),
+    });
+    vi.mocked(arenaRepository.findProofPost).mockResolvedValue({
+      id: 'post-id-1',
+      userId: 'user-id-1',
+      type: PostType.GAME_SESSION,
+      createdAt: new Date('2019-01-01T11:00:00.000Z'),
+      contentText: null,
+    });
+
+    await expect(
+      arenaService.submitProof(activeChallenge.id, 'user-id-1', {
+        proofType: ArenaProofType.GAME_SESSION,
+        proofId: 'post-id-1',
+      }),
+    ).rejects.toMatchObject({
+      code: 'ARENA_PROOF_OUTSIDE_WINDOW',
+    });
+  });
+
+  it('retorna ranking local do desafio', async () => {
+    vi.mocked(arenaRepository.listLeaderboard).mockResolvedValue([
+      {
+        position: 1,
+        userId: 'user-id-1',
+        username: 'clutchplayer',
+        displayName: 'Clutch Player',
+        score: 20,
+        submissionsCount: 2,
+        lastSubmissionAt: new Date('2026-05-01T12:00:00.000Z'),
+      },
+    ]);
+
+    const result = await arenaService.listLeaderboard(activeChallenge.id);
+
+    expect(result[0]?.position).toBe(1);
+    expect(arenaRepository.listLeaderboard).toHaveBeenCalledWith(activeChallenge.id);
+  });
+});

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -28,6 +28,7 @@ Este arquivo descreve o estado real atual do frontend do CLUTCH, os contratos qu
 - `/settings`
 - `/settings/integrations`
 - `/settings/integrations/discord/callback`
+- `/arena`
 - `/:username`
 - `/:username/library`
 
@@ -111,6 +112,11 @@ Esse catch-all encaminha chamadas para o backend real e, quando existe `clutch_s
 - `DELETE /auth/accounts/:provider`
 - `GET /auth/accounts/:provider/reauth/start`
 - `GET /auth/accounts/:provider/reauth/callback`
+- `GET /arena/challenges`
+- `GET /arena/challenges/:slug`
+- `POST /arena/challenges/:challengeId/join`
+- `POST /arena/challenges/:challengeId/submissions`
+- `GET /arena/challenges/:challengeId/leaderboard`
 
 ### Observacao importante
 - o frontend usa Discord OAuth real via backend, mas nao consome diretamente a rota interna de ingestao de presence Discord

--- a/frontend/src/app/(app)/arena/page.tsx
+++ b/frontend/src/app/(app)/arena/page.tsx
@@ -1,0 +1,5 @@
+import { ArenaPageContent } from '@/components/arena/arena-page-content';
+
+export default function ArenaPage() {
+  return <ArenaPageContent />;
+}

--- a/frontend/src/components/arena/arena-page-content.tsx
+++ b/frontend/src/components/arena/arena-page-content.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import { FormEvent, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { HydrationSafeTime } from '@/components/ui/hydration-safe-time';
+import { SectionHeading } from '@/components/ui/section-heading';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  ArenaRequestError,
+  fetchArenaChallenges,
+  fetchArenaLeaderboard,
+  joinArenaChallenge,
+  submitArenaProof,
+} from '@/services/arena';
+import type { ArenaChallenge, ArenaLeaderboardEntry } from '@/schemas/arena';
+
+function resolveArenaErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ArenaRequestError) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+function proofLabel(ruleType: ArenaChallenge['ruleType']): string {
+  if (ruleType === 'GAME_SESSION') {
+    return 'GAME_SESSION';
+  }
+
+  if (ruleType === 'ACHIEVEMENT') {
+    return 'ACHIEVEMENT';
+  }
+
+  return 'Evento comunitário';
+}
+
+function ChallengeCard({
+  challenge,
+  selected,
+  onSelect,
+}: {
+  challenge: ArenaChallenge;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="text-left"
+      aria-pressed={selected}
+    >
+      <Card tone={selected ? 'accent' : 'neutral'} className="h-full transition hover:border-accent-cyan">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge tone={selected ? 'accent' : 'neutral'}>Ranking local</Badge>
+          <Badge tone="neutral">{proofLabel(challenge.ruleType)}</Badge>
+        </div>
+        <h2 className="mt-4 font-display text-2xl font-semibold text-primary">
+          {challenge.title}
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-secondary">{challenge.description}</p>
+        <div className="mt-5 grid gap-3 text-sm text-secondary sm:grid-cols-2">
+          <span>{challenge.scoreValue} pts por prova</span>
+          <span>Cap {challenge.maxSubmissionsPerUser} provas</span>
+          <span>{challenge.participantCount} participantes</span>
+          <span>{challenge.submissionCount} submissões</span>
+        </div>
+      </Card>
+    </button>
+  );
+}
+
+function Leaderboard({ entries }: { entries: ArenaLeaderboardEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <Card>
+        <p className="text-sm leading-6 text-secondary">
+          O ranking local ainda está vazio. Entre no desafio e envie a primeira prova elegível.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-surface border border-border">
+      <table className="w-full border-collapse text-sm">
+        <thead className="bg-surface-primary text-left text-xs uppercase tracking-[0.24em] text-secondary">
+          <tr>
+            <th className="px-4 py-3">Posição</th>
+            <th className="px-4 py-3">Jogador</th>
+            <th className="px-4 py-3">Score</th>
+            <th className="px-4 py-3">Provas</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <tr key={entry.userId} className="border-t border-border bg-[rgba(26,26,39,0.55)]">
+              <td className="px-4 py-4 font-semibold text-primary">#{entry.position}</td>
+              <td className="px-4 py-4">
+                <span className="block font-medium text-primary">
+                  {entry.displayName ?? entry.username}
+                </span>
+                <span className="text-xs text-secondary">@{entry.username}</span>
+              </td>
+              <td className="px-4 py-4 text-primary">{entry.score}</td>
+              <td className="px-4 py-4 text-secondary">{entry.submissionsCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ChallengeDetail({ challenge }: { challenge: ArenaChallenge }) {
+  const queryClient = useQueryClient();
+  const { status } = useAuth();
+  const [proofId, setProofId] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const leaderboardQuery = useQuery({
+    queryKey: ['arena', 'leaderboard', challenge.id],
+    queryFn: () => fetchArenaLeaderboard(challenge.id),
+  });
+
+  const joinMutation = useMutation({
+    mutationFn: () => joinArenaChallenge(challenge.id),
+    onSuccess: async () => {
+      setMessage('Você entrou no desafio. Agora envie uma prova elegível.');
+      await queryClient.invalidateQueries({ queryKey: ['arena', 'challenges'] });
+    },
+    onError: (error) => {
+      setMessage(resolveArenaErrorMessage(error, 'Não foi possível entrar no desafio.'));
+    },
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: () => submitArenaProof(challenge.id, {
+      proofType: challenge.ruleType === 'ACHIEVEMENT' ? 'ACHIEVEMENT' : 'GAME_SESSION',
+      proofId,
+    }),
+    onSuccess: async () => {
+      setProofId('');
+      setMessage('Prova enviada. O ranking local foi atualizado.');
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['arena', 'challenges'] }),
+        queryClient.invalidateQueries({ queryKey: ['arena', 'leaderboard', challenge.id] }),
+      ]);
+    },
+    onError: (error) => {
+      setMessage(resolveArenaErrorMessage(error, 'Não foi possível submeter esta prova.'));
+    },
+  });
+
+  const isAuthenticated = status === 'authenticated';
+  const proofInputIsDisabled =
+    !challenge.viewerHasJoined ||
+    submitMutation.isPending ||
+    challenge.ruleType === 'COMMUNITY_EVENT_RSVP';
+  const canSubmitProof =
+    isAuthenticated &&
+    challenge.viewerHasJoined &&
+    proofId.trim().length > 0 &&
+    !submitMutation.isPending &&
+    challenge.ruleType !== 'COMMUNITY_EVENT_RSVP';
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmitProof) {
+      return;
+    }
+
+    submitMutation.mutate();
+  }
+
+  return (
+    <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(22rem,0.72fr)]">
+      <Card tone="accent" className="flex flex-col gap-6">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone="accent">MVP Arena</Badge>
+            <Badge tone="neutral">{proofLabel(challenge.ruleType)}</Badge>
+            {challenge.viewerHasJoined ? <Badge tone="success">Participando</Badge> : null}
+          </div>
+          <h2 className="mt-4 font-display text-3xl font-semibold text-primary">
+            {challenge.title}
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-secondary">{challenge.description}</p>
+        </div>
+
+        <div className="grid gap-4 text-sm text-secondary sm:grid-cols-2">
+          <div>
+            <span className="block text-xs uppercase tracking-[0.24em] text-secondary">
+              Início
+            </span>
+            <HydrationSafeTime
+              value={challenge.startsAt}
+              options={{ dateStyle: 'short', timeStyle: 'short' }}
+              className="mt-1 block text-primary"
+            />
+          </div>
+          <div>
+            <span className="block text-xs uppercase tracking-[0.24em] text-secondary">
+              Encerramento
+            </span>
+            <HydrationSafeTime
+              value={challenge.endsAt}
+              options={{ dateStyle: 'short', timeStyle: 'short' }}
+              className="mt-1 block text-primary"
+            />
+          </div>
+          <div>{challenge.scoreValue} pontos por prova aceita</div>
+          <div>Limite de {challenge.maxSubmissionsPerUser} provas por jogador</div>
+        </div>
+
+        {!isAuthenticated ? (
+          <p className="text-sm leading-6 text-secondary">
+            Entre na sessão para participar do desafio Arena.
+          </p>
+        ) : challenge.viewerHasJoined ? (
+          <p className="text-sm leading-6 text-secondary">
+            Use o ID de um post {proofLabel(challenge.ruleType)} seu, criado dentro da janela
+            do desafio. Presence passiva, reactions e comments não pontuam.
+          </p>
+        ) : (
+          <Button
+            type="button"
+            disabled={joinMutation.isPending}
+            onClick={() => joinMutation.mutate()}
+          >
+            Entrar no desafio
+          </Button>
+        )}
+
+        <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-2 text-sm font-medium text-primary">
+            ID do post de prova
+            <input
+              value={proofId}
+              onChange={(event) => setProofId(event.target.value)}
+              placeholder="post-id"
+              disabled={proofInputIsDisabled}
+              className="h-11 rounded-control border border-border bg-surface-primary px-control-x text-sm text-primary outline-none transition placeholder:text-secondary focus:border-accent-cyan"
+            />
+          </label>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-secondary" role={message ? 'alert' : undefined}>
+              {message ?? 'Ranking local, sem season formal ou reward engine neste MVP.'}
+            </p>
+            <Button type="submit" disabled={!canSubmitProof}>
+              Submeter prova
+            </Button>
+          </div>
+        </form>
+      </Card>
+
+      <div className="flex flex-col gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-secondary">
+            Ranking local
+          </p>
+          <h2 className="mt-2 font-display text-2xl font-semibold text-primary">
+            Placares deste desafio
+          </h2>
+        </div>
+        {leaderboardQuery.isLoading ? (
+          <Card>
+            <p className="text-sm text-secondary">Carregando ranking local...</p>
+          </Card>
+        ) : null}
+        {leaderboardQuery.isError ? (
+          <Card>
+            <p className="text-sm text-secondary" role="alert">
+              Não foi possível carregar o ranking local.
+            </p>
+          </Card>
+        ) : null}
+        {leaderboardQuery.data ? <Leaderboard entries={leaderboardQuery.data} /> : null}
+      </div>
+    </div>
+  );
+}
+
+export function ArenaPageContent() {
+  const challengesQuery = useQuery({
+    queryKey: ['arena', 'challenges'],
+    queryFn: fetchArenaChallenges,
+  });
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+
+  const selectedChallenge = useMemo(() => {
+    const challenges = challengesQuery.data ?? [];
+    return challenges.find((challenge) => challenge.slug === selectedSlug) ?? challenges[0] ?? null;
+  }, [challengesQuery.data, selectedSlug]);
+
+  return (
+    <div className="flex flex-col gap-section">
+      <SectionHeading
+        eyebrow="Modo Arena"
+        title="Desafios semanais assíncronos"
+        level="h1"
+        description="O MVP valida competição voluntária com provas leves, score simples e ranking local. Sem ranking global, temporada formal, guild wars ou reward engine."
+      />
+
+      {challengesQuery.isLoading ? (
+        <Card>
+          <p className="text-sm text-secondary">Carregando desafios Arena ativos...</p>
+        </Card>
+      ) : null}
+
+      {challengesQuery.isError ? (
+        <Card>
+          <p className="text-sm text-secondary" role="alert">
+            Não foi possível carregar os desafios Arena agora.
+          </p>
+        </Card>
+      ) : null}
+
+      {challengesQuery.data?.length === 0 ? (
+        <Card>
+          <p className="text-sm leading-6 text-secondary">
+            Ainda não há desafios Arena ativos. O slice está pronto para exibir desafios
+            semanais quando forem criados pelo backend.
+          </p>
+        </Card>
+      ) : null}
+
+      {challengesQuery.data && challengesQuery.data.length > 0 ? (
+        <>
+          <div className="grid gap-5 lg:grid-cols-2">
+            {challengesQuery.data.map((challenge) => (
+              <ChallengeCard
+                key={challenge.id}
+                challenge={challenge}
+                selected={selectedChallenge?.id === challenge.id}
+                onSelect={() => setSelectedSlug(challenge.slug)}
+              />
+            ))}
+          </div>
+
+          {selectedChallenge ? <ChallengeDetail challenge={selectedChallenge} /> : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -101,6 +101,12 @@ export function Sidebar({ isOpen, onClose, className }: SidebarProps) {
       description: 'Public guilds and basic membership',
     },
     {
+      label: 'Arena',
+      href: '/arena',
+      tone: pathname.startsWith('/arena') ? 'accent' : 'neutral',
+      description: 'Weekly asynchronous challenges',
+    },
+    {
       label: 'Notifications',
       href: '/notifications',
       tone: pathname === '/notifications' ? 'accent' : 'neutral',

--- a/frontend/src/schemas/arena.ts
+++ b/frontend/src/schemas/arena.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+export const arenaChallengeStatusSchema = z.enum(['DRAFT', 'ACTIVE', 'CLOSED', 'ARCHIVED']);
+export const arenaProofTypeSchema = z.enum(['GAME_SESSION', 'ACHIEVEMENT', 'COMMUNITY_EVENT_RSVP']);
+
+export const arenaChallengeSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  description: z.string(),
+  startsAt: z.string(),
+  endsAt: z.string(),
+  status: arenaChallengeStatusSchema,
+  ruleType: arenaProofTypeSchema,
+  scoreValue: z.number().int().nonnegative(),
+  maxSubmissionsPerUser: z.number().int().positive(),
+  participantCount: z.number().int().nonnegative(),
+  submissionCount: z.number().int().nonnegative(),
+  viewerHasJoined: z.boolean(),
+  viewerJoinedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const arenaSubmissionSchema = z.object({
+  id: z.string(),
+  challengeId: z.string(),
+  userId: z.string(),
+  proofType: arenaProofTypeSchema,
+  proofId: z.string(),
+  score: z.number().int().nonnegative(),
+  submittedAt: z.string(),
+});
+
+export const arenaLeaderboardEntrySchema = z.object({
+  position: z.number().int().positive(),
+  userId: z.string(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  score: z.number().int().nonnegative(),
+  submissionsCount: z.number().int().nonnegative(),
+  lastSubmissionAt: z.string(),
+});
+
+export const arenaChallengesResponseSchema = z.object({
+  challenges: z.array(arenaChallengeSchema),
+});
+
+export const arenaChallengeResponseSchema = z.object({
+  challenge: arenaChallengeSchema,
+});
+
+export const arenaSubmissionResponseSchema = z.object({
+  submission: arenaSubmissionSchema,
+});
+
+export const arenaLeaderboardResponseSchema = z.object({
+  leaderboard: z.array(arenaLeaderboardEntrySchema),
+});
+
+export const submitArenaProofRequestSchema = z.object({
+  proofType: z.enum(['GAME_SESSION', 'ACHIEVEMENT']),
+  proofId: z.string().trim().min(1),
+});
+
+export type ArenaChallenge = z.infer<typeof arenaChallengeSchema>;
+export type ArenaProofType = z.infer<typeof arenaProofTypeSchema>;
+export type ArenaSubmission = z.infer<typeof arenaSubmissionSchema>;
+export type ArenaLeaderboardEntry = z.infer<typeof arenaLeaderboardEntrySchema>;
+export type SubmitArenaProofValues = z.infer<typeof submitArenaProofRequestSchema>;

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -1,5 +1,17 @@
 export {};
 export {
+  arenaChallengeResponseSchema,
+  arenaChallengeSchema,
+  arenaChallengeStatusSchema,
+  arenaChallengesResponseSchema,
+  arenaLeaderboardEntrySchema,
+  arenaLeaderboardResponseSchema,
+  arenaProofTypeSchema,
+  arenaSubmissionResponseSchema,
+  arenaSubmissionSchema,
+  submitArenaProofRequestSchema,
+} from './arena';
+export {
   authSessionSchema,
   loginBackendResponseSchema,
   loginRequestSchema,

--- a/frontend/src/services/arena.ts
+++ b/frontend/src/services/arena.ts
@@ -1,0 +1,145 @@
+import { apiRequest } from '@/lib/api';
+import {
+  arenaChallengeResponseSchema,
+  arenaChallengesResponseSchema,
+  arenaLeaderboardResponseSchema,
+  arenaSubmissionResponseSchema,
+  submitArenaProofRequestSchema,
+  type ArenaChallenge,
+  type ArenaLeaderboardEntry,
+  type ArenaSubmission,
+  type SubmitArenaProofValues,
+} from '@/schemas/arena';
+
+type ErrorResponse = {
+  message?: string;
+};
+
+export class ArenaRequestError extends Error {
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ArenaRequestError';
+    this.status = status;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function resolveErrorMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) {
+    const message = (payload as ErrorResponse).message;
+
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+export async function fetchArenaChallenges(): Promise<ArenaChallenge[]> {
+  const response = await apiRequest('/arena/challenges', {
+    method: 'GET',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new ArenaRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar os desafios Arena.'),
+    );
+  }
+
+  return arenaChallengesResponseSchema.parse(payload).challenges;
+}
+
+export async function fetchArenaChallenge(slug: string): Promise<ArenaChallenge> {
+  const response = await apiRequest(`/arena/challenges/${encodeURIComponent(slug)}`, {
+    method: 'GET',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new ArenaRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar este desafio Arena.'),
+    );
+  }
+
+  return arenaChallengeResponseSchema.parse(payload).challenge;
+}
+
+export async function joinArenaChallenge(challengeId: string): Promise<ArenaChallenge> {
+  const response = await apiRequest(`/arena/challenges/${encodeURIComponent(challengeId)}/join`, {
+    method: 'POST',
+  });
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new ArenaRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel entrar neste desafio Arena.'),
+    );
+  }
+
+  return arenaChallengeResponseSchema.parse(payload).challenge;
+}
+
+export async function submitArenaProof(
+  challengeId: string,
+  input: SubmitArenaProofValues,
+): Promise<ArenaSubmission> {
+  const payload = submitArenaProofRequestSchema.parse(input);
+  const response = await apiRequest(
+    `/arena/challenges/${encodeURIComponent(challengeId)}/submissions`,
+    {
+      method: 'POST',
+      body: payload,
+    },
+  );
+  const responsePayload = await readJson(response);
+
+  if (!response.ok) {
+    throw new ArenaRequestError(
+      response.status,
+      resolveErrorMessage(responsePayload, 'Nao foi possivel submeter esta prova.'),
+    );
+  }
+
+  return arenaSubmissionResponseSchema.parse(responsePayload).submission;
+}
+
+export async function fetchArenaLeaderboard(
+  challengeId: string,
+): Promise<ArenaLeaderboardEntry[]> {
+  const response = await apiRequest(
+    `/arena/challenges/${encodeURIComponent(challengeId)}/leaderboard`,
+    {
+      method: 'GET',
+    },
+  );
+  const payload = await readJson(response);
+
+  if (!response.ok) {
+    throw new ArenaRequestError(
+      response.status,
+      resolveErrorMessage(payload, 'Nao foi possivel carregar o ranking local.'),
+    );
+  }
+
+  return arenaLeaderboardResponseSchema.parse(payload).leaderboard;
+}

--- a/frontend/tests/unit/components/arena-page-content.test.tsx
+++ b/frontend/tests/unit/components/arena-page-content.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArenaPageContent } from '@/components/arena/arena-page-content';
+import { useAuth } from '@/hooks/use-auth';
+import {
+  fetchArenaChallenges,
+  fetchArenaLeaderboard,
+  joinArenaChallenge,
+  submitArenaProof,
+} from '@/services/arena';
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/services/arena', () => ({
+  ArenaRequestError: class ArenaRequestError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = 'ArenaRequestError';
+    }
+  },
+  fetchArenaChallenges: vi.fn(),
+  fetchArenaLeaderboard: vi.fn(),
+  joinArenaChallenge: vi.fn(),
+  submitArenaProof: vi.fn(),
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFetchArenaChallenges = vi.mocked(fetchArenaChallenges);
+const mockedFetchArenaLeaderboard = vi.mocked(fetchArenaLeaderboard);
+const mockedJoinArenaChallenge = vi.mocked(joinArenaChallenge);
+const mockedSubmitArenaProof = vi.mocked(submitArenaProof);
+
+const challenge = {
+  id: 'challenge-id-1',
+  slug: 'semana-da-game-session',
+  title: 'Semana da Game Session',
+  description: 'Envie GAME_SESSION da semana.',
+  startsAt: '2026-05-01T00:00:00.000Z',
+  endsAt: '2026-05-08T00:00:00.000Z',
+  status: 'ACTIVE' as const,
+  ruleType: 'GAME_SESSION' as const,
+  scoreValue: 10,
+  maxSubmissionsPerUser: 3,
+  participantCount: 1,
+  submissionCount: 0,
+  viewerHasJoined: false,
+  viewerJoinedAt: null,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+};
+
+function renderArenaPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ArenaPageContent />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ArenaPageContent', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFetchArenaChallenges.mockReset();
+    mockedFetchArenaLeaderboard.mockReset();
+    mockedJoinArenaChallenge.mockReset();
+    mockedSubmitArenaProof.mockReset();
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-id-1', username: 'clutchplayer', email: 'player@clutch.gg' },
+      status: 'authenticated',
+      logout: vi.fn(),
+    });
+    mockedFetchArenaLeaderboard.mockResolvedValue([]);
+  });
+
+  it('renderiza lista de desafios e regras do MVP', async () => {
+    mockedFetchArenaChallenges.mockResolvedValue([challenge]);
+
+    renderArenaPage();
+
+    expect(await screen.findAllByText('Semana da Game Session')).toHaveLength(2);
+    expect(screen.getByText(/10 pts por prova/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cap 3 provas/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ranking local, sem season formal/i)).toBeInTheDocument();
+  });
+
+  it('renderiza empty state sem desafios', async () => {
+    mockedFetchArenaChallenges.mockResolvedValue([]);
+
+    renderArenaPage();
+
+    expect(await screen.findByText(/Ainda não há desafios Arena ativos/i)).toBeInTheDocument();
+  });
+
+  it('entra em desafio voluntariamente', async () => {
+    mockedFetchArenaChallenges.mockResolvedValue([challenge]);
+    mockedJoinArenaChallenge.mockResolvedValue({
+      ...challenge,
+      viewerHasJoined: true,
+      viewerJoinedAt: '2026-05-01T10:00:00.000Z',
+    });
+
+    renderArenaPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Entrar no desafio/i }));
+
+    await waitFor(() => {
+      expect(mockedJoinArenaChallenge).toHaveBeenCalledWith('challenge-id-1');
+    });
+  });
+
+  it('submete prova quando usuario ja participa', async () => {
+    mockedFetchArenaChallenges.mockResolvedValue([
+      {
+        ...challenge,
+        viewerHasJoined: true,
+        viewerJoinedAt: '2026-05-01T10:00:00.000Z',
+      },
+    ]);
+    mockedSubmitArenaProof.mockResolvedValue({
+      id: 'submission-id-1',
+      challengeId: 'challenge-id-1',
+      userId: 'user-id-1',
+      proofType: 'GAME_SESSION',
+      proofId: 'post-id-1',
+      score: 10,
+      submittedAt: '2026-05-01T12:00:00.000Z',
+    });
+
+    renderArenaPage();
+
+    fireEvent.change(await screen.findByLabelText(/ID do post de prova/i), {
+      target: { value: 'post-id-1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Submeter prova/i }));
+
+    await waitFor(() => {
+      expect(mockedSubmitArenaProof).toHaveBeenCalledWith('challenge-id-1', {
+        proofType: 'GAME_SESSION',
+        proofId: 'post-id-1',
+      });
+    });
+  });
+
+  it('exibe ranking local do desafio', async () => {
+    mockedFetchArenaChallenges.mockResolvedValue([challenge]);
+    mockedFetchArenaLeaderboard.mockResolvedValue([
+      {
+        position: 1,
+        userId: 'user-id-1',
+        username: 'clutchplayer',
+        displayName: 'Clutch Player',
+        score: 20,
+        submissionsCount: 2,
+        lastSubmissionAt: '2026-05-01T12:00:00.000Z',
+      },
+    ]);
+
+    renderArenaPage();
+
+    expect(await screen.findByText('Clutch Player')).toBeInTheDocument();
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
+
+  it('mostra erro seguro do backend', async () => {
+    mockedFetchArenaChallenges.mockResolvedValue([
+      {
+        ...challenge,
+        viewerHasJoined: true,
+        viewerJoinedAt: '2026-05-01T10:00:00.000Z',
+      },
+    ]);
+    mockedSubmitArenaProof.mockRejectedValue(new Error('Esta prova já foi usada neste desafio.'));
+
+    renderArenaPage();
+
+    fireEvent.change(await screen.findByLabelText(/ID do post de prova/i), {
+      target: { value: 'post-id-1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Submeter prova/i }));
+
+    expect(await screen.findByText(/Não foi possível submeter esta prova/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/sidebar.test.tsx
+++ b/frontend/tests/unit/components/sidebar.test.tsx
@@ -66,6 +66,7 @@ describe('Sidebar', () => {
       'href',
       '/notifications',
     );
+    expect(screen.getByText('Arena').closest('a')).toHaveAttribute('href', '/arena');
     expect(screen.getByText('Settings').closest('a')).toHaveAttribute('href', '/settings');
 
     expect(screen.queryByRole('link', { name: /friends/i })).not.toBeInTheDocument();

--- a/frontend/tests/unit/services/arena.test.ts
+++ b/frontend/tests/unit/services/arena.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiRequest } from '@/lib/api';
+import {
+  fetchArenaChallenges,
+  fetchArenaLeaderboard,
+  joinArenaChallenge,
+  submitArenaProof,
+} from '@/services/arena';
+
+vi.mock('@/lib/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockedApiRequest = vi.mocked(apiRequest);
+
+const challengePayload = {
+  id: 'challenge-id-1',
+  slug: 'semana-da-game-session',
+  title: 'Semana da Game Session',
+  description: 'Envie GAME_SESSION da semana.',
+  startsAt: '2026-05-01T00:00:00.000Z',
+  endsAt: '2026-05-08T00:00:00.000Z',
+  status: 'ACTIVE',
+  ruleType: 'GAME_SESSION',
+  scoreValue: 10,
+  maxSubmissionsPerUser: 3,
+  participantCount: 1,
+  submissionCount: 0,
+  viewerHasJoined: false,
+  viewerJoinedAt: null,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+};
+
+describe('arena service', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+  });
+
+  it('lista desafios Arena ativos', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(JSON.stringify({ challenges: [challengePayload] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const response = await fetchArenaChallenges();
+
+    expect(response[0]?.slug).toBe('semana-da-game-session');
+    expect(mockedApiRequest).toHaveBeenCalledWith('/arena/challenges', {
+      method: 'GET',
+    });
+  });
+
+  it('entra em desafio Arena', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          challenge: { ...challengePayload, viewerHasJoined: true },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await joinArenaChallenge('challenge-id-1');
+
+    expect(response.viewerHasJoined).toBe(true);
+    expect(mockedApiRequest).toHaveBeenCalledWith('/arena/challenges/challenge-id-1/join', {
+      method: 'POST',
+    });
+  });
+
+  it('submete prova elegivel', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          submission: {
+            id: 'submission-id-1',
+            challengeId: 'challenge-id-1',
+            userId: 'user-id-1',
+            proofType: 'GAME_SESSION',
+            proofId: 'post-id-1',
+            score: 10,
+            submittedAt: '2026-05-01T12:00:00.000Z',
+          },
+        }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await submitArenaProof('challenge-id-1', {
+      proofType: 'GAME_SESSION',
+      proofId: 'post-id-1',
+    });
+
+    expect(response.score).toBe(10);
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/arena/challenges/challenge-id-1/submissions',
+      {
+        method: 'POST',
+        body: {
+          proofType: 'GAME_SESSION',
+          proofId: 'post-id-1',
+        },
+      },
+    );
+  });
+
+  it('lista ranking local do desafio', async () => {
+    mockedApiRequest.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          leaderboard: [
+            {
+              position: 1,
+              userId: 'user-id-1',
+              username: 'clutchplayer',
+              displayName: 'Clutch Player',
+              score: 20,
+              submissionsCount: 2,
+              lastSubmissionAt: '2026-05-01T12:00:00.000Z',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const response = await fetchArenaLeaderboard('challenge-id-1');
+
+    expect(response[0]?.position).toBe(1);
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      '/arena/challenges/challenge-id-1/leaderboard',
+      {
+        method: 'GET',
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Resumo
Implementa o primeiro vertical slice funcional do Modo Arena com desafios semanais assíncronos, entrada voluntária, submissões por provas leves e ranking local por desafio.

A PR mantém o escopo MVP definido em #223 e #237: sem ranking global, sem temporada formal, sem reward engine, sem guild wars e sem realtime competitivo.

## O que foi alterado
- Backend:
  - adiciona modelos Prisma para `ArenaChallenge`, `ArenaParticipation` e `ArenaSubmission`.
  - adiciona constraints de janela válida, score positivo e cap positivo na migration.
  - adiciona repository, service e rotas `/arena/challenges` para listar desafios, ver detalhe, entrar, submeter prova e consultar leaderboard local.
  - valida provas por posts `GAME_SESSION` ou `ACHIEVEMENT`, com janela ativa, participação obrigatória, ownership da prova, deduplicação e cap por usuário.
  - cria submissões em transação serializável para reduzir corrida concorrente no cap por usuário.
  - adiciona seed dev/test com desafios semanais ativos.
- Frontend:
  - adiciona página `/arena` com lista de desafios, detalhe, CTA de entrada, submissão de prova e ranking local.
  - adiciona service e schemas Arena.
  - adiciona entrada Arena na navegação autenticada.
- Testes:
  - adiciona cobertura unitária e de rota para service/repository/routes Arena.
  - cobre desafio futuro/inativo/encerrado, prova duplicada, cap, conflito concorrente, score enviado pelo frontend e leaderboard local.
  - adiciona cobertura de service/componentes frontend para a página Arena.

## Motivação
A fase arquitetural do Modo Arena já definiu que o MVP deve validar valor por desafios assíncronos locais antes de abrir ranking global, temporadas formais ou recompensas fortes. Esta PR entrega esse primeiro fluxo funcional de forma limitada e rastreável, com hardening específico contra manipulação de score e duplicidade de submissão.

## Como validar
- Backend:
  - `cd backend && npm run test -- tests/unit/services/arena.service.test.ts tests/unit/repositories/arena.repository.test.ts tests/integration/routes/arena.routes.test.ts`
  - `cd backend && npm run typecheck`
  - `cd backend && npm run lint`
  - `cd backend && npm run build`
- Frontend:
  - `cd frontend && npm run test -- tests/unit/services/arena.test.ts tests/unit/components/arena-page-content.test.tsx tests/unit/components/sidebar.test.tsx`
  - `cd frontend && npm run typecheck`
  - `cd frontend && npm run lint`
  - `cd frontend && npm run build`
- Prisma:
  - `cd backend && npx prisma validate`

## Riscos e impactos
- Adiciona migration de banco para as tabelas Arena; ambientes precisam aplicar a migration antes de usar os endpoints.
- O leaderboard é local ao desafio e derivado das submissões; não há score global materializado nesta PR.
- O MVP aceita apenas provas por posts `GAME_SESSION` e `ACHIEVEMENT`; RSVP de evento comunitário fica fora deste primeiro slice funcional.
- A cobertura completa local foi limitada por dependência de Postgres/Redis e timeouts de suítes globais já existentes; os testes focados do slice passaram localmente.
- O lint backend passou com warnings preexistentes em `backend/src/config/rate-limit.ts`, fora do escopo desta PR.

## Evidências
- `npx prisma validate`: passou.
- Testes focados backend: 3 arquivos, 27 testes passaram.
- Testes focados frontend: 3 arquivos, 12 testes passaram.
- Backend typecheck/lint/build: passaram.
- Frontend typecheck/lint/build: passaram.
- `npm run test:coverage` backend/frontend foi executado, mas falhou por limitações de ambiente/timeouts de suítes globais fora do slice.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #298